### PR TITLE
adapt infrastructure actuator to terraformer@v2

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "v1.5.0"
+  tag: "v2.0.0"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/pkg/controller/common/terraform.go
+++ b/pkg/controller/common/terraform.go
@@ -57,6 +57,8 @@ func NewTerraformer(logger logr.Logger, factory terraformer.Factory, config *res
 	}
 
 	return tf.
+		UseV2(true).
+		SetLogLevel("info").
 		SetTerminationGracePeriodSeconds(630).
 		SetDeadlineCleaning(5 * time.Minute).
 		SetDeadlinePod(15 * time.Minute), nil

--- a/pkg/controller/common/terraform_test.go
+++ b/pkg/controller/common/terraform_test.go
@@ -73,6 +73,8 @@ var _ = Describe("Terraform", func() {
 				factory.EXPECT().
 					NewForConfig(gomock.Any(), &config, purpose, infra.Namespace, infra.Name, imagevector.TerraformerImage()).
 					Return(tf, nil),
+				tf.EXPECT().UseV2(true).Return(tf),
+				tf.EXPECT().SetLogLevel("info").Return(tf),
 				tf.EXPECT().SetTerminationGracePeriodSeconds(int64(630)).Return(tf),
 				tf.EXPECT().SetDeadlineCleaning(5*time.Minute).Return(tf),
 				tf.EXPECT().SetDeadlinePod(15*time.Minute).Return(tf),
@@ -96,6 +98,8 @@ var _ = Describe("Terraform", func() {
 				factory.EXPECT().
 					NewForConfig(gomock.Any(), &config, purpose, infra.Namespace, infra.Name, imagevector.TerraformerImage()).
 					Return(tf, nil),
+				tf.EXPECT().UseV2(true).Return(tf),
+				tf.EXPECT().SetLogLevel("info").Return(tf),
 				tf.EXPECT().SetTerminationGracePeriodSeconds(int64(630)).Return(tf),
 				tf.EXPECT().SetDeadlineCleaning(5*time.Minute).Return(tf),
 				tf.EXPECT().SetDeadlinePod(15*time.Minute).Return(tf),

--- a/pkg/controller/infrastructure/actuator_test.go
+++ b/pkg/controller/infrastructure/actuator_test.go
@@ -233,6 +233,8 @@ var _ = Describe("Actuator", func() {
 					terraformerFactory.EXPECT().NewForConfig(gomock.Any(), &restConfig, TerraformerPurpose, infra.Namespace, infra.Name, imagevector.TerraformerImage()).
 						Return(terraformer, nil),
 
+					terraformer.EXPECT().UseV2(true).Return(terraformer),
+					terraformer.EXPECT().SetLogLevel("info").Return(terraformer),
 					terraformer.EXPECT().SetTerminationGracePeriodSeconds(int64(630)).Return(terraformer),
 					terraformer.EXPECT().SetDeadlineCleaning(5*time.Minute).Return(terraformer),
 					terraformer.EXPECT().SetDeadlinePod(15*time.Minute).Return(terraformer),
@@ -353,6 +355,8 @@ var _ = Describe("Actuator", func() {
 					terraformerFactory.EXPECT().NewForConfig(gomock.Any(), &restConfig, TerraformerPurpose, infra.Namespace, infra.Name, imagevector.TerraformerImage()).
 						Return(terraformer, nil),
 
+					terraformer.EXPECT().UseV2(true).Return(terraformer),
+					terraformer.EXPECT().SetLogLevel("info").Return(terraformer),
 					terraformer.EXPECT().SetTerminationGracePeriodSeconds(int64(630)).Return(terraformer),
 					terraformer.EXPECT().SetDeadlineCleaning(5*time.Minute).Return(terraformer),
 					terraformer.EXPECT().SetDeadlinePod(15*time.Minute).Return(terraformer),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality robustness
/kind enhancement
/priority normal
/platform alicloud

**What this PR does / why we need it**:
This PR is to adapt infrastructure actuator to terraformer@v2.

**Which issue(s) this PR fixes**:
Fixes #
Ref gardener/terraformer#40

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The terraformer version has been upgraded to version `v2.0.0`.
```
