### PR TITLE
Filter api expose objects

### DIFF
--- a/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/pkg/webhook/controlplaneexposure/ensurer.go
@@ -24,6 +24,7 @@ import (
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -55,6 +56,10 @@ func (e *ensurer) InjectClient(client client.Client) error {
 
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx genericmutator.EnsurerContext, new, old *appsv1.Deployment) error {
+	if v1beta1helper.IsAPIServerExposureManaged(new) {
+		return nil
+	}
+
 	cluster, err := controller.GetCluster(ctx, e.client, new.Namespace)
 	if err != nil {
 		return err

--- a/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -91,6 +91,38 @@ var _ = Describe("Ensurer", func() {
 	})
 
 	Describe("#EnsureKubeAPIServerDeployment", func() {
+		It("should not modify kube-apiserver deployment if SNI is enabled", func() {
+			var (
+				dep = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      v1beta1constants.DeploymentNameKubeAPIServer,
+						Namespace: namespace,
+						Labels:    map[string]string{"core.gardener.cloud/apiserver-exposure": "gardener-managed"},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kube-apiserver",
+									},
+								},
+							},
+						},
+					},
+				}
+				depCopy = dep.DeepCopy()
+			)
+
+			// Create ensurer
+			ensurer := NewEnsurer(etcdStorage, logger)
+
+			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dummyContext, dep, nil)
+			Expect(err).To(Not(HaveOccurred()))
+
+			Expect(dep).To(Equal(depCopy))
+		})
+
 		It("should add missing elements to kube-apiserver deployment", func() {
 			var (
 				dep = &appsv1.Deployment{


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not mutate kube-apiserver exposure resources when gardener manages those. See https://github.com/gardener/gardener/pull/1929

**Which issue(s) this PR fixes**:
Fixes # n/a

**Special notes for your reviewer**:

~~This is WIP as https://github.com/gardener/gardener/commit/40864019e030923c80657ac5d46a34130bcf337d is still not available in any tags and vendor folder manually updated~~

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Do not mutate `kube-apiserver` exposure resources which Gardener marks as managed by it with `core.gardener.cloud/apiserver-exposure: gardener-managed` label.
```
