### PR TITLE
Fix machine-controller-manager-provider-alicloud image tag

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: machine-controller-manager-provider-alicloud
   sourceRepository: github.com/gardener/machine-controller-manager-provider-alicloud
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-alicloud
-  tag: "v0.1.0"
+  tag: "0.1.0"
 - name: alicloud-controller-manager
   sourceRepository: https://github.com/kubernetes/cloud-provider-alibaba-cloud
   repository: registry.eu-central-1.aliyuncs.com/gardener-de/alibaba-cloud-controller-manager


### PR DESCRIPTION
/kind bug

```
$ docker pull eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-alicloud:v0.1.0
Error response from daemon: manifest for eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-alicloud:v0.1.0 not found: manifest unknown: Failed to fetch "v0.1.0" from request "/v2/gardener-project/gardener/machine-controller-manager-provider-alicloud/manifests/v0.1.0".
```

```
$ docker pull eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-alicloud:0.1.0
0.1.0: Pulling from gardener-project/gardener/machine-controller-manager-provider-alicloud
188c0c94c7c5: Already exists
787de8bbc3c2: Pull complete
f894a6d4edb7: Pull complete
Digest: sha256:053175a6765debe5fe6d6ddb2652a29cbaa6c3400e7467d887db701d6910f0ff
Status: Downloaded newer image for eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-alicloud:0.1.0
eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-alicloud:0.1.0
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
