### PR TITLE
update snapshot csi version

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -51,6 +51,15 @@ images:
   repository: quay.io/k8scsi/csi-snapshotter
   tag: v1.2.2
   targetVersion: ">= 1.14"
+- name: csi-snapshotter
+  sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
+  repository: quay.io/k8scsi/csi-snapshotter
+  tag: v2.1.1
+  targetVersion: ">= 1.17"
+- name: csi-snapshot-controller
+  sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
+  repository: quay.io/k8scsi/snapshot-controller
+  tag: v2.1.1
 - name: csi-resizer
   sourceRepository: https://github.com/kubernetes-csi/external-resizer
   repository: quay.io/k8scsi/csi-resizer

--- a/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml
@@ -16,9 +16,9 @@ spec:
       role: csi-plugin-controller
   template:
     metadata:
-{{- if .Values.podAnnotations }}
+{{- if .Values.csiPluginController.podAnnotations }}
       annotations:
-{{ toYaml .Values.podAnnotations | indent 8 }}
+{{ toYaml .Values.csiPluginController.podAnnotations | indent 8 }}
 {{- end }}
       labels:
         garden.sapcloud.io/role: controlplane
@@ -53,9 +53,9 @@ spec:
               name: cloudprovider
               key: accessKeySecret
         imagePullPolicy: Always
-{{- if .Values.diskpluginResources }}
+{{- if .Values.csiPluginController.podResources.diskPlugin }}
         resources:
-{{ toYaml .Values.diskpluginResources | indent 12 }}
+{{ toYaml .Values.csiPluginController.podResources.diskPlugin | indent 12 }}
 {{- end }}
         ports:
         - containerPort: 80
@@ -80,9 +80,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-{{- if .Values.attacherResources }}
+{{- if .Values.csiPluginController.podResources.attacher }}
         resources:
-{{ toYaml .Values.attacherResources | indent 12 }}
+{{ toYaml .Values.csiPluginController.podResources.attacher | indent 12 }}
 {{- end }}
         volumeMounts:
         - name: csi-attacher
@@ -99,13 +99,13 @@ spec:
 {{- if semverCompare ">= 1.14" .Values.kubernetesVersion }}
         - "--leader-election-type=leases"
         - "--leader-election-namespace=kube-system"
-        - "--volume-name-prefix=pv-{{ .Values.persistentVolumePrefix }}"
+        - "--volume-name-prefix=pv-{{ .Values.csiPluginController.persistentVolumePrefix }}"
 {{- else }}
         - "--provisioner=diskplugin.csi.alibabacloud.com"
 {{- end }}
-{{- if .Values.provisionerResources }}
+{{- if .Values.csiPluginController.podResources.provisioner }}
         resources:
-{{ toYaml .Values.provisionerResources | indent 12 }}
+{{ toYaml .Values.csiPluginController.podResources.provisioner | indent 12 }}
 {{- end }}
         env:
         - name: CSI_ENDPOINT
@@ -125,14 +125,14 @@ spec:
 {{- if semverCompare ">= 1.14" .Values.kubernetesVersion }}
         - "--leader-election"
         - "--leader-election-namespace=kube-system"
-        - "--snapshot-name-prefix=s-{{ .Values.snapshotPrefix }}"
+        - "--snapshot-name-prefix=s-{{ .Values.csiPluginController.snapshotPrefix }}"
 {{- end }}
         env:
         - name: CSI_ENDPOINT
           value: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com/csi.sock
-{{- if .Values.snapshotterResources}}
+{{- if .Values.csiPluginController.podResources.snapshotter }}
         resources:
-{{ toYaml .Values.snapshotterResources | indent 12 }}
+{{ toYaml .Values.csiPluginController.podResources.snapshotter | indent 12 }}
 {{- end}}
         volumeMounts:
         - name: socket-dir
@@ -151,9 +151,9 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com/csi.sock
-{{- if .Values.resizerResources}}
+{{- if .Values.csiPluginController.podResources.resizer }}
         resources:
-{{ toYaml .Values.resizerResources | indent 12 }}
+{{ toYaml .Values.csiPluginController.podResources.resizer | indent 12 }}
 {{- end}}
         volumeMounts:
         - name: csi-resizer

