### PR TITLE
VPA for validator/admission component

### DIFF
--- a/charts/gardener-extension-validator-alicloud/charts/runtime/templates/vpa.yaml
+++ b/charts/gardener-extension-validator-alicloud/charts/runtime/templates/vpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.global.vpa.enabled}}
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "name" . }}-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  {{- if .Values.global.vpa.resourcePolicy }}
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: {{ required ".Values.global.vpa.resourcePolicy.minAllowed.cpu is required" .Values.global.vpa.resourcePolicy.minAllowed.cpu }}
+          memory: {{ required ".Values.global.vpa.resourcePolicy.minAllowed.memory is required" .Values.global.vpa.resourcePolicy.minAllowed.memory }}
+  {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "name" . }}
+  updatePolicy:
+    updateMode: {{ .Values.global.vpa.updatePolicy.updateMode }}
+{{- end }}

--- a/charts/gardener-extension-validator-alicloud/values.yaml
+++ b/charts/gardener-extension-validator-alicloud/values.yaml
@@ -7,6 +7,14 @@ global:
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources: {}
+  vpa:
+    enabled: true
+    resourcePolicy:
+      minAllowed:
+        cpu: 50m
+        memory: 64Mi
+    updatePolicy:
+      updateMode: "Auto"
   webhookConfig:
     caBundle: |
       -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability auto-scaling
/kind enhancement
/priority normal
/platform alicloud

**What this PR does / why we need it**:
VPA for validator/admission component

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The validator/admission component's Helm chart is now deploying a `VerticalPodAutoscaler` resource by default. If undesired or no VPA is available in the garden cluster then it can be turned of via `.Values.global.vpa.enabled=false`.
```
