### PR TITLE
Add PDB for validation server

### DIFF
--- a/charts/gardener-extension-validator-alicloud/charts/runtime/templates/poddisruptionbudget.yaml
+++ b/charts/gardener-extension-validator-alicloud/charts/runtime/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if gt (int .Values.global.replicaCount) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "labels" . | indent 4 }}
+spec:
+  maxUnavailable: {{ sub (int .Values.global.replicaCount) 1 }}
+  selector:
+    matchLabels:
+{{ include "labels" . | indent 6 }}
+{{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability robustness
/kind enhancement
/priority normal
/platform alicloud

**What this PR does / why we need it**:
This PR adds a `PodDisruptionBudget` to the validator chart which will be created when the replica count is larger than `1`, similar to how it's done for the extension controller.

/invite @ialidzhikov @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A `PodDisruptionBudget` for the validation server is now automatically deployed as part of its Helm chart if the replica count is larger than `1`.
```
