### PR TITLE
Update kubernetes-csi/external-snapshotter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/
 
 You can run the controller locally on your machine by executing `make start`.
 
-Static code checks and tests can be executed by running `VERIFY=true make all`. We are using Go modules for Golang package dependency management and [Ginkgo](https://github.com/onsi/ginkgo)/[Gomega](https://github.com/onsi/gomega) for testing.
+Static code checks and tests can be executed by running `make verify`. We are using Go modules for Golang package dependency management and [Ginkgo](https://github.com/onsi/ginkgo)/[Gomega](https://github.com/onsi/gomega) for testing.
 
 ## Feedback and Support
 

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -35,12 +35,12 @@ images:
 - name: csi-snapshotter
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/csi-snapshotter
-  tag: v2.1.4
+  tag: v2.1.5
   targetVersion: ">= 1.17"
 - name: csi-snapshot-controller
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/snapshot-controller
-  tag: v2.1.4
+  tag: v2.1.5
 - name: csi-resizer
   sourceRepository: https://github.com/kubernetes-csi/external-resizer
   repository: quay.io/k8scsi/csi-resizer

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -17,15 +17,15 @@ images:
   tag: v1.9.3-316 # the upstream image is using non-semver tag (registry.cn-shanghai.aliyuncs.com/acs/cloud-controller-manager-amd64:v1.9.3.316-g8daf1a9-aliyun).
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
-  repository: quay.io/k8scsi/csi-attacher
+  repository: k8s.gcr.io/sig-storage/csi-attacher
   tag: v2.2.0
 - name: csi-node-driver-registrar
   sourceRepository: https://github.com/kubernetes-csi/node-driver-registrar
-  repository: quay.io/k8scsi/csi-node-driver-registrar
+  repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
   tag: v1.3.0
 - name: csi-provisioner
   sourceRepository: https://github.com/kubernetes-csi/external-provisioner
-  repository: quay.io/k8scsi/csi-provisioner
+  repository: k8s.gcr.io/sig-storage/csi-provisioner
   tag: v1.6.0
 - name: csi-snapshotter
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
@@ -34,16 +34,16 @@ images:
   targetVersion: ">= 1.14, < 1.17"
 - name: csi-snapshotter
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
-  repository: quay.io/k8scsi/csi-snapshotter
+  repository: k8s.gcr.io/sig-storage/csi-snapshotter
   tag: v2.1.5
   targetVersion: ">= 1.17"
 - name: csi-snapshot-controller
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
-  repository: quay.io/k8scsi/snapshot-controller
+  repository: k8s.gcr.io/sig-storage/snapshot-controller
   tag: v2.1.5
 - name: csi-resizer
   sourceRepository: https://github.com/kubernetes-csi/external-resizer
-  repository: quay.io/k8scsi/csi-resizer
+  repository: k8s.gcr.io/sig-storage/csi-resizer
   tag: v0.5.0
 - name: csi-plugin-alicloud
   sourceRepository: https://github.com/AliyunContainerService/csi-plugin


### PR DESCRIPTION
/area storage
/kind enhancement

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The following images are updated:
- k8s.gcr.io/sig-storage/csi-snapshotter: v2.1.4 -> v2.1.5
- k8s.gcr.io/sig-storage/snapshot-controller: v2.1.4 -> v2.1.5
```
