### PR TITLE
Support multiple Alicloud disks when creating machines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ############# builder
-FROM golang:1.14.2 AS builder
+FROM golang:1.14.4 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-alicloud
 COPY . .
 RUN make install
 
 ############# base
-FROM alpine:3.11.6 AS base
+FROM alpine:3.12.0 AS base
 
 ############# gardener-extension-provider-alicloud
 FROM base AS gardener-extension-provider-alicloud

--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -30,6 +30,10 @@ spec:
   systemDisk:
     category: {{ $machineClass.systemDisk.category }}
     size: {{ $machineClass.systemDisk.size }}
+{{- if $machineClass.dataDisks }}
+  dataDisks:
+{{ toYaml $machineClass.dataDisks | indent 2 }}
+{{- end }}
   instanceChargeType: {{ $machineClass.instanceChargeType }}
   internetChargeType: {{ $machineClass.internetChargeType }}
   internetMaxBandwidthIn: {{ $machineClass.internetMaxBandwidthIn }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -11,6 +11,13 @@
 #   systemDisk:
 #     category: cloud_efficiency # cloud, cloud_efficiency, cloud_ssd, ephemeral_ssd
 #     size: 30 # 20-500
+#   dataDisks:
+#   - name: foo
+#     category: bar
+#     size: 30
+#     description: some description
+#     encrypted: true
+#     deleteWithInstance: true
 #   instanceChargeType: PostPaid # Prepaid or PostPaid (default)
 #   internetChargeType: PayByTraffic # PayByBandwidth or PayByTraffic (default)
 #   internetMaxBandwidthIn: 5 # 1-200

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -79,6 +79,30 @@ The `cloudControllerManager.featureGates` contains a map of explicitly enabled o
 For production usage it's not recommend to use this field at all as you can enable alpha features or disable beta/stable features, potentially impacting the cluster stability.
 If you don't want to configure anything for the `cloudControllerManager` simply omit the key in the YAML specification.
 
+## `WorkerConfig`
+
+The Alicloud extension does not support a specific `WorkerConfig` yet, however, it supports additional data volumes (plus encryption) per machine.
+By default (if not stated otherwise), all the disks are unencrypted.
+Please note that it is currently only possible to encrypt data disks (system disk is unsupported).
+For each data volume, you have to specify a name.
+The following YAML is a snippet of a `Shoot` resource:
+
+```yaml
+spec:
+  provider:
+    workers:
+    - name: cpu-worker
+      ...
+      volume:
+        type: cloud_efficiency
+        size: 20Gi
+      dataVolumes:
+      - name: kubelet-dir
+        type: cloud_efficiency
+        size: 25Gi
+        encrypted: true
+```
+
 ## Example `Shoot` manifest (one availability zone)
 
 Please find below an example `Shoot` manifest for one availability zone:

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -96,5 +96,10 @@ spec:
     volume:
       type: cloud_efficiency
       size: 30Gi
+  # dataVolumes:
+  # - name: kubelet-dir
+  #   type: cloud_efficiency
+  #   size: 36Gi
+  #   encrypted: false
     zones:
     - cn-beijing-f


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area storage
/kind enhancement
/priority normal
/platform alicloud

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/1893 was merged quite some time ago, this PR now adds support for the Alicloud extension to handle multiple Alicloud disks for the worker machines.

**Which issue(s) this PR fixes**:
Ref https://github.com/gardener/machine-controller-manager/issues/462

**Special notes for your reviewer**:
* Thanks @guydaichs for your work and contributions!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
It is now possible to configure additional data volumes for the worker machines. Please consult [this documentation](https://github.com/gardener/gardener-extension-provider-alicloud/blob/master/docs/usage-as-end-user.md#workerconfig) for more information.
```
