### PR TITLE
Update kubernetes-csi/external-snapshotter to v2.1.4

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -58,12 +58,12 @@ images:
 - name: csi-snapshotter
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/csi-snapshotter
-  tag: v2.1.3
+  tag: v2.1.4
   targetVersion: ">= 1.17"
 - name: csi-snapshot-controller
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/snapshot-controller
-  tag: v2.1.3
+  tag: v2.1.4
 - name: csi-resizer
   sourceRepository: https://github.com/kubernetes-csi/external-resizer
   repository: quay.io/k8scsi/csi-resizer


### PR DESCRIPTION
/area storage
/kind bug

Ref https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v2.1.4

Part of https://github.com/gardener/gardener/issues/2227

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The following images are updated (see [CHANGELOG](https://github.com/kubernetes-csi/external-snapshotter/blob/v2.1.4/CHANGELOG-2.1.md) for more details):
- quay.io/k8scsi/csi-snapshotter: v2.1.3 -> v2.1.4
- quay.io/k8scsi/snapshot-controller: v2.1.3 -> v2.1.4
```