### PR TITLE
revendor g/g 1.11.2 and mcm 0.34.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/frankban/quicktest v1.9.0 // indirect
 	github.com/gardener/etcd-druid v0.3.0
-	github.com/gardener/gardener v1.11.1
-	github.com/gardener/machine-controller-manager v0.34.0
+	github.com/gardener/gardener v1.11.2
+	github.com/gardener/machine-controller-manager v0.34.3
 	github.com/go-logr/logr v0.1.0
 	github.com/gobuffalo/packr/v2 v2.8.0
 	github.com/golang/mock v1.4.4-0.20200731163441-8734ec565a4d

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/gardener/external-dns-management v0.7.18/go.mod h1:oHhauLQ3/sop0c1urS
 github.com/gardener/gardener v1.1.2/go.mod h1:CP9I0tCDVXTLPkJv/jUtXVUh948kSNKEGUg0haLz9gk=
 github.com/gardener/gardener v1.3.1/go.mod h1:936P5tQbg6ViiW8BVC9ELM95sFrk4DgobKrxMNtn/LU=
 github.com/gardener/gardener v1.4.1-0.20200519155656-a8ccc6cc779a/go.mod h1:t9oESM37bAMIuezi9I0H0I8+++8jy8BUPitcf4ERRXY=
-github.com/gardener/gardener v1.11.1 h1:W55ueeo8i1ipzHwKR0ttcCM2ODzJazLI6Lh+3Qf5La4=
-github.com/gardener/gardener v1.11.1/go.mod h1:mOy8lkhTxq2zmCf0dCFiw9yepWlhUmOzdmIPuH0Pa+k=
+github.com/gardener/gardener v1.11.2 h1:SsBXb97GvqLwdNd01c/+ZUcE7idhd3Y5LW9+J/+NO3k=
+github.com/gardener/gardener v1.11.2/go.mod h1:mOy8lkhTxq2zmCf0dCFiw9yepWlhUmOzdmIPuH0Pa+k=
 github.com/gardener/gardener-resource-manager v0.10.0 h1:6OUKoWI3oha42F0oJN8OEo3UR+D3onOCel4Th+zgotU=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/gardener-resource-manager v0.13.1 h1:BiQ0EMO58663UN7lkOXRKV4gt5bEBIk80nxxokAboxc=
@@ -191,8 +191,8 @@ github.com/gardener/machine-controller-manager v0.27.0 h1:YSPaX1ILVR8OGRxRWnCFP4
 github.com/gardener/machine-controller-manager v0.27.0/go.mod h1:zlIxuLQMtRO+aXOFsG6qtYkBmggbWY82K7MSO051ARU=
 github.com/gardener/machine-controller-manager v0.33.0 h1:58Gh4MW7Yv9XoARKhP4wORDcn2Hofbuv/1OlMe9y1eY=
 github.com/gardener/machine-controller-manager v0.33.0/go.mod h1:jxxE+mGgXwg4iPlCHTG4GtUfK2CcHA6yYoIIowoxOZU=
