### PR TITLE
add infrastructure permission documentation

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -2,11 +2,29 @@
 
 The [`core.gardener.cloud/v1beta1.Shoot` resource](https://github.com/gardener/gardener/blob/master/example/90-shoot.yaml) declares a few fields that are meant to contain provider-specific configuration.
 
-In this document we are describing how this configuration looks like for Alicloud and provide an example `Shoot` manifest with minimal configuration that you can use to create an Alicloud cluster (modulo the landscape-specific information like cloud profile names, secret binding names, etc.).
+This document describes the configurable options for Alicloud and provides an example `Shoot` manifest with minimal configuration that can be used to create an Alicloud cluster (modulo the landscape-specific information like cloud profile names, secret binding names, etc.).
 
-## Provider secret data
+## Alicloud Provider Credentials
 
-Every shoot cluster references a `SecretBinding` which itself references a `Secret`, and this `Secret` contains the provider credentials of your Alicloud account.
+In order for Gardener to create a Kubernetes cluster using Alicloud infrastructure components, a Shoot has to provide credentials with sufficient permissions to the desired Alicloud project.
+Every shoot cluster references a `SecretBinding` which itself references a `Secret`, and this `Secret` contains the provider credentials of the Alicloud project.
+The `SecretBinding` is configurable in the [Shoot cluster](https://github.com/gardener/gardener/blob/master/example/90-shoot.yaml) with the field `secretBindingName`.
+
+The required credentials for the Alicloud project are an [AccessKey Pair](https://www.alibabacloud.com/help/doc-detail/29009.htm) associated with a [Resource Access Management (RAM) User](https://www.alibabacloud.com/help/doc-detail/28627.htm).
+A RAM user is a special account that can be used by services and applications to interact with Alicloud Cloud Platform APIs. 
+Applications can use AccessKey pair to authorize themselves to a set of APIs and perform actions within the permissions granted to the RAM user.
+
+Make sure to [create a Resource Access Management User](https://www.alibabacloud.com/help/doc-detail/93720.htm), and [create an AccessKey Pair](https://partners-intl.aliyun.com/help/doc-detail/116401.htm) that shall be used for the Shoot cluster.
+
+[Grant at least the following permissions](https://partners-intl.aliyun.com/help/doc-detail/116146.htm) to the Resource Access Management User.
+- AliyunECSFullAccess
+- AliyunVPCFullAccess
+- AliyunSLBFullAccess
+- AliyunNATGatewayFullAccess
+- AliyunEIPFullAccess
+
+Provide AccessKey Pair in the `Secret` (base64 encoded for fields `accessKeyID` and `accessKeySecret`, respectively), that is being referenced by the `SecretBinding` in the Shoot cluster configuration.
+
 This `Secret` must look as follows:
 
 ```yaml
@@ -20,8 +38,6 @@ data:
   accessKeyID: base64(access-key-id)
   accessKeySecret: base64(access-key-secret)
 ```
-
-Please look up https://www.alibabacloud.com/help/doc-detail/29009.htm as well.
 
 ## `InfrastructureConfig`
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal
/platform alicloud

**What this PR does / why we need it**:
This PR is to add infrastructure permission documentation.
**Which issue(s) this PR fixes**:
Fixes #138 
**Special notes for your reviewer**:
None
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
More detailed documents regarding required infrastructure permissions for both the operator and end-user.
```
