### PR TITLE
check whether the imageId is public

### DIFF
--- a/pkg/alicloud/client/client.go
+++ b/pkg/alicloud/client/client.go
@@ -198,6 +198,24 @@ func (c *ecsClient) CheckIfImageExists(ctx context.Context, imageID string) (boo
 	return response.TotalCount > 0, nil
 }
 
+// CheckIfImagePublic checks whether given imageID can is public image
+func (c *ecsClient) CheckIfImagePublic(ctx context.Context, imageID string) (bool, error) {
+	request := ecs.CreateDescribeImagesRequest()
+	request.ImageOwnerAlias = "system"
+	request.SetScheme("HTTPS")
+	response, err := c.client.DescribeImages(request)
+	if err != nil {
+		return false, err
+	}
+
+	for _, image := range response.Images.Image {
+		if image.ImageId == imageID || image.ImageName == imageID {
+			return true, nil
+		}
+	}
+	return response.TotalCount > 0, nil
+}
+
 // ShareImageToAccount shares the given image to target account from current client
 func (c *ecsClient) ShareImageToAccount(ctx context.Context, regionID, imageID, accountID string) error {
 	request := ecs.CreateModifyImageSharePermissionRequest()

--- a/pkg/alicloud/client/types.go
+++ b/pkg/alicloud/client/types.go
@@ -43,6 +43,7 @@ type STS interface {
 // ECS is an interface which must be implemented by alicloud ecs clients.
 type ECS interface {
 	CheckIfImageExists(ctx context.Context, imageID string) (bool, error)
+	CheckIfImagePublic(ctx context.Context, imageID string) (bool, error)
 	ShareImageToAccount(ctx context.Context, regionID, imageID, accountID string) error
 }
 

--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -368,6 +368,14 @@ func (a *actuator) shareCustomizedImages(ctx context.Context, infra *extensionsv
 			continue
 		}
 
+		isPublic, err := shootAlicloudECSClient.CheckIfImagePublic(ctx, imageID)
+		if err != nil {
+			return nil, err
+		}
+		if isPublic {
+			continue
+		}
+
 		exists, err := shootAlicloudECSClient.CheckIfImageExists(ctx, imageID)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
If users choose alicloud public os image, the infrastructure controller will hung there.