### PR TITLE
Register healthcheck func for csi-snapshot-controller Deployment

### DIFF
--- a/pkg/alicloud/types.go
+++ b/pkg/alicloud/types.go
@@ -60,8 +60,10 @@ const (
 	StorageEndpoint = "storageEndpoint"
 	//CloudControllerManagerName is the a constant for the name of the CloudController.
 	CloudControllerManagerName = "cloud-controller-manager"
-	// CsiPluginController is the a constant for the name of the CSI Plugin controller
-	CsiPluginController = "csi-plugin-controller"
+	// CSIPluginController is the a constant for the name of the csi-plugin-controller Deployment in the Seed.
+	CSIPluginController = "csi-plugin-controller"
+	// CSISnapshotControllerName is a constant for the name of the csi-snapshot-controller Deployment in the Seed.
+	CSISnapshotControllerName = "csi-snapshot-controller"
 
 	// CRDVolumeSnapshotClasses is a constant for the name of VolumeSnapshotClasses CRD
 	CRDVolumeSnapshotClasses = "volumesnapshotclasses.snapshot.storage.k8s.io"

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -56,7 +56,11 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 		[]healthcheck.ConditionTypeToHealthCheck{
 			{
 				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
-				HealthCheck:   general.NewSeedDeploymentHealthChecker(alicloud.CsiPluginController),
+				HealthCheck:   general.NewSeedDeploymentHealthChecker(alicloud.CSIPluginController),
+			},
+			{
+				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
+				HealthCheck:   general.NewSeedDeploymentHealthChecker(alicloud.CSISnapshotControllerName),
 			},
 			{
 				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),

--- a/test/integration/healthcheck/test.go
+++ b/test/integration/healthcheck/test.go
@@ -75,8 +75,8 @@ var _ = ginkgo.Describe("Provider-alicloud integration test: health checks", fun
 		})
 
 		ginkgo.Context("Condition type: ShootControlPlaneHealthy", func() {
-			f.Serial().Release().CIt(fmt.Sprintf("ControlPlane CRD should contain unhealthy condition because the deployment '%s' cannot be found in the shoot namespace in the seed", alicloud.CsiPluginController), func(ctx context.Context) {
-				err := healthcheckoperation.ControlPlaneHealthCheckDeleteSeedDeployment(ctx, f, f.Shoot.GetName(), alicloud.CsiPluginController, gardencorev1beta1.ShootControlPlaneHealthy)
+			f.Serial().Release().CIt(fmt.Sprintf("ControlPlane CRD should contain unhealthy condition because the deployment '%s' cannot be found in the shoot namespace in the seed", alicloud.CSIPluginController), func(ctx context.Context) {
+				err := healthcheckoperation.ControlPlaneHealthCheckDeleteSeedDeployment(ctx, f, f.Shoot.GetName(), alicloud.CSIPluginController, gardencorev1beta1.ShootControlPlaneHealthy)
 				framework.ExpectNoError(err)
 			}, timeout)
 		})


### PR DESCRIPTION
/kind enhancement
/priority normal
/platform alicloud

Register healthcheck func for csi-snapshot-controller Deployment to allow unhealthy Deployment to be properly reflected in the ControlPlane and Shoot status.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardener-extension-provider-alicloud does now have a health check for the csi-snapshot-controller Deployment
```
