### PR TITLE
Delete running terraformer Pods before deleting infrastructure

### DIFF
--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -480,7 +480,7 @@ func (a *actuator) Delete(ctx context.Context, infra *extensionsv1alpha1.Infrast
 	}
 
 	// terraform pod from previous reconciliation might still be running, ensure they are gone before doing any operations
-	if err := tf.WaitForCleanEnvironment(ctx); err != nil {
+	if err := tf.EnsureCleanedUp(ctx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/area robustness
/kind bug
/priority normal
/platform alicloud

**What this PR does / why we need it**:
With this PR the infrastructure actuator does not only wait for all terraformer Pods to be gone when deleting the infrastructure but actually deletes them instead.
This is to ensure, that terraformer Pods from previous reconciliations/deletions (which might have been interrupted because of provider controller restart) don't hang forever and block the infrastructure deletion.

**Which issue(s) this PR fixes**:
Ref https://github.com/gardener/gardener-extension-provider-aws/issues/121#issuecomment-649284940
Ref https://github.com/gardener/gardener-extension-provider-aws/pull/124#discussion_r440805536

**Special notes for your reviewer**:
/invite @ialidzhikov @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug has been fixed, that caused the `Infrastructure` deletion to be blocked forever in case there are already running terraformer Pods.
```
