### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:v0.26.3->v0.27.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.26.3"
+  tag: "v0.27.0"
 - name: alicloud-controller-manager
   sourceRepository: https://github.com/kubernetes/cloud-provider-alibaba-cloud
   repository: registry.eu-central-1.aliyuncs.com/gardener-de/alibaba-cloud-controller-manager


### PR DESCRIPTION
*Release Notes*:
``` improvement user github.com/gardener/machine-controller-manager #438 @dkistner
Azure: Support for accelerated networking enabled VMs
```

``` improvement operator github.com/gardener/machine-controller-manager #436 @vpnachev
Azure: VMs now can be created with image ID.
```

``` improvement operator github.com/gardener/machine-controller-manager #432 @hardikdr
Improves the machine-creation and machine-deletion flow by listing and verifying the state of the machines before actual creation and deletion.
```

``` improvement operator github.com/gardener/machine-controller-manager #432 @hardikdr
MCM now dynamically maps the node-objects with machines if `Status.Node` is not set.
```

``` improvement operator github.com/gardener/machine-controller-manager #429 @prashanth26
Sort active machines by creation timestamp
```

``` improvement operator github.com/gardener/machine-controller-manager #427 @zuzzas
Openstack: When a Server creation ERRORs, provide formatted Fault information
```

``` noteworthy operator github.com/gardener/machine-controller-manager #420 @prashanth26
Prepend mcm to all work queue metrics
```

``` noteworthy operator github.com/gardener/machine-controller-manager #420 @prashanth26
Subsystems and Namespaces to MCM metrics
```

``` noteworthy operator github.com/gardener/machine-controller-manager #420 @prashanth26
Renamed mcm_machine_deployment_items_total & mcm_machine_set_items_total metrics
```

``` noteworthy operator github.com/gardener/machine-controller-manager #420 @prashanth26
Bugfix: Set deleteOnTermination to true by default for volumes. Disks that are created with the instance are deleted with instance termination.
```

``` improvement operator github.com/gardener/machine-controller-manager #420 @prashanth26
Set deleteOnTermination flag to true while deleting the VMs in AWS.
```

``` improvement operator github.com/gardener/machine-controller-manager #416 @amshuman-kr
Skip eviction during drain if ForceDeletePods is enabled.
```

``` improvement operator github.com/gardener/machine-controller-manager #412 @kayrus
Openstack: Print API request/response debug when verbosity is set to 6
```

``` improvement operator github.com/gardener/machine-controller-manager #406 @dkistner
Azure: VM deletion checks any orphan dependant resources and tries to delete them if exists.
```

``` improvement developer github.com/gardener/machine-controller-manager #406 @dkistner
Azure: Update of the Azure SDK to use more recent version
```