--- a/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-snapshot-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-snapshot-controller.yaml
@@ -1,0 +1,48 @@
+{{- if semverCompare ">= 1.17" .Values.kubernetesVersion }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csi-snapshot-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: csi-snapshot-controller
+    role: controller
+spec:
+  replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      app: csi-snapshot-controller
+      role: controller
+  template:
+    metadata:
+{{- if .Values.csiSnapshotController.podAnnotations }}
+      annotations:
+{{ toYaml .Values.csiSnapshotController.podAnnotations | indent 8 }}
+{{- end }}
+      labels:
+        app: csi-snapshot-controller
+        role: controller
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-shoot-apiserver: allowed
+    spec:
+      containers:
+      - name: csi-snapshot-controller
+        image: {{ index .Values.images "csi-snapshot-controller" }}
+        imagePullPolicy: IfNotPresent
+        args:
+        - "--kubeconfig=/var/lib/csi-snapshot-controller/kubeconfig"
+        - "--leader-election=true"
+        - "--leader-election-namespace=kube-system"
+{{- if .Values.csiSnapshotController.podResources.snapshotController }}
+        resources:
+{{ toYaml .Values.csiSnapshotController.podResources.snapshotController | indent 10 }}
+{{- end }}
+        volumeMounts:
+        - name: csi-snapshot-controller
+          mountPath: /var/lib/csi-snapshot-controller
+      volumes:
+      - name: csi-snapshot-controller
+        secret:
+          secretName: csi-snapshot-controller
+{{- end }}

--- a/charts/internal/seed-controlplane/charts/csi-alicloud/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/values.yaml
@@ -1,47 +1,63 @@
-replicas: 1
-images:
-  csi-attacher: image-repository:image-tag
-  csi-provisioner: image-repository:image-tag
-  csi-plugin-alicloud: image-repository:image-tag
-  csi-snapshotter: image-repository:image-tag
-  csi-resizer: image-repository:image-tag
-regionID: shanghai-cn
-snapshotPrefix: ""
-persistentVolumePrefix: ""
-podAnnotations: {}
-attacherResources:
-  requests:
-    cpu: 10m
-    memory: 32Mi
-  limits:
-    cpu: 30m
-    memory: 50Mi
-provisionerResources:
-  requests:
-    cpu: 10m
-    memory: 32Mi
-  limits:
-    cpu: 30m
-    memory: 50Mi
-snapshotterResources:
-  requests:
-    cpu: 10m
-    memory: 32Mi
-  limits:
-    cpu: 30m
-    memory: 50Mi
-resizerResources:
-  requests:
-    cpu: 10m
-    memory: 32Mi
-  limits:
-    cpu: 30m
-    memory: 50Mi
-diskpluginResources:
-  requests:
-    cpu: 20m
-    memory: 50Mi
-  limits:
-    cpu: 50m
-    memory: 80Mi
 kubernetesVersion: v1.14.0
+regionID: shanghai-cn
+replicas: 1
+
+images:
+  csi-attacher: repository:tag
+  csi-provisioner: repository:tag
+  csi-plugin-alicloud: repository:tag
+  csi-snapshotter: repository:tag
+  csi-snapshot-controller: repository:tag
+  csi-resizer: repository:tag
+
+csiPluginController:
+  snapshotPrefix: ""
+  persistentVolumePrefix: ""
+  podAnnotations: {}
+  podResources:
+    diskPlugin:
+      requests:
+        cpu: 20m
+        memory: 50Mi
+      limits:
+        cpu: 50m
+        memory: 80Mi
+    attacher:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 30m
+        memory: 50Mi
+    provisioner:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 30m
+        memory: 50Mi
+    snapshotter:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 30m
+        memory: 50Mi
+    resizer:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 30m
+        memory: 50Mi
+
+csiSnapshotController:
+  podAnnotations: {}
+  podResources:
+    snapshotController:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 30m
+        memory: 50Mi

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-snapshot-controller-rbac.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-snapshot-controller-rbac.yaml
@@ -1,23 +1,20 @@
-kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: {{ include "csi-disk-plugin.extensionsGroup" . }}:kube-system:csi-snapshotter
+  name: {{ include "csi-disk-plugin.extensionsGroup" . }}:kube-system:csi-snapshot-controller
 rules:
 - apiGroups: [""]
   resources: ["persistentvolumes"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "update"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["list", "watch", "create", "update", "patch"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list"]
 - apiGroups: ["snapshot.storage.k8s.io"]
   resources: ["volumesnapshotclasses"]
   verbs: ["get", "list", "watch"]
@@ -25,54 +22,45 @@ rules:
   resources: ["volumesnapshotcontents"]
   verbs: ["create", "get", "list", "watch", "update", "delete"]
 - apiGroups: ["snapshot.storage.k8s.io"]
-  resources: ["volumesnapshotcontents/status"]
-  verbs: ["update"]
-- apiGroups: ["snapshot.storage.k8s.io"]
   resources: ["volumesnapshots"]
   verbs: ["get", "list", "watch", "update"]
 - apiGroups: ["snapshot.storage.k8s.io"]
   resources: ["volumesnapshots/status"]
   verbs: ["update"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["create", "list", "watch", "delete"]
 ---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "csi-disk-plugin.extensionsGroup" . }}:csi-snapshotter
-subjects:
-- kind: User
-  name: system:csi-snapshotter
+  name: {{ include "csi-disk-plugin.extensionsGroup" . }}:csi-snapshot-controller
 roleRef:
-  kind: ClusterRole
-  name: {{ include "csi-disk-plugin.extensionsGroup" . }}:kube-system:csi-snapshotter
   apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "csi-disk-plugin.extensionsGroup" . }}:kube-system:csi-snapshot-controller
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:csi-snapshot-controller
 ---
