### PR TITLE
refactor infra TF values structure

### DIFF
--- a/charts/internal/alicloud-infra/values.yaml
+++ b/charts/internal/alicloud-infra/values.yaml
@@ -1,26 +1,27 @@
 alicloud:
   region: cn-beijing
 
-create:
-  vpc: true
-
 clusterName: test-namespace
 
 sshPublicKey: sshkey-12345
 
 vpc:
+  create: true
   id: alicloud_vpc.vpc.id
   cidr: 10.10.10.10/6
-  natGatewayID: alicloud_nat_gateway.nat_gateway.id
-  snatTableID: alicloud_nat_gateway.nat_gateway.snat_table_ids
+
+natGateway:
+  id: alicloud_nat_gateway.nat_gateway.id
+  sNatTableIDs: alicloud_nat_gateway.nat_gateway.snat_table_ids
+
+eip:
   internetChargeType: PayByTraffic
 
 zones:
 - name: cn-beijing-a
   cidr:
     workers: 10.250.0.0/19
-#  natGateway:
-#    eipAllocationID: eip-ufxsdg122elmszcg
+#  eipAllocationID: eip-ufxsdg122elmszcg
 - name: cn-beijing-b
   cidr:
     workers: 10.250.100.0/19

--- a/pkg/controller/infrastructure/client.go
+++ b/pkg/controller/infrastructure/client.go
@@ -51,7 +51,7 @@ func GetVPCInfo(vpcClient alicloudclient.VPC, vpcID string) (*VPCInfo, error) {
 
 	natGateway := describeNatGatewaysRes.NatGateways.NatGateway[0]
 	natGatewayID := natGateway.NatGatewayId
-	sNATTableIDs := strings.Join(natGateway.SnatTableIds.SnatTableId, ",")
+	sNatTableIDs := strings.Join(natGateway.SnatTableIds.SnatTableId, ",")
 
 	internetChargeType, err := FetchEIPInternetChargeType(vpcClient, vpcID)
 	if err != nil {
@@ -61,7 +61,7 @@ func GetVPCInfo(vpcClient alicloudclient.VPC, vpcID string) (*VPCInfo, error) {
 	return &VPCInfo{
 		CIDR:               vpcCIDR,
 		NATGatewayID:       natGatewayID,
-		SNATTableIDs:       sNATTableIDs,
+		SNATTableIDs:       sNatTableIDs,
 		InternetChargeType: internetChargeType,
 	}, nil
 }

--- a/pkg/controller/infrastructure/terraform_test.go
+++ b/pkg/controller/infrastructure/terraform_test.go
@@ -54,12 +54,18 @@ var _ = Describe("TerraformChartOps", func() {
 			)
 
 			Expect(ops.ComputeCreateVPCInitializerValues(&config, internetChargeType)).To(Equal(&InitializerValues{
-				CreateVPC:          true,
-				VPCID:              TerraformDefaultVPCID,
-				VPCCIDR:            string(cidr),
-				NATGatewayID:       TerraformDefaultNATGatewayID,
-				SNATTableIDs:       TerraformDefaultSNATTableIDs,
-				InternetChargeType: internetChargeType,
+				VPC: VPC{
+					CreateVPC: true,
+					VPCID:     TerraformDefaultVPCID,
+					VPCCIDR:   cidr,
+				},
+				NATGateway: NATGateway{
+					NATGatewayID: TerraformDefaultNATGatewayID,
+					SNATTableIDs: TerraformDefaultSNATTableIDs,
+				},
+				EIP: EIP{
+					InternetChargeType: internetChargeType,
+				},
 			}))
 		})
 	})
@@ -86,11 +92,15 @@ var _ = Describe("TerraformChartOps", func() {
 			)
 
 			Expect(ops.ComputeUseVPCInitializerValues(&config, &info)).To(Equal(&InitializerValues{
-				CreateVPC:    false,
-				VPCID:        strconv.Quote(id),
-				VPCCIDR:      cidr,
-				NATGatewayID: strconv.Quote(natGatewayID),
-				SNATTableIDs: strconv.Quote(sNATTableIDs),
+				VPC: VPC{
+					CreateVPC: false,
+					VPCID:     strconv.Quote(id),
+					VPCCIDR:   cidr,
+				},
+				NATGateway: NATGateway{
+					NATGatewayID: strconv.Quote(natGatewayID),
+					SNATTableIDs: strconv.Quote(sNATTableIDs),
+				},
 			}))
 		})
 	})
