### PR TITLE
Revert "Revert Terraform resource timeouts"

### DIFF
--- a/charts/internal/alicloud-infra/templates/main.tf
+++ b/charts/internal/alicloud-infra/templates/main.tf
@@ -14,6 +14,11 @@ resource "alicloud_key_pair" "publickey" {
 resource "alicloud_vpc" "vpc" {
   name       = "{{ required "clusterName is required" .Values.clusterName }}-vpc"
   cidr_block = "{{ required "vpc.cidr is required" .Values.vpc.cidr }}"
+
+  timeouts {
+    create = "5m"
+    delete = "5m"
+  }
 }
 
 resource "alicloud_nat_gateway" "nat_gateway" {
@@ -30,6 +35,11 @@ resource "alicloud_vswitch" "vsw_z{{ $index }}" {
   vpc_id            = {{ required "vpc.id is required" $.Values.vpc.id }}
   cidr_block        = "{{ required "zone.cidr.workers is required" $zone.cidr.workers }}"
   availability_zone = "{{ required "zone.name is required" $zone.name }}"
+
+  timeouts {
+    create = "5m"
+    delete = "5m"
+  }
 }
 
 {{- $createEip := true }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/kind task
/priority normal
/platform alicloud

**What this PR does / why we need it**:
This reverts commit 6797d2608857b435eb98a1858e346ae18eaac119.
With https://github.com/gardener/gardener-extension-provider-alicloud/pull/85 we reverted https://github.com/gardener/gardener-extension-provider-alicloud/pull/79 as back then the terraform-provider-alicloud version was not supporting it. After terraform-provider-alicloud version update in https://github.com/gardener/gardener-extension-provider-alicloud/pull/91, the `timeouts` block can be added again.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
