### PR TITLE
Fix external-snapshotter version for Kubernetes >= 1.17

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -50,7 +50,7 @@ images:
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/csi-snapshotter
   tag: v1.2.2
-  targetVersion: ">= 1.14"
+  targetVersion: ">= 1.14, < 1.17"
 - name: csi-snapshotter
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/csi-snapshotter


### PR DESCRIPTION
/area storage
/kind bug
/platform alicloud

Fix #208 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing provider-alicloud to deploy wrong version of the external-snapshotter sidecar for Kubernetes >= 1.17 clusters is now fixed.
```
