### PR TITLE
validate workers number

### DIFF
--- a/pkg/apis/alicloud/validation/shoot.go
+++ b/pkg/apis/alicloud/validation/shoot.go
@@ -59,6 +59,10 @@ func ValidateWorkers(workers []core.Worker, zones []apisalicloud.Zone, fldPath *
 			continue
 		}
 
+		if worker.Maximum != 0 && worker.Minimum == 0 {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Index(i).Child("minimum"), "minimum value must be >= 1 if maximum value > 0 (cluster-autoscaler cannot handle min=0)"))
+		}
+
 		allErrs = append(allErrs, validateZones(worker.Zones, alicloudZones, fldPath.Index(i).Child("zones"))...)
 	}
 

--- a/pkg/apis/alicloud/validation/shoot_test.go
+++ b/pkg/apis/alicloud/validation/shoot_test.go
@@ -170,6 +170,29 @@ var _ = Describe("Shoot validation", func() {
 					})),
 				))
 			})
+
+			It("should forbid because worker setting maximum > 0 and minimum = 0", func() {
+				workers[0].Maximum = 1
+				workers[0].Minimum = 0
+
+				errorList := ValidateWorkers(workers, alicloudZones, field.NewPath("workers"))
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeForbidden),
+						"Field": Equal("workers[0].minimum"),
+					})),
+				))
+			})
+
+			It("should pass because worker setting maximum = 0 and minimum = 0", func() {
+				workers[0].Maximum = 0
+				workers[0].Minimum = 0
+
+				errorList := ValidateWorkers(workers, alicloudZones, field.NewPath("workers"))
+
+				Expect(errorList).To(BeEmpty())
+			})
 		})
 
 		Describe("#ValidateWorkersUpdate", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is Add validation to prevent worker.min to be set to 0.
**Which issue(s) this PR fixes**:
Fixes #
#44 
**Special notes for your reviewer**:
None
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Alicloud provider now allows setting `minimum=0` for worker pools in the `Shoot`. 
```