-{{- if semverCompare ">= 1.14" .Values.kubernetesVersion }}
----
-# Attacher must be able to work with config map in current namespace
-# if (and only if) leadership election is enabled
-kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
-  namespace: kube-system
-  name: csi-snapshotter
+  name: csi-snapshot-controller
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
-kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
-  name: csi-snapshotter
-  namespace: kube-system
+  name: csi-snapshot-controller
+  namespace: {{ .Release.Namespace }}
 subjects:
-- kind: User
-  name: system:csi-snapshotter
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:csi-snapshot-controller
 roleRef:
-  kind: Role
-  name: csi-snapshotter
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
+  kind: Role
+  name: csi-snapshot-controller

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/crd-volumesnapshotclasses.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/crd-volumesnapshotclasses.yaml
@@ -1,0 +1,79 @@
+{{- if semverCompare ">= 1.17" .Values.kubernetesVersion }}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotclasses.snapshot.storage.k8s.io
+  annotations:
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
+    resources.gardener.cloud/delete-on-invalid-update: "true"
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .driver
+      name: Driver
+      type: string
+    - JSONPath: .deletionPolicy
+      description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass
+        should be deleted when its bound VolumeSnapshot is deleted.
+      name: DeletionPolicy
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotClass
+    listKind: VolumeSnapshotClassList
+    plural: volumesnapshotclasses
+    singular: volumesnapshotclass
+  preserveUnknownFields: false
+  scope: Cluster
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshotClass specifies parameters that a underlying storage
+        system uses when creating a volume snapshot. A specific VolumeSnapshotClass
+        is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses
+        are non-namespaced
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        deletionPolicy:
+          description: deletionPolicy determines whether a VolumeSnapshotContent created
+            through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot
+            is deleted. Supported values are "Retain" and "Delete". "Retain" means
+            that the VolumeSnapshotContent and its physical snapshot on underlying
+            storage system are kept. "Delete" means that the VolumeSnapshotContent
+            and its physical snapshot on underlying storage system are deleted. Required.
+          enum:
+            - Delete
+            - Retain
+          type: string
+        driver:
+          description: driver is the name of the storage driver that handles this
+            VolumeSnapshotClass. Required.
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        parameters:
+          additionalProperties:
+            type: string
+          description: parameters is a key-value map with storage driver specific
+            parameters for creating snapshots. These values are opaque to Kubernetes.
+          type: object
+      required:
+        - deletionPolicy
+        - driver
+      type: object
+  version: v1beta1
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/crd-volumesnapshotcontents.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/crd-volumesnapshotcontents.yaml
@@ -1,0 +1,226 @@
+{{- if semverCompare ">= 1.17" .Values.kubernetesVersion }}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotcontents.snapshot.storage.k8s.io
+  annotations:
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
+    resources.gardener.cloud/delete-on-invalid-update: "true"
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.readyToUse
+      description: Indicates if a snapshot is ready to be used to restore a volume.
+      name: ReadyToUse
+      type: boolean
+    - JSONPath: .status.restoreSize
+      description: Represents the complete size of the snapshot in bytes
+      name: RestoreSize
+      type: integer
+    - JSONPath: .spec.deletionPolicy
+      description: Determines whether this VolumeSnapshotContent and its physical snapshot
+        on the underlying storage system should be deleted when its bound VolumeSnapshot
+        is deleted.
+      name: DeletionPolicy
+      type: string
+    - JSONPath: .spec.driver
+      description: Name of the CSI driver used to create the physical snapshot on the
+        underlying storage system.
+      name: Driver
+      type: string
+    - JSONPath: .spec.volumeSnapshotClassName
+      description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+      name: VolumeSnapshotClass
+      type: string
+    - JSONPath: .spec.volumeSnapshotRef.name
+      description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent
+        object is bound.
+      name: VolumeSnapshot
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotContent
+    listKind: VolumeSnapshotContentList
+    plural: volumesnapshotcontents
+    singular: volumesnapshotcontent
+  preserveUnknownFields: false
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshotContent represents the actual "on-disk" snapshot
+        object in the underlying storage system
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: spec defines properties of a VolumeSnapshotContent created
+            by the underlying storage system. Required.
+          properties:
+            deletionPolicy:
+              description: deletionPolicy determines whether this VolumeSnapshotContent
+                and its physical snapshot on the underlying storage system should
+                be deleted when its bound VolumeSnapshot is deleted. Supported values
+                are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent
+                and its physical snapshot on underlying storage system are kept. "Delete"
+                means that the VolumeSnapshotContent and its physical snapshot on
+                underlying storage system are deleted. In dynamic snapshot creation
+                case, this field will be filled in with the "DeletionPolicy" field
+                defined in the VolumeSnapshotClass the VolumeSnapshot refers to. For
+                pre-existing snapshots, users MUST specify this field when creating
+                the VolumeSnapshotContent object. Required.
+              enum:
+                - Delete
+                - Retain
+              type: string
+            driver:
+              description: driver is the name of the CSI driver used to create the
+                physical snapshot on the underlying storage system. This MUST be the
+                same as the name returned by the CSI GetPluginName() call for that
+                driver. Required.
+              type: string
+            source:
+              description: source specifies from where a snapshot will be created.
+                This field is immutable after creation. Required.
+              properties:
+                snapshotHandle:
+                  description: snapshotHandle specifies the CSI "snapshot_id" of a
+                    pre-existing snapshot on the underlying storage system. This field
+                    is immutable.
+                  type: string
+                volumeHandle:
+                  description: volumeHandle specifies the CSI "volume_id" of the volume
+                    from which a snapshot should be dynamically taken from. This field
+                    is immutable.
+                  type: string
+              type: object
+            volumeSnapshotClassName:
+              description: name of the VolumeSnapshotClass to which this snapshot
+                belongs.
+              type: string
+            volumeSnapshotRef:
+              description: volumeSnapshotRef specifies the VolumeSnapshot object to
+                which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName
+                field must reference to this VolumeSnapshotContent's name for the
+                bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent
+                object, name and namespace of the VolumeSnapshot object MUST be provided
+                for binding to happen. This field is immutable after creation. Required.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+          required:
+            - deletionPolicy
+            - driver
+            - source
+            - volumeSnapshotRef
+          type: object
+        status:
+          description: status represents the current information of a snapshot.
+          properties:
+            creationTime:
+              description: creationTime is the timestamp when the point-in-time snapshot
+                is taken by the underlying storage system. In dynamic snapshot creation
+                case, this field will be filled in with the "creation_time" value
+                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
+                snapshot, this field will be filled with the "creation_time" value
+                returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                it. If not specified, it indicates the creation time is unknown. The
+                format of this field is a Unix nanoseconds time encoded as an int64.
+                On Unix, the command `date +%s%N` returns the current time in nanoseconds
+                since 1970-01-01 00:00:00 UTC.
+              format: int64
+              type: integer
+            error:
+              description: error is the latest observed error during snapshot creation,
+                if any.
+              properties:
+                message:
+                  description: 'message is a string detailing the encountered error
+                    during snapshot creation if specified. NOTE: message may be logged,
+                    and it should not contain sensitive information.'
+                  type: string
+                time:
+                  description: time is the timestamp when the error was encountered.
+                  format: date-time
+                  type: string
+              type: object
+            readyToUse:
+              description: readyToUse indicates if a snapshot is ready to be used
+                to restore a volume. In dynamic snapshot creation case, this field
+                will be filled in with the "ready_to_use" value returned from CSI
+                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
+                field will be filled with the "ready_to_use" value returned from the
+                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
+                this field will be set to "True". If not specified, it means the readiness
+                of a snapshot is unknown.
+              type: boolean
+            restoreSize:
+              description: restoreSize represents the complete size of the snapshot
+                in bytes. In dynamic snapshot creation case, this field will be filled
+                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
+                gRPC call. For a pre-existing snapshot, this field will be filled
+                with the "size_bytes" value returned from the CSI "ListSnapshots"
+                gRPC call if the driver supports it. When restoring a volume from
+                this snapshot, the size of the volume MUST NOT be smaller than the
+                restoreSize if it is specified, otherwise the restoration will fail.
+                If not specified, it indicates that the size is unknown.
+              format: int64
+              type: integer
+            snapshotHandle:
+              description: snapshotHandle is the CSI "snapshot_id" of a snapshot on
+                the underlying storage system. If not specified, it indicates that
+                dynamic snapshot creation has either failed or it is still in progress.
+              type: string
+          type: object
+      required:
+        - spec
+      type: object
+  version: v1beta1
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/crd-volumesnapshots.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/crd-volumesnapshots.yaml
@@ -1,0 +1,188 @@
+{{- if semverCompare ">= 1.17" .Values.kubernetesVersion }}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshots.snapshot.storage.k8s.io
+  annotations:
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/260"
+    resources.gardener.cloud/delete-on-invalid-update: "true"
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.readyToUse
+      description: Indicates if a snapshot is ready to be used to restore a volume.
+      name: ReadyToUse
+      type: boolean
+    - JSONPath: .spec.source.persistentVolumeClaimName
+      description: Name of the source PVC from where a dynamically taken snapshot will
+        be created.
+      name: SourcePVC
+      type: string
+    - JSONPath: .spec.source.volumeSnapshotContentName
+      description: Name of the VolumeSnapshotContent which represents a pre-provisioned
+        snapshot.
+      name: SourceSnapshotContent
+      type: string
+    - JSONPath: .status.restoreSize
+      description: Represents the complete size of the snapshot.
+      name: RestoreSize
+      type: string
+    - JSONPath: .spec.volumeSnapshotClassName
+      description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+      name: SnapshotClass
+      type: string
+    - JSONPath: .status.boundVolumeSnapshotContentName
+      description: The name of the VolumeSnapshotContent to which this VolumeSnapshot
+        is bound.
+      name: SnapshotContent
+      type: string
+    - JSONPath: .status.creationTime
+      description: Timestamp when the point-in-time snapshot is taken by the underlying
+        storage system.
+      name: CreationTime
+      type: date
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshot
+    listKind: VolumeSnapshotList
+    plural: volumesnapshots
+    singular: volumesnapshot
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshot is a user's request for either creating a point-in-time
+        snapshot of a persistent volume, or binding to a pre-existing snapshot.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: 'spec defines the desired characteristics of a snapshot requested
+            by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
+            Required.'
+          properties:
+            source:
+              description: source specifies where a snapshot will be created from.
+                This field is immutable after creation. Required.
+              properties:
+                persistentVolumeClaimName:
+                  description: persistentVolumeClaimName specifies the name of the
+                    PersistentVolumeClaim object in the same namespace as the VolumeSnapshot
+                    object where the snapshot should be dynamically taken from. This
+                    field is immutable.
+                  type: string
+                volumeSnapshotContentName:
+                  description: volumeSnapshotContentName specifies the name of a pre-existing
+                    VolumeSnapshotContent object. This field is immutable.
+                  type: string
+              type: object
+            volumeSnapshotClassName:
+              description: 'volumeSnapshotClassName is the name of the VolumeSnapshotClass
+                requested by the VolumeSnapshot. If not specified, the default snapshot
+                class will be used if one exists. If not specified, and there is no
+                default snapshot class, dynamic snapshot creation will fail. Empty
+                string is not allowed for this field. TODO(xiangqian): a webhook validation
+                on empty string. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes'
+              type: string
+          required:
+            - source
+          type: object
+        status:
+          description: 'status represents the current information of a snapshot. NOTE:
+            status can be modified by sources other than system controllers, and must
+            not be depended upon for accuracy. Controllers should only use information
+            from the VolumeSnapshotContent object after verifying that the binding
+            is accurate and complete.'
+          properties:
+            boundVolumeSnapshotContentName:
+              description: 'boundVolumeSnapshotContentName represents the name of
+                the VolumeSnapshotContent object to which the VolumeSnapshot object
+                is bound. If not specified, it indicates that the VolumeSnapshot object
+                has not been successfully bound to a VolumeSnapshotContent object
+                yet. NOTE: Specified boundVolumeSnapshotContentName alone does not
+                mean binding       is valid. Controllers MUST always verify bidirectional
+                binding between       VolumeSnapshot and VolumeSnapshotContent to
+                avoid possible security issues.'
+              type: string
+            creationTime:
+              description: creationTime is the timestamp when the point-in-time snapshot
+                is taken by the underlying storage system. In dynamic snapshot creation
+                case, this field will be filled in with the "creation_time" value
+                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
+                snapshot, this field will be filled with the "creation_time" value
+                returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                it. If not specified, it indicates that the creation time of the snapshot
+                is unknown.
+              format: date-time
+              type: string
+            error:
+              description: error is the last observed error during snapshot creation,
+                if any. This field could be helpful to upper level controllers(i.e.,
+                application controller) to decide whether they should continue on
+                waiting for the snapshot to be created based on the type of error
+                reported.
+              properties:
+                message:
+                  description: 'message is a string detailing the encountered error
+                    during snapshot creation if specified. NOTE: message may be logged,
+                    and it should not contain sensitive information.'
+                  type: string
+                time:
+                  description: time is the timestamp when the error was encountered.
+                  format: date-time
+                  type: string
+              type: object
+            readyToUse:
+              description: readyToUse indicates if a snapshot is ready to be used
+                to restore a volume. In dynamic snapshot creation case, this field
+                will be filled in with the "ready_to_use" value returned from CSI
+                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
+                field will be filled with the "ready_to_use" value returned from the
+                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
+                this field will be set to "True". If not specified, it means the readiness
+                of a snapshot is unknown.
+              type: boolean
+            restoreSize:
+              anyOf:
+                - type: integer
+                - type: string
+              description: restoreSize represents the complete size of the snapshot
+                in bytes. In dynamic snapshot creation case, this field will be filled
+                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
+                gRPC call. For a pre-existing snapshot, this field will be filled
+                with the "size_bytes" value returned from the CSI "ListSnapshots"
+                gRPC call if the driver supports it. When restoring a volume from
+                this snapshot, the size of the volume MUST NOT be smaller than the
+                restoreSize if it is specified, otherwise the restoration will fail.
+                If not specified, it indicates that the size is unknown.
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+          type: object
+      required:
+        - spec
+      type: object
+  version: v1beta1
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/pkg/alicloud/types.go
+++ b/pkg/alicloud/types.go
@@ -37,6 +37,8 @@ const (
 	CSIProvisionerImageName = "csi-provisioner"
 	// CSISnapshotterImageName is the name of the CSI snapshotter image.
 	CSISnapshotterImageName = "csi-snapshotter"
+	// CSISnapshotControllerImageName is the name of the CSI snapshot controller image.
+	CSISnapshotControllerImageName = "csi-snapshot-controller"
 	// CSIResizerImageName is the name of the CSI resizer image.
 	CSIResizerImageName = "csi-resizer"
 
@@ -62,6 +64,13 @@ const (
 	CloudControllerManagerName = "cloud-controller-manager"
 	// CsiPluginController is the a constant for the name of the CSI Plugin controller
 	CsiPluginController = "csi-plugin-controller"
+
+	// CRDVolumeSnapshotClasses is a constant for the name of VolumeSnapshotClasses CRD
+	CRDVolumeSnapshotClasses = "volumesnapshotclasses.snapshot.storage.k8s.io"
+	// CRDVolumeSnapshotContents is a constant for the name of VolumeSnapshotContents CRD
+	CRDVolumeSnapshotContents = "volumesnapshotcontents.snapshot.storage.k8s.io"
+	// CRDVolumeSnapshots is a constant for the name of CRDVolumeSnapshots CRD
+	CRDVolumeSnapshots = "volumesnapshots.snapshot.storage.k8s.io"
 )
 
 var (

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"path/filepath"
 
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
 	apisalicloud "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/helper"
@@ -117,6 +119,19 @@ var controlPlaneSecrets = &secrets.Secrets{
 					APIServerURL: v1beta1constants.DeploymentNameKubeAPIServer,
 				},
 			},
+			&secrets.ControlPlaneSecretConfig{
+				CertificateSecretConfig: &secrets.CertificateSecretConfig{
+					Name:         "csi-snapshot-controller",
+					CommonName:   "system:csi-snapshot-controller",
+					Organization: []string{user.SystemPrivilegedGroup},
+					CertType:     secrets.ClientCert,
+					SigningCA:    cas[v1beta1constants.SecretNameCACluster],
+				},
+				KubeConfigRequest: &secrets.KubeConfigRequest{
+					ClusterName:  clusterName,
+					APIServerURL: v1beta1constants.DeploymentNameKubeAPIServer,
+				},
+			},
 		}
 	},
 }
