### PR TITLE
Pull CSI driver only if it is not present

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml
@@ -52,7 +52,7 @@ spec:
             secretKeyRef:
               name: cloudprovider
               key: accessKeySecret
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
 {{- if .Values.csiPluginController.podResources.diskPlugin }}
         resources:
 {{ toYaml .Values.csiPluginController.podResources.diskPlugin | indent 12 }}

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
@@ -68,7 +68,7 @@ spec:
             secretKeyRef:
               name: csi-diskplugin-alicloud
               key: accessKeySecret
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: pods-mount-dir
           mountPath: /var/lib/kubelet


### PR DESCRIPTION
/area cost
/platform alicloud

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The imagePullPolicy of the Alicloud CSI driver is now switched from `Always` to `IfNotPresent`. This should avoid unnecessary image pulls when the image is already present.
```
