### PR TITLE
Revert "Forbid network cidr 100.64.0.0/10"

### DIFF
--- a/pkg/apis/alicloud/validation/shoot_test.go
+++ b/pkg/apis/alicloud/validation/shoot_test.go
@@ -18,6 +18,7 @@ import (
 	apisalicloud "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
 	. "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/validation"
 	"github.com/gardener/gardener/pkg/apis/core"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -29,87 +30,25 @@ var _ = Describe("Shoot validation", func() {
 	Describe("#ValidateNetworking", func() {
 		var networkingPath = field.NewPath("spec", "networking")
 
-		It("should return no error because network settings are correct", func() {
+		It("should return no error because nodes CIDR was provided", func() {
 			networking := core.Networking{
-				Nodes:    pointer.StringPtr("10.252.0.0/16"),
-				Pods:     pointer.StringPtr("192.168.0.0/16"),
-				Services: pointer.StringPtr("172.16.0.0/16"),
+				Nodes: pointer.StringPtr("1.2.3.4/5"),
 			}
 
 			errorList := ValidateNetworking(networking, networkingPath)
+
 			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should return errors because CIDR overlaps with 100.64.0.0/10", func() {
-			networking := core.Networking{
-				Nodes:    pointer.StringPtr("100.100.0.0/16"),
-				Pods:     pointer.StringPtr("100.101.0.0/16"),
-				Services: pointer.StringPtr("100.102.0.0/16"),
-			}
-			errorList := ValidateNetworking(networking, networkingPath)
-
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.networking.nodes"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.networking.services"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.networking.pods"),
-				})),
-			))
-		})
-
-		It("should return errors because CIDR is nil", func() {
-			networking := core.Networking{
-				Nodes:    nil,
-				Pods:     nil,
-				Services: nil,
-			}
+		It("should return an error because no nodes CIDR was provided", func() {
+			networking := core.Networking{}
 
 			errorList := ValidateNetworking(networking, networkingPath)
+
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
 					"Field": Equal("spec.networking.nodes"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.networking.pods"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.networking.services"),
-				})),
-			))
-		})
-
-		It("should forbid updating networking CIDR", func() {
-			oldNetworking := core.Networking{
-				Nodes:    pointer.StringPtr("10.252.0.0/16"),
-				Pods:     pointer.StringPtr("192.168.0.0/16"),
-				Services: pointer.StringPtr("172.16.0.0/16"),
-			}
-
-			newNetworking := core.Networking{
-				Nodes:    pointer.StringPtr("10.250.0.0/16"),
-				Pods:     pointer.StringPtr("192.168.0.0/16"),
-				Services: pointer.StringPtr("172.17.0.0/16"),
-			}
-
-			errorList := ValidateNetworkingUpdate(oldNetworking, newNetworking, networkingPath)
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.networking.nodes"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.networking.services"),
 				})),
 			))
 		})


### PR DESCRIPTION
Reverts gardener/gardener-extension-provider-alicloud#170

By default, a shoot created from dashboard has no pod/service network settings. It will fail to pass validation check, though there is a defaulter logic in shoot admission in g/g. The issue is that the validation webhook takes place before admission plugins in g/g. https://github.com/gardener/gardener/pull/3298 fixed the order issue. We will dismiss this revert after fix in g/g is released.