### PR TITLE
remove shared vpc for integration tests

### DIFF
--- a/.ci/testruns/default/templates/testrun.yaml
+++ b/.ci/testruns/default/templates/testrun.yaml
@@ -37,9 +37,3 @@ spec:
       - name: REGION
         type: env
         value: eu-central-1
-      - name: VPC_ID
-        type: env
-        valueFrom:
-          secretKeyRef:
-            name: alicloud-configuration
-            key: vpcID

--- a/.test-defs/infrastructure-test.yaml
+++ b/.test-defs/infrastructure-test.yaml
@@ -15,6 +15,5 @@ spec:
       --access-key-id=$ACCESS_KEY_ID
       --access-key-secret=$ACCESS_KEY_SECRET
       --region=$REGION
-      --vpc-id=$VPC_ID
 
   image: golang:1.14


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement
/priority normal
/platform alicloud

**What this PR does / why we need it**:
This PR is to remove the usage of shared VPC for infra integration tests. Because enhanced type NAT on Alicloud is supported now, and its cost is much cheaper than before. So it is not necessary to leverage shared VPC for testing.
**Which issue(s) this PR fixes**:
Fixes #
None
**Special notes for your reviewer**:
None
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Shared VPC and NATs are removed for integration tests.
```
