### PR TITLE
add method to set protection flag of slb

### DIFF
--- a/pkg/alicloud/client/client.go
+++ b/pkg/alicloud/client/client.go
@@ -300,13 +300,30 @@ func (c *slbClient) GetFirstVServerGroupName(ctx context.Context, region, loadBa
 	return response.VServerGroups.VServerGroup[0].VServerGroupName, nil
 }
 
-// DeleteLoadBalancer deletes the LoadBalancer with given region and loadBalancerID
+// DeleteLoadBalancer deletes the LoadBalancer with given region and loadBalancerID.
 func (c *slbClient) DeleteLoadBalancer(ctx context.Context, region, loadBalancerID string) error {
 	request := slb.CreateDeleteLoadBalancerRequest()
 	request.SetScheme("HTTPS")
 	request.RegionId = region
 	request.LoadBalancerId = loadBalancerID
 	_, err := c.client.DeleteLoadBalancer(request)
+	return err
+}
+
+// SetLoadBalancerDeleteProtection sets the protection flag of load balancer with given loadBalancerID.
+func (c *slbClient) SetLoadBalancerDeleteProtection(ctx context.Context, region, loadBalancerID string, protection bool) error {
+	request := slb.CreateSetLoadBalancerDeleteProtectionRequest()
+
+	if protection {
+		request.DeleteProtection = "on"
+	} else {
+		request.DeleteProtection = "off"
+	}
+	request.SetScheme("HTTPS")
+	request.RegionId = region
+	request.LoadBalancerId = loadBalancerID
+	_, err := c.client.SetLoadBalancerDeleteProtection(request)
+
 	return err
 }
 

--- a/pkg/alicloud/client/types.go
+++ b/pkg/alicloud/client/types.go
@@ -51,6 +51,7 @@ type SLB interface {
 	GetLoadBalancerIDs(ctx context.Context, region string) ([]string, error)
 	GetFirstVServerGroupName(ctx context.Context, region, loadBalancerID string) (string, error)
 	DeleteLoadBalancer(ctx context.Context, region, loadBalancerID string) error
+	SetLoadBalancerDeleteProtection(ctx context.Context, region, loadBalancerID string, protection bool) error
 }
 
 // VPC is an interface which must be implemented by alicloud vpc clients.

--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -484,6 +484,10 @@ func (a *actuator) cleanupServiceLoadBalancers(ctx context.Context, infra *exten
 		slices := strings.Split(vServerGroupName, "/")
 		clusterID := slices[len(slices)-1]
 		if clusterID == infra.Namespace {
+			err = shootAlicloudSLBClient.SetLoadBalancerDeleteProtection(ctx, infra.Spec.Region, loadBalancerID, false)
+			if err != nil {
+				return err
+			}
 			err = shootAlicloudSLBClient.DeleteLoadBalancer(ctx, infra.Spec.Region, loadBalancerID)
 			if err != nil {
 				return err

--- a/pkg/mock/provider-alicloud/alicloud/client/mocks.go
+++ b/pkg/mock/provider-alicloud/alicloud/client/mocks.go
@@ -270,6 +270,20 @@ func (mr *MockSLBMockRecorder) GetLoadBalancerIDs(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadBalancerIDs", reflect.TypeOf((*MockSLB)(nil).GetLoadBalancerIDs), arg0, arg1)
 }
 
+// SetLoadBalancerDeleteProtection mocks base method.
+func (m *MockSLB) SetLoadBalancerDeleteProtection(arg0 context.Context, arg1, arg2 string, arg3 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetLoadBalancerDeleteProtection", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetLoadBalancerDeleteProtection indicates an expected call of SetLoadBalancerDeleteProtection.
+func (mr *MockSLBMockRecorder) SetLoadBalancerDeleteProtection(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLoadBalancerDeleteProtection", reflect.TypeOf((*MockSLB)(nil).SetLoadBalancerDeleteProtection), arg0, arg1, arg2, arg3)
+}
+
 // MockVPC is a mock of VPC interface.
 type MockVPC struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority normal
/platform alicloud

**What this PR does / why we need it**:
This PR is to add one method which sets `protection` flag of LoadBalancer.
Currently, LoadBalancer behind the k8s service is enabled the protection flag by default. So these LoadBalancers cannot be deleted by alicloud SDK, which causes the following error:

> ErrorCode: OperationDenied.DeleteProtectionIsOn
> Recommend: https://error-center.aliyun.com/status/search?Keyword=OperationDenied.DeleteProtectionIsOn&source=PopGw
> RequestId: 5F314EFC-xxxx-xxxx-xxxx-B9B57FFAC4AA
> Message: The loadbalancer can't be deleted due to DeleteProtection is enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
With new version of Cloud Controller Manager introduced, we fixed an issue that Loadbalancer can't be released.
```
