### PR TITLE
Update kubernetes-csi/external-snapshotter to v2.1.3

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -54,12 +54,12 @@ images:
 - name: csi-snapshotter
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/csi-snapshotter
-  tag: v2.1.1
+  tag: v2.1.3
   targetVersion: ">= 1.17"
 - name: csi-snapshot-controller
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/snapshot-controller
-  tag: v2.1.1
+  tag: v2.1.3
 - name: csi-resizer
   sourceRepository: https://github.com/kubernetes-csi/external-resizer
   repository: quay.io/k8scsi/csi-resizer


### PR DESCRIPTION
/area storage
/platform alicloud

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The following images are updated to address [CVE-2020-8569](https://groups.google.com/g/kubernetes-dev/c/_2a2BVACg3s/m/taaiikXRAgAJ):
- quay.io/k8scsi/csi-snapshotter: v2.1.1 -> v2.1.3
- quay.io/k8scsi/snapshot-controller: v2.1.1 -> v2.1.3
```
