### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:v0.26.1->v0.26.2]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.26.1"
+  tag: "v0.26.2"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl


### PR DESCRIPTION
*Release Notes*:
``` noteworthy operator github.com/gardener/machine-controller-manager #408 @hardikdr
Bugfix: Set deleteOnTermination to true by default for volumes. Disks that are created with the instance are deleted with instance termination.
```