### PR TITLE
set ExternalTrafficPolicy of kubeapi server service to Local

### DIFF
--- a/pkg/webhook/controlplaneexposure/add.go
+++ b/pkg/webhook/controlplaneexposure/add.go
@@ -20,6 +20,7 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
+	corev1 "k8s.io/api/core/v1"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -47,7 +48,7 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) (*extensionsw
 	return controlplane.New(mgr, controlplane.Args{
 		Kind:     controlplane.KindSeed,
 		Provider: alicloud.Type,
-		Types:    []runtime.Object{&appsv1.Deployment{}, &druidv1alpha1.Etcd{}},
+		Types:    []runtime.Object{&appsv1.Deployment{}, &druidv1alpha1.Etcd{}, &corev1.Service{}},
 		Mutator:  genericmutator.NewMutator(NewEnsurer(&opts.ETCDStorage, logger), nil, nil, nil, logger),
 	})
 }

--- a/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/pkg/webhook/controlplaneexposure/ensurer.go
@@ -17,7 +17,10 @@ package controlplaneexposure
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/config"
+	webhookutils "github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/utils"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
@@ -52,6 +55,11 @@ type ensurer struct {
 func (e *ensurer) InjectClient(client client.Client) error {
 	e.client = client
 	return nil
+}
+
+// EnsureKubeAPIServerService ensures that the kube-apiserver service conforms to the provider requirements.
+func (e *ensurer) EnsureKubeAPIServerService(ctx context.Context, ectx genericmutator.EnsurerContext, new, old *corev1.Service) error {
+	return webhookutils.MutateLBService(new, old)
 }
 
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.

--- a/pkg/webhook/shoot/mutator.go
+++ b/pkg/webhook/shoot/mutator.go
@@ -17,8 +17,8 @@ package shoot
 import (
 	"context"
 
+	webhookutils "github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/utils"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
-
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -63,7 +63,7 @@ func (m *mutator) Mutate(ctx context.Context, new, old runtime.Object) error {
 			}
 
 			extensionswebhook.LogMutation(logger, x.Kind, x.Namespace, x.Name)
-			return m.mutateLBService(ctx, x, oldSvc)
+			return webhookutils.MutateLBService(x, oldSvc)
 		}
 	case *appsv1.Deployment:
 		if x.Name == "metrics-server" {

--- a/pkg/webhook/utils/lb_service.go
+++ b/pkg/webhook/utils/lb_service.go
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shoot
+package utils
 
 import (
-	"context"
-
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (m *mutator) mutateLBService(ctx context.Context, new, old *corev1.Service) error {
+func MutateLBService(new, old *corev1.Service) error {
 	new.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
 
 	// Do not overwrite '.spec.healthCheckNodePort'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal
/platform alicloud

**What this PR does / why we need it**:
Set ExternalTrafficPolicy of kube-apiserver service to Local in Alicloud. 
**Which issue(s) this PR fixes**:
Fixes #25 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Set ExternalTrafficPolicy of kube-apiserver service to Local in Alicloud.
```
