### PR TITLE
Use Terraform resource timeouts and workqueue backoff

### DIFF
--- a/charts/internal/alicloud-infra/templates/main.tf
+++ b/charts/internal/alicloud-infra/templates/main.tf
@@ -14,7 +14,13 @@ resource "alicloud_key_pair" "publickey" {
 resource "alicloud_vpc" "vpc" {
   name       = "{{ required "clusterName is required" .Values.clusterName }}-vpc"
   cidr_block = "{{ required "vpc.cidr is required" .Values.vpc.cidr }}"
+
+  timeouts {
+    create = "5m"
+    delete = "5m"
+  }
 }
+
 resource "alicloud_nat_gateway" "nat_gateway" {
   vpc_id = "{{ required "vpc.id is required" .Values.vpc.id }}"
   specification   = "Small"
@@ -31,6 +37,11 @@ resource "alicloud_vswitch" "vsw_z{{ $index }}" {
   vpc_id            = "{{ required "vpc.id is required" $.Values.vpc.id }}"
   cidr_block        = "{{ required "zone.cidr.workers is required" $zone.cidr.workers }}"
   availability_zone = "{{ required "zone.name is required" $zone.name }}"
+
+  timeouts {
+    create = "5m"
+    delete = "5m"
+  }
 }
 
 // Create a new EIP.

--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -30,7 +30,6 @@ import (
 
 	extensioncontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	commonext "github.com/gardener/gardener/extensions/pkg/controller/common"
-	controllererrors "github.com/gardener/gardener/extensions/pkg/controller/error"
 	"github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
 	extensionschartrenderer "github.com/gardener/gardener/extensions/pkg/gardener/chartrenderer"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
@@ -406,10 +405,7 @@ func (a *actuator) reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 
 	if err := tf.InitializeWith(initializer).Apply(); err != nil {
 		a.logger.Error(err, "failed to apply the terraform config", "infrastructure", infra.Name)
-		return &controllererrors.RequeueAfterError{
-			Cause:        err,
-			RequeueAfter: 30 * time.Second,
-		}
+		return err
 	}
 
 	machineImages, err := a.shareCustomizedImages(ctx, infra, cluster)


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we add some timeouts for those Terraform resources that are supporting it. Also, we will no longer requeue with the constant `30s` on errors but leverage the exponential backoff functionality of the underlying workqueue.

Part of gardener/gardener#2253

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
