### PR TITLE
Revert Terraform resource timeouts

### DIFF
--- a/charts/internal/alicloud-infra/templates/main.tf
+++ b/charts/internal/alicloud-infra/templates/main.tf
@@ -14,11 +14,6 @@ resource "alicloud_key_pair" "publickey" {
 resource "alicloud_vpc" "vpc" {
   name       = "{{ required "clusterName is required" .Values.clusterName }}-vpc"
   cidr_block = "{{ required "vpc.cidr is required" .Values.vpc.cidr }}"
-
-  timeouts {
-    create = "5m"
-    delete = "5m"
-  }
 }
 
 resource "alicloud_nat_gateway" "nat_gateway" {
@@ -37,11 +32,6 @@ resource "alicloud_vswitch" "vsw_z{{ $index }}" {
   vpc_id            = "{{ required "vpc.id is required" $.Values.vpc.id }}"
   cidr_block        = "{{ required "zone.cidr.workers is required" $zone.cidr.workers }}"
   availability_zone = "{{ required "zone.name is required" $zone.name }}"
-
-  timeouts {
-    create = "5m"
-    delete = "5m"
-  }
 }
 
 // Create a new EIP.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/kind bug
/priority normal
/platform alicloud

**What this PR does / why we need it**:
Currently `Infrastructure` reconciliation fails with
```
  Warning  InfrastructureReconciliation  8m48s                  infrastructure_controller  Error reconciling infrastructure: Terraform execution for command 'apply' could not be completed. The following issues have been found in the logs:

-> Pod 'foo.infra.tf-apply-7vvmg' reported:
* Unsupported block type
  on tf/main.tf line 17, in resource "alicloud_vpc" "vpc":
  17:   timeouts {

Blocks of type "timeouts" are not expected here.

failed to apply the terraform config
github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/infrastructure.(*actuator).reconcile
  /go/src/github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/infrastructure/actuator.go:407
github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/infrastructure.(*actuator).Reconcile
  /go/src/github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/infrastructure/actuator.go:373
github.com/gardener/gardener/extensions/pkg/controller/infrastructure.(*reconciler).reconcile
  /go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/github.com/gardener/gardener/extensions/pkg/controller/infrastructure/reconciler.go:133
github.com/gardener/gardener/extensions/pkg/controller/infrastructure.(*reconciler).Reconcile
  /go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/github.com/gardener/gardener/extensions/pkg/controller/infrastructure/reconciler.go:119
github.com/gardener/gardener/extensions/pkg/controller.(*operationAnnotationWrapper).Reconcile
  /go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/github.com/gardener/gardener/extensions/pkg/controller/reconciler.go:89
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
  /go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:256
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
  /go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
  /go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1
  /go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152
k8s.io/apimachinery/pkg/util/wait.JitterUntil
  /go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153
k8s.io/apimachinery/pkg/util/wait.Until
  /go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
runtime.goexit
  /usr/local/go/src/runtime/asm_amd64.s:1373
```

https://github.com/gardener/gardener-extension-provider-alicloud/pull/79 introduces timeouts for `alicloud_vpc ` and `alicloud_vswitch`. However as stated in https://www.terraform.io/docs/providers/alicloud/r/vswitch.html#timeouts and https://www.terraform.io/docs/providers/alicloud/r/vpc.html#timeouts, the `timeouts` block is available for terraform-provider version `> 1.79.0`, we are currently using `1.55.2`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
