### PR TITLE
:sparkle: Enable server side encryption of buckets

### DIFF
--- a/pkg/alicloud/client/client.go
+++ b/pkg/alicloud/client/client.go
@@ -125,6 +125,15 @@ func (c *storageClient) CreateBucketIfNotExists(ctx context.Context, bucketName 
 		}
 	}
 
+	encryptionRule := oss.ServerEncryptionRule{
+		SSEDefault: oss.SSEDefaultRule{
+			SSEAlgorithm: string(oss.AESAlgorithm),
+		},
+	}
+	if err := c.client.SetBucketEncryption(bucketName, encryptionRule, expirationOption); err != nil {
+		return err
+	}
+
 	rules := []oss.LifecycleRule{
 		{
 			Prefix: "",


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area security
/kind enhancement
/priority normal
/platform alicloud

**What this PR does / why we need it**:
This PR enables the default SSE for OSS buckets.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Enable service side encryption for provisioned OSS buckets.
```
