### PR TITLE
Forbid network cidr 100.64.0.0/10

### DIFF
--- a/pkg/apis/alicloud/validation/shoot.go
+++ b/pkg/apis/alicloud/validation/shoot.go
@@ -28,9 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// AliCloudVPCCidr is the IPV4 CIDR used within AliCloud.
+// AliCloudVPCCidr is a IPV4 CIDR used within AliCloud.
 // For example: the meta service endpoint is 100.100.100.200.
-// This CIDR can be accessed by any machines which is running with AliCloud VPC.
+// This CIDR can be accessed by any machine which is running with AliCloud VPC.
 const AliCloudVPCCidr = "100.64.0.0/10"
 
 // ValidateNetworking validates the network settings of a Shoot.

--- a/pkg/apis/alicloud/validation/shoot.go
+++ b/pkg/apis/alicloud/validation/shoot.go
@@ -28,44 +28,45 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// AliCloudVPCCidr is a IPV4 CIDR used within AliCloud.
-// For example: the meta service endpoint is 100.100.100.200.
-// This CIDR can be accessed by any machine which is running with AliCloud VPC.
-const AliCloudVPCCidr = "100.64.0.0/10"
+const (
+	maxDataDiskCount = 64
 
-// ValidateNetworking validates the network settings of a Shoot.
-func ValidateNetworking(networking core.Networking, fldPath *field.Path) field.ErrorList {
+	dataDiskNameFmt string = `[a-zA-Z][a-zA-Z0-9\.\-_:]+`
+
+	// ReservedCIDR is a IPV4 CIDR reserved for AliCloud internal usage.
+	// For example: the meta service endpoint is 100.100.100.200.
+	ReservedCIDR = "100.64.0.0/10"
+)
+
+// ValidateNetworkingUpdate validates the network setting of a Shoot during update.
+// The network CIDR settings should be immutable.
+func ValidateNetworkingUpdate(newNetworking, oldNetworking core.Networking, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if networking.Nodes == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("nodes"), "a nodes CIDR must be provided for AliCloud shoots"))
-	} else {
-		if cidrvalidation.NetworksIntersect(*networking.Nodes, AliCloudVPCCidr) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("nodes"), *networking.Nodes, "must not overlap with 100.64.0.0/10 because 10.64.0.0/10 is reserved by AliCloud"))
-		}
-	}
-	if cidrvalidation.NetworksIntersect(*networking.Pods, AliCloudVPCCidr) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("pods"), *networking.Pods, "must not overlap with 100.64.0.0/10 because 10.64.0.0/10 is reserved by AliCloud"))
-	}
-	if cidrvalidation.NetworksIntersect(*networking.Services, AliCloudVPCCidr) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("services"), *networking.Services, "must not overlap with 100.64.0.0/10 because 10.64.0.0/10 is reserved by AliCloud"))
-	}
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newNetworking.Nodes, oldNetworking.Nodes, fldPath.Child("nodes"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newNetworking.Pods, oldNetworking.Pods, fldPath.Child("pods"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newNetworking.Services, oldNetworking.Services, fldPath.Child("services"))...)
 
 	return allErrs
 }
 
-const (
-	maxDataDiskCount        = 64
-	dataDiskNameFmt  string = `[a-zA-Z][a-zA-Z0-9\.\-_:]+`
-)
+// ValidateNetworking validates the network settings of a Shoot during creation.
+func ValidateNetworking(networking core.Networking, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
 
-var dataDiskNameRegexp = regexp.MustCompile("^" + dataDiskNameFmt + "$")
+	allErrs = append(allErrs, validateNetworkCIDR(networking.Nodes, fldPath.Child("nodes"))...)
+	allErrs = append(allErrs, validateNetworkCIDR(networking.Pods, fldPath.Child("pods"))...)
+	allErrs = append(allErrs, validateNetworkCIDR(networking.Services, fldPath.Child("services"))...)
+
+	return allErrs
+}
 
 // ValidateWorkers validates the workers of a Shoot.
 func ValidateWorkers(workers []core.Worker, zones []apisalicloud.Zone, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-
 	alicloudZones := sets.NewString()
+	dataDiskNameRegexp := regexp.MustCompile("^" + dataDiskNameFmt + "$")
+
 	for _, alicloudZone := range zones {
 		alicloudZones.Insert(alicloudZone.Name)
 	}
@@ -150,5 +151,17 @@ func validateVolumeFunc(volumeType *string, size string, fldPath *field.Path) fi
 	if size == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("size"), "must not be empty"))
 	}
+	return allErrs
+}
+
+func validateNetworkCIDR(cidr *string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if cidr == nil {
+		allErrs = append(allErrs, field.Required(fldPath, "a CIDR must be provided for Alicloud shoots"))
+	} else if cidrvalidation.NetworksIntersect(*cidr, ReservedCIDR) {
+		allErrs = append(allErrs, field.Invalid(fldPath, fldPath, fmt.Sprintf("must not overlap with %s, it is reserved by Alicloud", ReservedCIDR)))
+	}
+
 	return allErrs
 }