@@ -136,10 +151,18 @@ var controlPlaneChart = &chart.Chart{
 			},
 		},
 		{
-			Name:   "csi-alicloud",
-			Images: []string{alicloud.CSIAttacherImageName, alicloud.CSIProvisionerImageName, alicloud.CSISnapshotterImageName, alicloud.CSIResizerImageName, alicloud.CSIPluginImageName},
+			Name: "csi-alicloud",
+			Images: []string{
+				alicloud.CSIAttacherImageName,
+				alicloud.CSIProvisionerImageName,
+				alicloud.CSISnapshotterImageName,
+				alicloud.CSIResizerImageName,
+				alicloud.CSIPluginImageName,
+				alicloud.CSISnapshotControllerImageName,
+			},
 			Objects: []*chart.Object{
 				{Type: &appsv1.Deployment{}, Name: "csi-plugin-controller"},
+				{Type: &appsv1.Deployment{}, Name: "csi-snapshot-controller"},
 			},
 		},
 	},
@@ -181,11 +204,19 @@ var controlPlaneShootChart = &chart.Chart{
 				{Type: &rbacv1.Role{}, Name: "csi-provisioner"},
 				{Type: &rbacv1.RoleBinding{}, Name: "csi-provisioner"},
 				// csi-snapshotter
+				{Type: &apiextensionsv1beta1.CustomResourceDefinition{}, Name: alicloud.CRDVolumeSnapshotClasses},
+				{Type: &apiextensionsv1beta1.CustomResourceDefinition{}, Name: alicloud.CRDVolumeSnapshotContents},
+				{Type: &apiextensionsv1beta1.CustomResourceDefinition{}, Name: alicloud.CRDVolumeSnapshots},
 				{Type: &corev1.ServiceAccount{}, Name: "csi-snapshotter"},
 				{Type: &rbacv1.ClusterRole{}, Name: extensionsv1alpha1.SchemeGroupVersion.Group + ":kube-system:csi-snapshotter"},
 				{Type: &rbacv1.ClusterRoleBinding{}, Name: extensionsv1alpha1.SchemeGroupVersion.Group + ":csi-snapshotter"},
 				{Type: &rbacv1.Role{}, Name: "csi-snapshotter"},
 				{Type: &rbacv1.RoleBinding{}, Name: "csi-snapshotter"},
+				// csi-snapshot-controller
+				{Type: &rbacv1.ClusterRole{}, Name: extensionsv1alpha1.SchemeGroupVersion.Group + ":kube-system:csi-snapshot-controller"},
+				{Type: &rbacv1.ClusterRoleBinding{}, Name: extensionsv1alpha1.SchemeGroupVersion.Group + ":csi-snapshot-controller"},
+				{Type: &rbacv1.Role{}, Name: "csi-snapshot-controller"},
+				{Type: &rbacv1.RoleBinding{}, Name: "csi-snapshot-controller"},
 				// csi-resizer
 				{Type: &corev1.ServiceAccount{}, Name: "csi-resizer"},
 				{Type: &rbacv1.ClusterRole{}, Name: extensionsv1alpha1.SchemeGroupVersion.Group + ":kube-system:csi-resizer"},
@@ -343,17 +374,24 @@ func (vp *valuesProvider) getControlPlaneChartValues(
 			"cloudConfig": ccmConfig,
 		},
 		"csi-alicloud": map[string]interface{}{
-			"replicas":               extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
-			"kubernetesVersion":      cluster.Shoot.Spec.Kubernetes.Version,
-			"regionID":               cp.Spec.Region,
-			"snapshotPrefix":         cluster.Shoot.Name,
-			"persistentVolumePrefix": cluster.Shoot.Name,
-			"podAnnotations": map[string]interface{}{
-				"checksum/secret-csi-attacher":    checksums["csi-attacher"],
-				"checksum/secret-csi-provisioner": checksums["csi-provisioner"],
-				"checksum/secret-csi-snapshotter": checksums["csi-snapshotter"],
-				"checksum/secret-csi-resizer":     checksums["csi-resizer"],
-				"checksum/secret-cloudprovider":   checksums[v1beta1constants.SecretNameCloudProvider],
+			"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
+			"regionID":          cp.Spec.Region,
+			"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
+			"csiPluginController": map[string]interface{}{
+				"snapshotPrefix":         cluster.Shoot.Name,
+				"persistentVolumePrefix": cluster.Shoot.Name,
+				"podAnnotations": map[string]interface{}{
+					"checksum/secret-csi-attacher":    checksums["csi-attacher"],
+					"checksum/secret-csi-provisioner": checksums["csi-provisioner"],
+					"checksum/secret-csi-snapshotter": checksums["csi-snapshotter"],
+					"checksum/secret-csi-resizer":     checksums["csi-resizer"],
+					"checksum/secret-cloudprovider":   checksums[v1beta1constants.SecretNameCloudProvider],
+				},
+			},
+			"csiSnapshotController": map[string]interface{}{
+				"podAnnotations": map[string]interface{}{
+					"checksum/secret-csi-snapshot-controller": checksums["csi-snapshot-controller"],
+				},
 			},
 		},
 	}

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -136,6 +136,7 @@ var _ = Describe("ValuesProvider", func() {
 			"csi-attacher":                           "2da58ad61c401a2af779a909d22fb42eed93a1524cbfdab974ceedb413fcb914",
 			"csi-provisioner":                        "f75b42d40ab501428c383dfb2336cb1fc892bbee1fc1d739675171e4acc4d911",
 			"csi-snapshotter":                        "bf417dd97dc3e8c2092bb5b2ba7b0f1093ebc4bb5952091ee554cf5b7ea74508",
+			"csi-snapshot-controller":                "4b7977b627acb0c1f74607cb31bd3a706a18ff1067121e31cec5e432a8f6ab15",
 			"csi-resizer":                            "5df115bd53f09da2d6d27bfb048c14dabd14a66608cfdba5ecd2d0687889cc6a",
 		}
 
@@ -158,17 +159,26 @@ var _ = Describe("ValuesProvider", func() {
 				},
 			},
 			"csi-alicloud": map[string]interface{}{
-				"replicas":               1,
-				"snapshotPrefix":         "myshoot",
-				"persistentVolumePrefix": "myshoot",
-				"kubernetesVersion":      "1.14.0",
-				"regionID":               "eu-central-1",
-				"podAnnotations": map[string]interface{}{
-					"checksum/secret-csi-attacher":    "2da58ad61c401a2af779a909d22fb42eed93a1524cbfdab974ceedb413fcb914",
-					"checksum/secret-csi-provisioner": "f75b42d40ab501428c383dfb2336cb1fc892bbee1fc1d739675171e4acc4d911",
-					"checksum/secret-csi-snapshotter": "bf417dd97dc3e8c2092bb5b2ba7b0f1093ebc4bb5952091ee554cf5b7ea74508",
-					"checksum/secret-csi-resizer":     "5df115bd53f09da2d6d27bfb048c14dabd14a66608cfdba5ecd2d0687889cc6a",
-					"checksum/secret-cloudprovider":   "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
+				"replicas":          1,
+				"regionID":          "eu-central-1",
+				"kubernetesVersion": "1.14.0",
+
+				"csiPluginController": map[string]interface{}{
+					"snapshotPrefix":         "myshoot",
+					"persistentVolumePrefix": "myshoot",
+					"podAnnotations": map[string]interface{}{
+						"checksum/secret-csi-attacher":    "2da58ad61c401a2af779a909d22fb42eed93a1524cbfdab974ceedb413fcb914",
+						"checksum/secret-csi-provisioner": "f75b42d40ab501428c383dfb2336cb1fc892bbee1fc1d739675171e4acc4d911",
+						"checksum/secret-csi-snapshotter": "bf417dd97dc3e8c2092bb5b2ba7b0f1093ebc4bb5952091ee554cf5b7ea74508",
+						"checksum/secret-csi-resizer":     "5df115bd53f09da2d6d27bfb048c14dabd14a66608cfdba5ecd2d0687889cc6a",
+						"checksum/secret-cloudprovider":   "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
+					},
+				},
+
+				"csiSnapshotController": map[string]interface{}{
+					"podAnnotations": map[string]interface{}{
+						"checksum/secret-csi-snapshot-controller": "4b7977b627acb0c1f74607cb31bd3a706a18ff1067121e31cec5e432a8f6ab15",
+					},
 				},
 			},
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind enhancement
/priority normal
/platform alicloud

**What this PR does / why we need it**:
This PR is to update `snapshot` CSI version from `1.2.2` to `2.1.1`. Version `2.x.x` is not compatible with `1.x.x` version, because CRDs `volumesnapshotclasses`, `volumesnapshots`, `volumesnapshotcontents` are promoted to `v1beta1`. 

So we do the following logic to update `snapshot` CSI version:
1. if shoots contain old version CRDs, but don't have related CROs, delete old CRDs and deploy new CRDs.
2. if shoots contain old version CRDs, and have related CROS, will not delete CRDs. Gardener Dashboard will show the related errors. Customers need to backup and delete related CROs manually.
3. if shoots already contain new version CRDs, do nothing.

**Which issue(s) this PR fixes**:
Fixes #
#72 
**Special notes for your reviewer**:
Because it is an incompatible update, CROs of old version snapshot CRDs (v1alpha1) will be cleaned.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Update Snapshot CSI version to v2.1.1. Because it is an incompatible update, CROs of old version snapshot CRDs (v1alpha1) will be cleaned during the update.
```