-github.com/gardener/machine-controller-manager v0.34.0 h1:PLKWz/wtlapVmgUWD3KpbY8KCs1v0JiK3h4/Bx3f0Rc=
-github.com/gardener/machine-controller-manager v0.34.0/go.mod h1:jxxE+mGgXwg4iPlCHTG4GtUfK2CcHA6yYoIIowoxOZU=
+github.com/gardener/machine-controller-manager v0.34.3 h1:Ffrb5O7MEEDoBrSsmFFtApd7QAKKaTgXlx0LhwYrRlU=
+github.com/gardener/machine-controller-manager v0.34.3/go.mod h1:jxxE+mGgXwg4iPlCHTG4GtUfK2CcHA6yYoIIowoxOZU=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go
@@ -412,6 +412,19 @@ func (b *Botanist) HibernateControlPlane(ctx context.Context) error {
 		if err := b.WaitUntilEndpointsDoNotContainPodIPs(ctxWithTimeOut); err != nil {
 			return err
 		}
+
+		// TODO: remove this mitigation once there is a garbage collection for VolumeAttachments (ref https://github.com/kubernetes/kubernetes/issues/77324)
+		// Currently on hibernation Machines are forecefully deleted and machine-controller-manager does not wait volumes to be detached.
+		// In this case kube-controller-manager cannot delete the corresponding VolumeAttachment objects and they are orphaned.
+		// Such orphaned VolumeAttachments then prevent/block PV deletion. For more details see https://github.com/gardener/gardener-extension-provider-gcp/issues/172.
+		// As the Nodes are already deleted, we can delete all VolumeAttachments.
+		if err := DeleteVolumeAttachments(ctxWithTimeOut, b.K8sShootClient.Client()); err != nil {
+			return err
+		}
+
+		if err := WaitUntilVolumeAttachmentsDeleted(ctxWithTimeOut, b.K8sShootClient.Client(), b.Logger); err != nil {
+			return err
+		}
 	}
 
 	// invalidate shoot client here before scaling down API server

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/volumeattachments.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/volumeattachments.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gardener/gardener/pkg/utils/retry"
+
+	"github.com/sirupsen/logrus"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DeleteVolumeAttachments deletes all VolumeAttachments.
+func DeleteVolumeAttachments(ctx context.Context, c client.Client) error {
+	return c.DeleteAllOf(
+		ctx,
+		&storagev1beta1.VolumeAttachment{},
+	)
+}
+
+// WaitUntilVolumeAttachmentsDeleted waits until no VolumeAttachments exist anymore.
+func WaitUntilVolumeAttachmentsDeleted(ctx context.Context, c client.Client, log *logrus.Entry) error {
+	return retry.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
+		vaList := &storagev1beta1.VolumeAttachmentList{}
+		if err := c.List(ctx, vaList); err != nil {
+			return retry.SevereError(err)
+		}
+
+		if len(vaList.Items) == 0 {
+			return retry.Ok()
+		}
+
+		log.Infof("Waiting until all VolumeAttachments have been deleted in the shoot cluster...")
+		return retry.MinorError(fmt.Errorf("not all VolumeAttachments have been deleted in the shoot cluster"))
+	})
+}

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/types.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/types.go
@@ -222,6 +222,9 @@ const (
 
 	// MachineFailed means operation failed leading to machine status failure
 	MachineFailed MachinePhase = "Failed"
+
+	// MachineCrashLoopBackOff means creation or deletion of the machine is failing.
+	MachineCrashLoopBackOff MachinePhase = "CrashLoopBackOff"
 )
 
 // MachinePhase is a label for the condition of a machines at the current time.

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/machine_types.go
@@ -146,9 +146,12 @@ const (
 
 	// MachineFailed means operation failed leading to machine status failure
 	MachineFailed MachinePhase = "Failed"
+
+	// MachineCrashLoopBackOff means creation or deletion of the machine is failing.
+	MachineCrashLoopBackOff MachinePhase = "CrashLoopBackOff"
 )
 
-// MachinePhase is a label for the condition of a machines at the current time.
+// MachineState is a current state of the machine.
 type MachineState string
 
 // These are the valid statuses of machines.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -36,8 +36,6 @@ github.com/aliyun/aliyun-oss-go-sdk/oss
 # github.com/beorn7/perks v1.0.1
 ## explicit
 github.com/beorn7/perks/quantile
-# github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
-## explicit
 # github.com/coreos/go-systemd/v22 v22.1.0
 ## explicit
 github.com/coreos/go-systemd/v22/unit
@@ -70,7 +68,7 @@ github.com/gardener/etcd-druid/api/v1alpha1
 # github.com/gardener/external-dns-management v0.7.18
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
-# github.com/gardener/gardener v1.11.1
+# github.com/gardener/gardener v1.11.2
 ## explicit
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE
@@ -212,7 +210,7 @@ github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1/helper
 github.com/gardener/gardener-resource-manager/pkg/manager
 # github.com/gardener/hvpa-controller v0.2.5
 github.com/gardener/hvpa-controller/api/v1alpha1
-# github.com/gardener/machine-controller-manager v0.34.0
+# github.com/gardener/machine-controller-manager v0.34.3
 ## explicit
 github.com/gardener/machine-controller-manager/pkg/apis/machine
 github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/priority normal
/platform alicloud

**What this PR does / why we need it**:
This PR is to revendor g/g 1.11.2 and machine-controller-manager 0.34.3

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`github.com/gardener/gardener` dependency is now updated from `v1.11.1` to `v1.11.2`. `github.com/gardener/machine-controller-manager` dependency is now updated from `0.34.0` to `0.34.3`.
```