--- a/pkg/apis/alicloud/validation/shoot_test.go
+++ b/pkg/apis/alicloud/validation/shoot_test.go
@@ -27,41 +27,25 @@ import (
 
 var _ = Describe("Shoot validation", func() {
 	Describe("#ValidateNetworking", func() {
-		var (
-			networkingPath *field.Path
-			networking     core.Networking
-		)
+		var networkingPath = field.NewPath("spec", "networking")
 
-		BeforeEach(func() {
-			networkingPath = field.NewPath("spec", "networking")
-			networking = core.Networking{
+		It("should return no error because network settings are correct", func() {
+			networking := core.Networking{
 				Nodes:    pointer.StringPtr("10.252.0.0/16"),
 				Pods:     pointer.StringPtr("192.168.0.0/16"),
 				Services: pointer.StringPtr("172.16.0.0/16"),
 			}
-		})
 
-		It("should return no error because nodes CIDR was provided", func() {
 			errorList := ValidateNetworking(networking, networkingPath)
 			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should return an error because no nodes CIDR was provided", func() {
-			networking.Nodes = nil
-
-			errorList := ValidateNetworking(networking, networkingPath)
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.networking.nodes"),
-				})),
-			))
-		})
-
 		It("should return errors because CIDR overlaps with 100.64.0.0/10", func() {
-			networking.Nodes = pointer.StringPtr("100.100.0.0/16")
-			networking.Services = pointer.StringPtr("100.101.0.0/16")
-			networking.Pods = pointer.StringPtr("100.102.0.0/16")
+			networking := core.Networking{
+				Nodes:    pointer.StringPtr("100.100.0.0/16"),
+				Pods:     pointer.StringPtr("100.101.0.0/16"),
+				Services: pointer.StringPtr("100.102.0.0/16"),
+			}
 			errorList := ValidateNetworking(networking, networkingPath)
 
 			Expect(errorList).To(ConsistOf(
@@ -76,6 +60,56 @@ var _ = Describe("Shoot validation", func() {
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("spec.networking.pods"),
+				})),
+			))
+		})
+
+		It("should return errors because CIDR is nil", func() {
+			networking := core.Networking{
+				Nodes:    nil,
+				Pods:     nil,
+				Services: nil,
+			}
+
+			errorList := ValidateNetworking(networking, networkingPath)
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.networking.nodes"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.networking.pods"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.networking.services"),
+				})),
+			))
+		})
+
+		It("should forbid updating networking CIDR", func() {
+			oldNetworking := core.Networking{
+				Nodes:    pointer.StringPtr("10.252.0.0/16"),
+				Pods:     pointer.StringPtr("192.168.0.0/16"),
+				Services: pointer.StringPtr("172.16.0.0/16"),
+			}
+
+			newNetworking := core.Networking{
+				Nodes:    pointer.StringPtr("10.250.0.0/16"),
+				Pods:     pointer.StringPtr("192.168.0.0/16"),
+				Services: pointer.StringPtr("172.17.0.0/16"),
+			}
+
+			errorList := ValidateNetworkingUpdate(oldNetworking, newNetworking, networkingPath)
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.networking.nodes"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.networking.services"),
 				})),
 			))
 		})

--- a/pkg/validator/shoot_validator.go
+++ b/pkg/validator/shoot_validator.go
@@ -26,13 +26,6 @@ import (
 )
 
 func (v *Shoot) validateShoot(ctx context.Context, shoot *core.Shoot, infraConfig *alicloud.InfrastructureConfig) error {
-	// Network validation
-	networkPath := field.NewPath("spec", "networking")
-
-	if errList := alicloudvalidation.ValidateNetworking(shoot.Spec.Networking, networkPath); len(errList) != 0 {
-		return errList.ToAggregate()
-	}
-
 	// Provider validation
 	fldPath := field.NewPath("spec", "provider")
 
@@ -57,8 +50,10 @@ func (v *Shoot) validateShoot(ctx context.Context, shoot *core.Shoot, infraConfi
 
 func (v *Shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.Shoot) error {
 	var (
-		fldPath            = field.NewPath("spec", "provider")
-		infraConfigFldPath = fldPath.Child("infrastructureConfig")
+		fldPath            = field.NewPath("spec")
+		networkingFldPath  = fldPath.Child("networking")
+		providerFldPath    = fldPath.Child("provider")
+		infraConfigFldPath = providerFldPath.Child("infrastructureConfig")
 	)
 
 	// InfrastructureConfig update
@@ -78,7 +73,11 @@ func (v *Shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.S
 		}
 	}
 
-	if errList := alicloudvalidation.ValidateWorkersUpdate(oldShoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers, fldPath.Child("workers")); len(errList) != 0 {
+	if errList := alicloudvalidation.ValidateWorkersUpdate(oldShoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers, providerFldPath.Child("workers")); len(errList) != 0 {
+		return errList.ToAggregate()
+	}
+
+	if errList := alicloudvalidation.ValidateNetworkingUpdate(oldShoot.Spec.Networking, shoot.Spec.Networking, networkingFldPath); len(errList) != 0 {
 		return errList.ToAggregate()
 	}
 
@@ -86,6 +85,13 @@ func (v *Shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.S
 }
 
 func (v *Shoot) validateShootCreation(ctx context.Context, shoot *core.Shoot) error {
+	// Network validation
+	networkPath := field.NewPath("spec", "networking")
+	if errList := alicloudvalidation.ValidateNetworking(shoot.Spec.Networking, networkPath); len(errList) != 0 {
+		return errList.ToAggregate()
+	}
+
+	// Infra validation
 	fldPath := field.NewPath("spec", "provider")
 	infraConfig, err := checkAndDecodeInfrastructureConfig(v.decoder, shoot.Spec.Provider.InfrastructureConfig, fldPath.Child("infrastructureConfig"))
 	if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/priority normal
/platform alicloud

**What this PR does / why we need it**:
Avoid user to input wrong cidrs for network settings
**Which issue(s) this PR fixes**:
Fixes #169

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Users are forbidden to set cidrs for nodes/pods/services which overlap 100.64.0.0/10 because 100.64.0.0/10 is reverved by AliCloud
```
