### PR TITLE
Do not change for non-loadbalancer type service

### DIFF
--- a/pkg/webhook/shoot/lb_service_test.go
+++ b/pkg/webhook/shoot/lb_service_test.go
@@ -40,14 +40,20 @@ var _ = Describe("Mutator", func() {
 				Name:      "vpn-shoot",
 				Namespace: metav1.NamespaceSystem,
 			},
-			Spec: corev1.ServiceSpec{ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster},
+			Spec: corev1.ServiceSpec{
+				Type:                  corev1.ServiceTypeLoadBalancer,
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+			},
 		}
 		nginxIngressSvc = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "addons-nginx-ingress-controller",
 				Namespace: metav1.NamespaceSystem,
 			},
-			Spec: corev1.ServiceSpec{ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster},
+			Spec: corev1.ServiceSpec{
+				Type:                  corev1.ServiceTypeLoadBalancer,
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+			},
 		}
 		otherSvc = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/webhook/utils/lb_service.go
+++ b/pkg/webhook/utils/lb_service.go
@@ -18,7 +18,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// MutateLBService mutates ServiceExternalTrafficPolicyTypeLocal of LoadBalancer type service
 func MutateLBService(new, old *corev1.Service) error {
+	if new.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return nil
+	}
+
 	new.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
 
 	// Do not overwrite '.spec.healthCheckNodePort'


### PR DESCRIPTION
Don't mutate kube-apiserver service with ClusterIP type.
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression
/priority blocker
/platform alicloud

**What this PR does / why we need it**:
For APIServerSNI feature gate enabled gardenlet, kube-apiserver service is ClusterIP type. In this case, we should not change Kube-apiserver service.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
