### PR TITLE
[trigger new PR] [ci:component:github.com/gardener/machine-controller-manager:v0.31.0->v0.32.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.31.0"
+  tag: "v0.32.0"
 - name: alicloud-controller-manager
   sourceRepository: https://github.com/kubernetes/cloud-provider-alibaba-cloud
   repository: registry.eu-central-1.aliyuncs.com/gardener-de/alibaba-cloud-controller-manager


### PR DESCRIPTION
*Release Notes*:
``` improvement developer github.com/gardener/machine-controller-manager #480 @prashanth26
Bugfix: Drain machines with only a valid node (name)
```

``` improvement operator github.com/gardener/machine-controller-manager #457 @zuzzas
Added an option to use configDrive in the OpenStackMachineClass
```