@@ -145,12 +155,18 @@ var _ = Describe("TerraformChartOps", func() {
 				internetChargeType = "internetChargeType"
 
 				values = InitializerValues{
-					CreateVPC:          true,
-					VPCCIDR:            vpcCIDR,
-					VPCID:              vpcID,
-					NATGatewayID:       natGatewayID,
-					SNATTableIDs:       sNATTableIDs,
-					InternetChargeType: internetChargeType,
+					VPC: VPC{
+						CreateVPC: true,
+						VPCCIDR:   vpcCIDR,
+						VPCID:     vpcID,
+					},
+					NATGateway: NATGateway{
+						NATGatewayID: natGatewayID,
+						SNATTableIDs: sNATTableIDs,
+					},
+					EIP: EIP{
+						InternetChargeType: internetChargeType,
+					},
 				}
 			)
 
@@ -158,14 +174,16 @@ var _ = Describe("TerraformChartOps", func() {
 				"alicloud": map[string]interface{}{
 					"region": region,
 				},
-				"create": map[string]interface{}{
-					"vpc": true,
-				},
 				"vpc": map[string]interface{}{
-					"cidr":               vpcCIDR,
-					"id":                 vpcID,
-					"natGatewayID":       natGatewayID,
-					"snatTableID":        sNATTableIDs,
+					"create": true,
+					"cidr":   vpcCIDR,
+					"id":     vpcID,
+				},
+				"natGateway": map[string]interface{}{
+					"id":           natGatewayID,
+					"sNatTableIDs": sNATTableIDs,
+				},
+				"eip": map[string]interface{}{
 					"internetChargeType": internetChargeType,
 				},
 				"clusterName":  namespace,
@@ -176,9 +194,7 @@ var _ = Describe("TerraformChartOps", func() {
 						"cidr": map[string]interface{}{
 							"workers": zone1Worker,
 						},
-						"natGateway": map[string]interface{}{
-							"eipAllocationID": zone1EipAllocID,
-						},
+						"eipAllocationID": zone1EipAllocID,
 					},
 					{
 						"name": zone2Name,

--- a/pkg/controller/infrastructure/types.go
+++ b/pkg/controller/infrastructure/types.go
@@ -43,6 +43,24 @@ const (
 	TerraformDefaultSNATTableIDs = "alicloud_nat_gateway.nat_gateway.snat_table_ids"
 )
 
+// VPC contains values of VPC used to render terraform charts.
+type VPC struct {
+	CreateVPC bool
+	VPCID     string
+	VPCCIDR   string
+}
+
+// NATGateway contains values of NATGateway used to render terraform charts.
+type NATGateway struct {
+	NATGatewayID string
+	SNATTableIDs string
+}
+
+// EIP contains values of EIP used to render terraform charts
+type EIP struct {
+	InternetChargeType string
+}
+
 // VPCInfo contains info about an existing VPC.
 type VPCInfo struct {
 	CIDR               string
@@ -53,12 +71,9 @@ type VPCInfo struct {
 
 // InitializerValues are values used to render a terraform initializer chart.
 type InitializerValues struct {
-	CreateVPC          bool
-	VPCID              string
-	VPCCIDR            string
-	NATGatewayID       string
-	SNATTableIDs       string
-	InternetChargeType string
+	VPC        VPC
+	NATGateway NATGateway
+	EIP        EIP
 }
 
 // TerraformChartOps are operations to do for interfacing with Terraform charts.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/priority normal
/platform alicloud

**What this PR does / why we need it**:
This PR is to refactor the TF values structure of infrastructure. 
Values now are split into `VPC`, `NAT` and `EIP` structures respectively,  in which it would be flexible for enhancing or adding new flags for different resources in the future.

**Which issue(s) this PR fixes**:
Fixes #
None
**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
