### PR TITLE
Adapt to terraform v0.12 language changes

### DIFF
--- a/charts/internal/alicloud-infra/templates/variables.tf
+++ b/charts/internal/alicloud-infra/templates/variables.tf
@@ -1,9 +1,9 @@
 variable "ACCESS_KEY_ID" {
   description = "Alicloud access key id"
-  type        = "string"
+  type        = string
 }
 
 variable "ACCESS_KEY_SECRET" {
   description = "Alicloud access key secret"
-  type        = "string"
+  type        = string
 }

--- a/charts/internal/alicloud-infra/values.yaml
+++ b/charts/internal/alicloud-infra/values.yaml
@@ -9,10 +9,10 @@ clusterName: test-namespace
 sshPublicKey: sshkey-12345
 
 vpc:
-  id: ${alicloud_vpc.vpc.id}
+  id: alicloud_vpc.vpc.id
   cidr: 10.10.10.10/6
-  natGatewayID: ${alicloud_nat_gateway.nat_gateway.id}
-  snatTableID: ${alicloud_nat_gateway.nat_gateway.snat_table_ids}
+  natGatewayID: alicloud_nat_gateway.nat_gateway.id
+  snatTableID: alicloud_nat_gateway.nat_gateway.snat_table_ids
   internetChargeType: PayByTraffic
 
 zones:

--- a/pkg/controller/infrastructure/terraform.go
+++ b/pkg/controller/infrastructure/terraform.go
@@ -15,6 +15,8 @@
 package infrastructure
 
 import (
+	"strconv"
+
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/v1alpha1"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -43,10 +45,10 @@ func (terraformOps) ComputeCreateVPCInitializerValues(config *v1alpha1.Infrastru
 func (terraformOps) ComputeUseVPCInitializerValues(config *v1alpha1.InfrastructureConfig, info *VPCInfo) *InitializerValues {
 	return &InitializerValues{
 		CreateVPC:          false,
-		VPCID:              *config.Networks.VPC.ID,
+		VPCID:              strconv.Quote(*config.Networks.VPC.ID),
 		VPCCIDR:            info.CIDR,
-		NATGatewayID:       info.NATGatewayID,
-		SNATTableIDs:       info.SNATTableIDs,
+		NATGatewayID:       strconv.Quote(info.NATGatewayID),
+		SNATTableIDs:       strconv.Quote(info.SNATTableIDs),
 		InternetChargeType: info.InternetChargeType,
 	}
 }

--- a/pkg/controller/infrastructure/terraform_test.go
+++ b/pkg/controller/infrastructure/terraform_test.go
@@ -15,6 +15,8 @@
 package infrastructure_test
 
 import (
+	"strconv"
+
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/v1alpha1"
 	. "github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/infrastructure"
 
@@ -85,10 +87,10 @@ var _ = Describe("TerraformChartOps", func() {
 
 			Expect(ops.ComputeUseVPCInitializerValues(&config, &info)).To(Equal(&InitializerValues{
 				CreateVPC:    false,
-				VPCID:        id,
+				VPCID:        strconv.Quote(id),
 				VPCCIDR:      cidr,
-				NATGatewayID: natGatewayID,
-				SNATTableIDs: sNATTableIDs,
+				NATGatewayID: strconv.Quote(natGatewayID),
+				SNATTableIDs: strconv.Quote(sNATTableIDs),
 			}))
 		})
 	})

--- a/pkg/controller/infrastructure/types.go
+++ b/pkg/controller/infrastructure/types.go
@@ -36,11 +36,11 @@ const (
 	TerraformerOutputKeyVSwitchNodesPrefix = "vswitch_id_z"
 
 	// TerraformDefaultVPCID is the default value for the VPC ID in the chart.
-	TerraformDefaultVPCID = "${alicloud_vpc.vpc.id}"
+	TerraformDefaultVPCID = "alicloud_vpc.vpc.id"
 	// TerraformDefaultNATGatewayID is the default value for the NAT gateway ID in the chart.
-	TerraformDefaultNATGatewayID = "${alicloud_nat_gateway.nat_gateway.id}"
+	TerraformDefaultNATGatewayID = "alicloud_nat_gateway.nat_gateway.id"
 	// TerraformDefaultSNATTableIDs is the default value for the SNAT table IDs in the chart.
-	TerraformDefaultSNATTableIDs = "${alicloud_nat_gateway.nat_gateway.snat_table_ids}"
+	TerraformDefaultSNATTableIDs = "alicloud_nat_gateway.nat_gateway.snat_table_ids"
 )
 
 // VPCInfo contains info about an existing VPC.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/kind cleanup
/priority normal
/platform alicloud

**What this PR does / why we need it**:
Adapt to terraform v0.12 language changes

**Which issue(s) this PR fixes**:
Fixes #99

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Until now `provider-alicloud` was maintaining a Terraform configuration which is both `v0.12` and `v0.11` compatible. The Terraform configuration is now adapted to the new Terraform language which makes it Terraform `v0.11` incompatible.
```
