### PR TITLE
[ci:component:github.com/gardener/terraformer:0.20.0->v1.0.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.20.0"
+  tag: "v1.0.0"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/terraformer #38 @ialidzhikov
`nsxt` and `random` providers are now removed from the terraform bundle.
```

``` action operator github.com/gardener/terraformer #37 @rfranzke
The Terraformer does now lookup the relevant data stored in `ConfigMap`s or `Secret`s live from the system instead of relying on mounted volumes. This is a breaking change as the volume mount approach does no longer work, please adapt your manifests [according to the examples](https://github.com/gardener/terraformer/tree/master/example). The rationale behind it is to not rely on potentially stale kubelet cache while it mounts the volume which may, in rare cases, cause state loss.
```

``` improvement operator github.com/gardener/terraformer #36 @ialidzhikov
`terraformer` does no longer ignore the termination signals sent to PID 1. It does now send a termination signal to the terraform process itself and waits for its completion. This should prevent rare cases in which the `terraformer` was not storing the state of created infrastructure resources.
```