### PR TITLE
Switch to kaniko oci builder

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -6,6 +6,7 @@ gardener-extension-provider-alicloud:
       version:
         preprocess: 'inject-commit-hash'
       publish:
+        oci-builder: 'kaniko'
         dockerimages:
           gardener-extension-provider-alicloud:
             registry: 'gcr-readwrite'
@@ -35,7 +36,7 @@ gardener-extension-provider-alicloud:
         test-integration:
           execute:
           - test-integration.sh
-          depends:
+          trait_depends:
           - publish
           image: 'eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable'
       traits:
@@ -53,6 +54,7 @@ gardener-extension-provider-alicloud:
               slack_cfg_name: 'scp_workspace'
         component_descriptor: ~
         publish:
+          oci-builder: 'kaniko'
           dockerimages:
             gardener-extension-provider-alicloud:
               tag_as_latest: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ############# builder
-FROM eu.gcr.io/gardener-project/3rd/golang:1.16.2 AS builder
+FROM golang:1.16.3 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-alicloud
 COPY . .
 RUN make install
 
 ############# base
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.13.2 AS base
+FROM alpine:3.13.4 AS base
 
 ############# gardener-extension-provider-alicloud
 FROM base AS gardener-extension-provider-alicloud


### PR DESCRIPTION
Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/281

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
