### PR TITLE
Fix the infrastructure-test TestDefinition

### DIFF
--- a/.test-defs/infrastructure-test.yaml
+++ b/.test-defs/infrastructure-test.yaml
@@ -16,4 +16,4 @@ spec:
       --access-key-secret=$ACCESS_KEY_SECRET
       --region=$REGION
 
-  image: golang:1.14
+  image: golang:1.16.3

--- a/.test-defs/provider-alicloud.yaml
+++ b/.test-defs/provider-alicloud.yaml
@@ -16,4 +16,4 @@ spec:
     --network-worker-cidr=$NETWORK_WORKER_CIDR  
     --zone=$ZONE
 
-  image: golang:1.13.0
+  image: golang:1.16.3


### PR DESCRIPTION
/kind bug

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/311

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
