### PR TITLE
Enable ccm to access alicloud provider network

### DIFF
--- a/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/_helpers.tpl
+++ b/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/_helpers.tpl
@@ -7,3 +7,7 @@
 {{- define "deploymentversion" -}}
 apps/v1
 {{- end -}}
+
+{{- define "networkpolicyversion" -}}
+networking.k8s.io/v1
+{{- end -}}

--- a/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/alicloud-ccm-deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/alicloud-ccm-deployment.yaml
@@ -46,6 +46,7 @@ spec:
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-public-networks: allowed
         networking.gardener.cloud/to-shoot-apiserver: allowed
+        networking.gardener.cloud/to-alicloud-networks: allowed
         networking.gardener.cloud/from-prometheus: allowed
     spec:
       containers:

--- a/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/allow-to-alicloud-network.yaml
+++ b/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/allow-to-alicloud-network.yaml
@@ -1,0 +1,20 @@
+apiVersion: {{ include "networkpolicyversion" . }}
+kind: NetworkPolicy
+metadata:
+  annotations:
+    gardener.cloud/description: |
+      Allows Egress from pods labeled with 'networking.gardener.cloud/to-alicloud-networks=allowed'
+      to Alicloud CloudProvider's specific IPs. Currently, only consider 100.96.0.0/11.
+  name: allow-to-alicloud-networks
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      networking.gardener.cloud/to-alicloud-networks: allowed
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 100.96.0.0/11
+  policyTypes:
+  - Egress
+  ingress: []


### PR DESCRIPTION
**What this PR does / why we need it**:
Add network policy for Alicloud Cloud controller manager, enable it to access Alicloud APIs. 
**Which issue(s) this PR fixes**:
Fixes #30 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Shoot can be created or woken up in Alicloud in Frankfurt region without errors.
```
