### PR TITLE
Remove deprecated role label key from components

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: machine-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: controlplane
     app: kubernetes
     role: machine-controller-manager
 spec:
@@ -24,6 +23,7 @@ spec:
 {{- end }}
       labels:
         garden.sapcloud.io/role: controlplane
+        gardener.cloud/role: controlplane
         app: kubernetes
         role: machine-controller-manager
         networking.gardener.cloud/to-dns: allowed

--- a/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: cloud-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: controlplane
     app: kubernetes
     role: cloud-controller-manager
 spec:
@@ -23,6 +22,7 @@ spec:
 {{- end }}
       labels:
         garden.sapcloud.io/role: controlplane
+        gardener.cloud/role: controlplane
         app: kubernetes
         role: cloud-controller-manager
         networking.gardener.cloud/to-dns: allowed

--- a/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml
@@ -4,7 +4,6 @@ metadata:
   name: csi-plugin-controller
   namespace: {{ .Release.Namespace }}
 labels:
-  garden.sapcloud.io/role: controlplane
   app: kubernetes
   role: csi-plugin-controller
 spec:
@@ -22,6 +21,7 @@ spec:
 {{- end }}
       labels:
         garden.sapcloud.io/role: controlplane
+        gardener.cloud/role: controlplane
         app: kubernetes
         role: csi-plugin-controller
         networking.gardener.cloud/to-dns: allowed

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kube-system
   labels:
     origin: gardener
-    garden.sapcloud.io/role: system-component
     app: csi-disk-plugin-alicloud
 spec:
   selector:
@@ -18,7 +17,6 @@ spec:
       labels:
         app: csi-disk-plugin-alicloud
         origin: gardener
-        garden.sapcloud.io/role: system-component
     spec:
       priorityClassName: system-node-critical
       serviceAccount: csi-disk-plugin-alicloud

--- a/pkg/alicloud/types.go
+++ b/pkg/alicloud/types.go
@@ -19,8 +19,6 @@ import "path/filepath"
 const (
 	// Name is the name of the Alicloud provider.
 	Name = "provider-alicloud"
-	// StorageProviderName is the name of the Alicloud storage provider.
-	StorageProviderName = "OSS"
 
 	// InfraRelease is the name of the alicloud-infra chart.
 	InfraRelease = "alicloud-infra"

--- a/test/e2e/netpol-gen/app/alicloud.go
+++ b/test/e2e/netpol-gen/app/alicloud.go
@@ -49,9 +49,8 @@ func NewCloudAware() np.CloudAware {
 		cloudControllerManagerNotSecured: &np.SourcePod{
 			Ports: np.NewSinglePort(10253),
 			Pod: np.NewPod("cloud-controller-manager-http", labels.Set{
-				"app":                     "kubernetes",
-				"garden.sapcloud.io/role": "controlplane",
-				"role":                    "cloud-controller-manager",
+				"app":  "kubernetes",
+				"role": "cloud-controller-manager",
 			}),
 			ExpectedPolicies: sets.NewString(
 				"allow-from-prometheus",
@@ -65,9 +64,8 @@ func NewCloudAware() np.CloudAware {
 		kubeControllerManagerSecured: &np.SourcePod{
 			Ports: np.NewSinglePort(10257),
 			Pod: np.NewPod("kube-controller-manager-https", labels.Set{
-				"app":                     "kubernetes",
-				"garden.sapcloud.io/role": "controlplane",
-				"role":                    "controller-manager",
+				"app":  "kubernetes",
+				"role": "controller-manager",
 			}, ">= 1.13"),
 			ExpectedPolicies: sets.NewString(
 				"allow-from-prometheus",
@@ -80,9 +78,8 @@ func NewCloudAware() np.CloudAware {
 		kubeControllerManagerNotSecured: &np.SourcePod{
 			Ports: np.NewSinglePort(10252),
 			Pod: np.NewPod("kube-controller-manager-http", labels.Set{
-				"app":                     "kubernetes",
-				"garden.sapcloud.io/role": "controlplane",
-				"role":                    "controller-manager",
+				"app":  "kubernetes",
+				"role": "controller-manager",
 			}, "< 1.13"),
 			ExpectedPolicies: sets.NewString(
 				"allow-from-prometheus",
@@ -95,9 +92,8 @@ func NewCloudAware() np.CloudAware {
 		csiPlugin: &np.SourcePod{
 			Ports: np.NewSinglePort(80),
 			Pod: np.NewPod("csi-plugin-controller", labels.Set{
-				"app":                     "kubernetes",
-				"garden.sapcloud.io/role": "controlplane",
-				"role":                    "csi-plugin-controller",
+				"app":  "kubernetes",
+				"role": "csi-plugin-controller",
 			}),
 			ExpectedPolicies: sets.NewString(
 				"allow-to-public-networks",

--- a/test/e2e/networkpolicies/networkpolicy_test.go
+++ b/test/e2e/networkpolicies/networkpolicy_test.go
@@ -138,9 +138,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "cloud-controller-manager-http",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "cloud-controller-manager"},
+					"app":  "kubernetes",
+					"role": "cloud-controller-manager"},
 				ShootVersionConstraint: "",
 				SeedClusterConstraints: sets.String(nil)},
 			Ports: []networkpolicies.Port{
@@ -157,9 +156,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "cloud-controller-manager-http",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "cloud-controller-manager"},
+					"app":  "kubernetes",
+					"role": "cloud-controller-manager"},
 				ShootVersionConstraint: "",
 				SeedClusterConstraints: sets.String(nil)},
 			Port: networkpolicies.Port{
@@ -169,9 +167,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "csi-plugin-controller",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "csi-plugin-controller"},
+					"app":  "kubernetes",
+					"role": "csi-plugin-controller"},
 				ShootVersionConstraint: "",
 				SeedClusterConstraints: sets.String(nil)},
 			Ports: []networkpolicies.Port{
@@ -187,9 +184,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "csi-plugin-controller",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "csi-plugin-controller"},
+					"app":  "kubernetes",
+					"role": "csi-plugin-controller"},
 				ShootVersionConstraint: "",
 				SeedClusterConstraints: sets.String(nil)},
 			Port: networkpolicies.Port{
@@ -352,9 +348,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "kube-controller-manager-http",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "controller-manager"},
+					"app":  "kubernetes",
+					"role": "controller-manager"},
 				ShootVersionConstraint: "< 1.13",
 				SeedClusterConstraints: sets.String(nil)},
 			Ports: []networkpolicies.Port{
@@ -370,9 +365,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "kube-controller-manager-http",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "controller-manager"},
+					"app":  "kubernetes",
+					"role": "controller-manager"},
 				ShootVersionConstraint: "< 1.13",
 				SeedClusterConstraints: sets.String(nil)},
 			Port: networkpolicies.Port{
@@ -382,9 +376,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "kube-controller-manager-https",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "controller-manager"},
+					"app":  "kubernetes",
+					"role": "controller-manager"},
 				ShootVersionConstraint: ">= 1.13",
 				SeedClusterConstraints: sets.String(nil)},
 			Ports: []networkpolicies.Port{
@@ -400,9 +393,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "kube-controller-manager-https",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "controller-manager"},
+					"app":  "kubernetes",
+					"role": "controller-manager"},
 				ShootVersionConstraint: ">= 1.13",
 				SeedClusterConstraints: sets.String(nil)},
 			Port: networkpolicies.Port{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal
/platform alicloud

**What this PR does / why we need it**:
Fore more details see https://github.com/gardener/gardener-extension-provider-aws/pull/230

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
