### PR TITLE
following changes of alicloud nat upgrade

### DIFF
--- a/pkg/alicloud/client/client.go
+++ b/pkg/alicloud/client/client.go
@@ -19,12 +19,11 @@ import (
 	"fmt"
 	"net/http"
 
-	aliclouderrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
-
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	ram "github.com/aliyun/alibaba-cloud-sdk-go/services/resourcemanager"
@@ -359,7 +358,7 @@ func (c *vpcClient) DescribeEipAddresses(req *vpc.DescribeEipAddressesRequest) (
 	return c.client.DescribeEipAddresses(req)
 }
 
-// ramClient defines the struct of VPC client
+// ramClient defines the struct of RAM client
 type ramClient struct {
 	client *ram.Client
 }
@@ -385,7 +384,7 @@ func (c *ramClient) GetServiceLinkedRole(roleName string) (*ram.Role, error) {
 	response, err := c.client.GetRole(request)
 	if err != nil {
 		if isNoPermissionError(err) {
-			return nil, fmt.Errorf("no permission to get service linked role, please grant credentials correct privileges. See https://github.com/gardener/gardener-extension-provider-alicloud/blob/master/docs/usage-as-end-user.md#Permissions")
+			return nil, fmt.Errorf("no permission to get service linked role, please grant credentials correct privileges. See https://github.com/gardener/gardener-extension-provider-alicloud/blob/v1.21.0/docs/usage-as-end-user.md#Permissions")
 		}
 		if isRoleNotExistsError(err) {
 			return nil, nil
@@ -409,7 +408,7 @@ func (c *ramClient) CreateServiceLinkedRole(regionID, serviceName string) error 
 
 	if _, err := c.client.CreateServiceLinkedRole(request); err != nil {
 		if isNoPermissionError(err) {
-			return fmt.Errorf("no permission to create service linked role, please grant credentials correct privileges. See https://github.com/gardener/gardener-extension-provider-alicloud/blob/master/docs/usage-as-end-user.md#Permissions")
+			return fmt.Errorf("no permission to create service linked role, please grant credentials correct privileges. See https://github.com/gardener/gardener-extension-provider-alicloud/blob/v1.21.0/docs/usage-as-end-user.md#Permissions")
 		}
 		return err
 	}
@@ -418,7 +417,7 @@ func (c *ramClient) CreateServiceLinkedRole(regionID, serviceName string) error 
 }
 
 func isNoPermissionError(err error) bool {
-	if serverError, ok := err.(*aliclouderrors.ServerError); ok {
+	if serverError, ok := err.(*errors.ServerError); ok {
 		if serverError.ErrorCode() == alicloud.ErrorCodeNoPermission {
 			return true
 		}
@@ -427,7 +426,7 @@ func isNoPermissionError(err error) bool {
 }
 
 func isRoleNotExistsError(err error) bool {
-	if serverError, ok := err.(*aliclouderrors.ServerError); ok {
+	if serverError, ok := err.(*errors.ServerError); ok {
 		if serverError.ErrorCode() == alicloud.ErrorCodeRoleEntityNotExist {
 			return true
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal
/platform alicloud

**What this PR does / why we need it**:
This PR contains the following changes of Alicloud NAT upgrade, related to PRs #201 and https://github.com/gardener/dashboard/pull/924.

- Forcefully to upgrade `Normal` type NAT Gateway to the `Enhanced` one. (⚠️ breaking change)
- Shoot owners have to grant more permissions of RAM backed by the credentials. Two more permissions `GetRole` and `CreateRole` now are required, otherwise shoot reconciliation would be broken. (⚠️ breaking change)
- Old Alicloud NAT Gateway would be destroyed only when the new type one was created successfully.

**Which issue(s) this PR fixes**:
Fixes #
#168 
**Special notes for your reviewer**:
related to PRs #201 and https://github.com/gardener/dashboard/pull/924.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Forcefully to upgrade Normal type NAT Gateway to the Enhanced one.
```

```breaking user
Shoot owners have to grant more permissions of RAM backed by the credentials. Two more permissions `GetRole` and `CreateRole` now are required, otherwise shoot reconciliation would be broken.
```

```other user
Old Alicloud NAT Gateway would be destroyed only when the new type one was created successfully.
```
