### PR TITLE
Remove webhook for API server Service

### DIFF
--- a/pkg/webhook/controlplaneexposure/add.go
+++ b/pkg/webhook/controlplaneexposure/add.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/genericmutator"
 
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -47,7 +46,7 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) (*extensionsw
 	return controlplane.Add(mgr, controlplane.AddArgs{
 		Kind:     controlplane.KindSeed,
 		Provider: alicloud.Type,
-		Types:    []runtime.Object{&appsv1.Deployment{}, &appsv1.StatefulSet{}, &corev1.Service{}},
+		Types:    []runtime.Object{&appsv1.Deployment{}, &appsv1.StatefulSet{}},
 		Mutator:  genericmutator.NewMutator(NewEnsurer(&opts.ETCDStorage, logger), nil, nil, nil, logger),
 	})
 }

--- a/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/pkg/webhook/controlplaneexposure/ensurer.go
@@ -55,12 +55,6 @@ func (e *ensurer) InjectClient(client client.Client) error {
 	return nil
 }
 
-// EnsureKubeAPIServerService ensures that the kube-apiserver service conforms to the provider requirements.
-func (e *ensurer) EnsureKubeAPIServerService(ctx context.Context, ectx genericmutator.EnsurerContext, svc *corev1.Service) error {
-	svc.Spec.ExternalTrafficPolicy = "Local"
-	return nil
-}
-
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx genericmutator.EnsurerContext, dep *appsv1.Deployment) error {
 	cluster, err := controller.GetCluster(ctx, e.client, dep.Namespace)

--- a/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -161,21 +161,6 @@ var _ = Describe("Ensurer", func() {
 		})
 	})
 
-	Describe("#EnsureKubeAPIServerService", func() {
-		It("should set ExternalTrafficPolicy to Local for KubeAPIServer Service", func() {
-			svc = &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kube-apiserver",
-					Namespace: metav1.NamespaceSystem},
-				Spec: corev1.ServiceSpec{ExternalTrafficPolicy: "Cluster"}}
-
-			ensurer := NewEnsurer(etcdStorage, logger)
-			err := ensurer.EnsureKubeAPIServerService(context.TODO(), dummyContext, svc)
-			Expect(err).To(Not(HaveOccurred()))
-			Expect(string(svc.Spec.ExternalTrafficPolicy)).Should(Equal("Local"))
-		})
-	})
-
 	Describe("#EnsureETCDStatefulSet", func() {
 		It("should add or modify elements to etcd-main statefulset", func() {
 			var (


### PR DESCRIPTION
**What this PR does / why we need it**:
Set ExternalTrafficPolicy of kube-apiserver service to local.
**Which issue(s) this PR fixes**:
Fixes #25 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Set ExternalTrafficPolicy of kube-apiserver service to Cluster in Alicloud.
```
