### PR TITLE
add mutator of mertics-server

### DIFF
--- a/pkg/webhook/shoot/add.go
+++ b/pkg/webhook/shoot/add.go
@@ -18,6 +18,7 @@ import (
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 	"github.com/gardener/gardener-extensions/pkg/webhook/shoot"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,7 +39,7 @@ var logger = log.Log.WithName("alicloud-shoot-webhook")
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) (*extensionswebhook.Webhook, error) {
 	logger.Info("Adding webhook to manager")
 	return shoot.Add(mgr, shoot.AddArgs{
-		Types:   []runtime.Object{&corev1.Service{}},
+		Types:   []runtime.Object{&corev1.Service{}, &appsv1.Deployment{}},
 		Mutator: NewMutator(),
 	})
 }

--- a/pkg/webhook/shoot/mutator_test.go
+++ b/pkg/webhook/shoot/mutator_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"context"
+	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Mutator", func() {
+	var (
+		mutator = NewMutator()
+		dep     = &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "metrics-server"},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "metrics-server",
+								Command: []string{
+									"--profiling=false",
+									"--cert-dir=/home/certdir",
+									"--secure-port=8443",
+									"--kubelet-insecure-tls",
+									"--tls-cert-file=/srv/metrics-server/tls/tls.crt",
+									"--tls-private-key-file=/srv/metrics-server/tls/tls.key",
+									"--v=2",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	)
+	Describe("#MutateMetricsServerDeployment", func() {
+		It("should modify existing elements of metrics-server deployment", func() {
+			err := mutator.Mutate(context.TODO(), dep)
+			c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "metrics-server")
+			Expect(c).To(Not(BeNil()))
+			Expect(c.Command).To(ContainElement("--kubelet-preferred-address-types=InternalIP"))
+			Expect(err).To(Not(HaveOccurred()))
+		})
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR is to mutate metrics-service deployment, adding command option `--kubelet-preferred-address-types=InternalIP`
**Which issue(s) this PR fixes**:
Fixes #
#39 
**Special notes for your reviewer**:
None
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.
None
Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Metric server can now fetch node metrics in Alicloud now.
```
