### PR TITLE
depend on publish-trait rather than on injected step(s)

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -35,7 +35,7 @@ gardener-extension-provider-alicloud:
         test-integration:
           execute:
           - test-integration.sh
-          depends:
+          trait_depends:
           - publish
           image: 'eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable'
       traits:


### PR DESCRIPTION
**What this PR does / why we need it**:
prepare switching to kaniko-builder