### PR TITLE
Migration of in-tree to out-of-tree MCM providers

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -7,6 +7,10 @@ images:
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
   tag: "v0.36.0"
+- name: machine-controller-manager-provider-alicloud
+  sourceRepository: github.com/gardener/machine-controller-manager-provider-alicloud
+  repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-alicloud
+  tag: "v0.1.0"
 - name: alicloud-controller-manager
   sourceRepository: https://github.com/kubernetes/cloud-provider-alibaba-cloud
   repository: registry.eu-central-1.aliyuncs.com/gardener-de/alibaba-cloud-controller-manager

--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -39,12 +39,42 @@ spec:
       serviceAccountName: machine-controller-manager
       terminationGracePeriodSeconds: 5
       containers:
+      - name: machine-controller-manager-provider-alicloud
+        image: {{ index .Values.images "machine-controller-manager-provider-alicloud" }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - ./machine-controller
+        - --control-kubeconfig=inClusterConfig
+        - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
+        - --machine-creation-timeout=20m
+        - --machine-drain-timeout=2h
+        - --machine-health-timeout=10m
+        - --namespace={{ .Release.Namespace }}
+        - --port={{ .Values.metricsPortAlicloud }}
+        - --v=3
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: {{ .Values.metricsPortAlicloud }}
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/machine-controller-manager
+          name: machine-controller-manager
+          readOnly: true
       - name: alicloud-machine-controller-manager
         image: {{ index .Values.images "machine-controller-manager" }}
         imagePullPolicy: IfNotPresent
         command:
         - ./machine-controller-manager
         - --control-kubeconfig=inClusterConfig
+        - --delete-migrated-machine-class=true
         - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
         - --namespace={{ .Release.Namespace }}
         - --port={{ .Values.metricsPort }}

--- a/charts/internal/machine-controller-manager/seed/values.yaml
+++ b/charts/internal/machine-controller-manager/seed/values.yaml
@@ -1,5 +1,6 @@
 images:
   machine-controller-manager: image-repository:image-tag
+  machine-controller-manager-provider-alicloud: image-repository:image-tag
 
 replicas: 1
 
@@ -13,6 +14,7 @@ namespace:
   uid: uuid-of-namespace
 
 metricsPort: 10258
+metricsPortAlicloud: 10259
 
 vpa:
   enabled: true

--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -14,11 +14,11 @@ data:
   userData: {{ $machineClass.secret.userData | b64enc }}
 ---
 apiVersion: machine.sapcloud.io/v1alpha1
-kind: AlicloudMachineClass
+kind: MachineClass
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
-spec:
+providerSpec:
   imageID: {{ $machineClass.imageID }}
   instanceType: {{ $machineClass.instanceType }}
   region: {{ $machineClass.region }}
@@ -39,10 +39,10 @@ spec:
   keyPairName: {{ $machineClass.keyPairName }}
   tags:
 {{ toYaml $machineClass.tags | indent 4 }}
-  secretRef:
-    name: {{ $machineClass.name }}
-    namespace: {{ $.Release.Namespace }}
-  credentialsSecretRef:
-    name: {{ $machineClass.credentialsSecretRef.name }}
-    namespace: {{ $machineClass.credentialsSecretRef.namespace }}
+secretRef:
+  name: {{ $machineClass.name }}
+  namespace: {{ $.Release.Namespace }}
+credentialsSecretRef:
+  name: {{ $machineClass.credentialsSecretRef.name }}
+  namespace: {{ $machineClass.credentialsSecretRef.namespace }}
 {{- end }}

--- a/pkg/alicloud/types.go
+++ b/pkg/alicloud/types.go
@@ -25,6 +25,8 @@ const (
 
 	// MachineControllerManagerImageName is the name of the MachineControllerManager image.
 	MachineControllerManagerImageName = "machine-controller-manager"
+	// MachineControllerManagerProviderAlicloudImageName is the name of the MachineControllerManagerProviderAlicloud image.
+	MachineControllerManagerProviderAlicloudImageName = "machine-controller-manager-provider-alicloud"
 	// CloudControllerManagerImageName is the name of the CloudControllerManager image.
 	CloudControllerManagerImageName = "alicloud-controller-manager"
 	// CSIAttacherImageName is the name of the CSI attacher image.

--- a/pkg/controller/worker/machine_controller_manager.go
+++ b/pkg/controller/worker/machine_controller_manager.go
@@ -34,7 +34,7 @@ var (
 	mcmChart = &chart.Chart{
 		Name:   alicloud.MachineControllerManagerName,
 		Path:   filepath.Join(alicloud.InternalChartsPath, alicloud.MachineControllerManagerName, "seed"),
-		Images: []string{alicloud.MachineControllerManagerImageName},
+		Images: []string{alicloud.MachineControllerManagerImageName, alicloud.MachineControllerManagerProviderAlicloudImageName},
 		Objects: []*chart.Object{
 			{Type: &appsv1.Deployment{}, Name: alicloud.MachineControllerManagerName},
 			{Type: &corev1.Service{}, Name: alicloud.MachineControllerManagerName},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind api-change
/priority normal
/platform alicloud

**What this PR does / why we need it**:
This PR is to implement the migration of in-tree to out-of-tree for MCM providers.

⚠️ Please make sure that you have already upgraded g/g version [>= v1.14.0] before upgrading your `gardener-extension-provider-alicloud` [version >= v1.22.0], otherwise this would lead to failure of clusters making use of this feature. 

Migration of MCM provider from in-tree to out-of-tree. Refer - [MCM provider Alicloud](https://github.com/gardener/machine-controller-manager-provider-alicloud).

Migration from `AlicloudMachineClass` to `MachineClass`. This migration occurs implicitly without causing rollouts of existing nodes/VMs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Please make sure that you have already upgraded g/g version [>= v1.14.0] before upgrading your `gardener-extension-provider-alicloud` [version >= v1.22.0], otherwise this would lead to failure of clusters making use of this feature. 
```
```feature user
Migration of MCM provider from in-tree to out-of-tree. Refer - [MCM provider Alicloud](https://github.com/gardener/machine-controller-manager-provider-alicloud).
```
```feature user
Migration from `AlicloudMachineClass` to `MachineClass`. This migration occurs implicitly without causing rollouts of existing nodes/VMs.
```
