### PR TITLE
fix issue eip_association cannot be destroyed

### DIFF
--- a/charts/internal/alicloud-infra/templates/main.tf
+++ b/charts/internal/alicloud-infra/templates/main.tf
@@ -51,6 +51,7 @@ resource "alicloud_snat_entry" "snat_z{{ $index }}" {
   snat_table_id     = "{{ required "snatTableID is required" $.Values.vpc.snatTableID }}"
   source_vswitch_id = "${alicloud_vswitch.vsw_z{{ $index }}.id}"
   snat_ip           = "${alicloud_eip.eip_natgw_z{{ $index }}.ip_address}"
+  depends_on        = [alicloud_eip_association.eip_natgw_asso_z{{ $index }}]
 }
 
 // Output


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area control-plane
/kind bug
/priority normal
/platform alicloud

**What this PR does / why we need it**:
This PR is to fix the issue in which `alicloud_eip_association` cannot be destroyed. The reason is that it is blocked by the deletion of `alicloud_snat_entry` if both resources are destroyed in parallel. So we need to add dependency between them, to let `alicloud_snat_entry` be destroyed first, and then to destroy `alicloud_eip_association`.
**Which issue(s) this PR fixes**:
Fixes #
None
**Special notes for your reviewer**:
None
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
