### PR TITLE
Specify livenessProbe for the CSI driver

### DIFF
--- a/.test-defs/provider-alicloud.yaml
+++ b/.test-defs/provider-alicloud.yaml
@@ -13,7 +13,7 @@ spec:
     --infrastructure-provider-config-filepath=$INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
     --controlplane-provider-config-filepath=$CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
     --network-vpc-cidr=$NETWORK_VPC_CIDR
-    --network-worker-cidr=$NETWORK_WORKER_CIDR  
+    --network-worker-cidr=$NETWORK_WORKER_CIDR
     --zone=$ZONE
 
   image: golang:1.16.3

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -49,3 +49,7 @@ images:
   sourceRepository: https://github.com/AliyunContainerService/csi-plugin
   repository: registry.eu-central-1.aliyuncs.com/gardener-de/csi-plugin-alicloud
   tag: v1.16.9-43 # the upstream image is using non-semver tags which is causing issues in the CI/CD pipelines of Gardener, thus the image is replicated and tagged with semver version in another registry (registry.cn-hangzhou.aliyuncs.com/acs/csi-plugin:v1.16.9.43-f36bb540-aliyun).
+- name: csi-liveness-probe
+  sourceRepository: github.com/kubernetes-csi/livenessprobe
+  repository: k8s.gcr.io/sig-storage/livenessprobe
+  tag: v2.2.0

--- a/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml
@@ -59,6 +59,17 @@ spec:
 {{- end }}
         ports:
         - containerPort: 80
+        - name: healthz
+          containerPort: 9808
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          timeoutSeconds: 3
+          periodSeconds: 10
+          failureThreshold: 5
         volumeMounts:
         - name: socket-dir
           mountPath: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com
@@ -149,7 +160,18 @@ spec:
         - name: csi-resizer
           mountPath: /var/lib/csi-resizer
         - name: socket-dir
-          mountPath: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com 
+          mountPath: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com
+      - name: alicloud-csi-liveness-probe
+        image: {{ index .Values.images "csi-liveness-probe" }}
+        args:
+        - --csi-address=/var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com/csi.sock
+{{- if .Values.csiPluginController.podResources.livenessProbe }}
+        resources:
+{{ toYaml .Values.csiPluginController.podResources.livenessProbe | indent 12 }}
+{{- end }}
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com
       volumes:
       - name: socket-dir
         emptyDir: {}

--- a/charts/internal/seed-controlplane/charts/csi-alicloud/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/values.yaml
@@ -9,6 +9,7 @@ images:
   csi-snapshotter: repository:tag
   csi-snapshot-controller: repository:tag
   csi-resizer: repository:tag
+  csi-liveness-probe: repository:tag
 
 csiPluginController:
   snapshotPrefix: ""
@@ -44,6 +45,13 @@ csiPluginController:
         cpu: 30m
         memory: 50Mi
     resizer:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 30m
+        memory: 50Mi
+    livenessProbe:
       requests:
         cpu: 10m
         memory: 32Mi

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
@@ -43,6 +43,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+{{- if .Values.resources.nodeDriverRegistrar }}
+        resources:
+{{ toYaml .Values.resources.nodeDriverRegistrar | indent 10 }}
+{{- end }}
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi
@@ -68,7 +72,23 @@ spec:
             secretKeyRef:
               name: csi-diskplugin-alicloud
               key: accessKeySecret
+{{- if .Values.resources.driver }}
+        resources:
+{{ toYaml .Values.resources.driver | indent 10 }}
+{{- end }}
         imagePullPolicy: IfNotPresent
+        ports:
+        - name: healthz
+          containerPort: 9808
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          timeoutSeconds: 3
+          periodSeconds: 10
+          failureThreshold: 5
         volumeMounts:
         - name: pods-mount-dir
           mountPath: /var/lib/kubelet
@@ -76,6 +96,17 @@ spec:
         - mountPath: /dev
           name: host-dev
           mountPropagation: "HostToContainer"
+      - name: csi-liveness-probe
+        image: {{ index .Values.images "csi-liveness-probe" }}
+        args:
+        - --csi-address=/csi/csi.sock
+{{- if .Values.resources.livenessProbe }}
+        resources:
+{{ toYaml .Values.resources.livenessProbe | indent 10 }}
+{{- end }}
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
       volumes:
       - name: registration-dir
         hostPath:

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/values.yaml
@@ -1,8 +1,33 @@
 images:
   csi-driver-registrar: image-repository:image-tag
   csi-plugin-alicloud: image-repository:image-tag
+  csi-liveness-probe: image-repository:image-tag
+
 credential:
   accessKeyID: keyID
   accessKeySecret: secret
 kubernetesVersion: v1.14.0
 vpaEnabled: false
+
+resources:
+  driver:
+    requests:
+      cpu: 20m
+      memory: 50Mi
+    limits:
+      cpu: 50m
+      memory: 80Mi
+  nodeDriverRegistrar:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 30m
+      memory: 50Mi
+  livenessProbe:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 30m
+      memory: 50Mi

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -67,10 +67,10 @@ spec:
     vpc:
       id: vpc-gw879zodzt6z1cupe3ps4
       vswitches:
-      - purpose: nodes 
+      - purpose: nodes
         id: vs-001
         zone: cn-beijing-f
-      securityGroups: 
+      securityGroups:
       - purpose: nodes
         id: sg-gw8efawapk7dhq6q5z24
     keyPairName: shoot--foobar--alicloud-ssh-publickey

--- a/pkg/alicloud/types.go
+++ b/pkg/alicloud/types.go
@@ -41,6 +41,8 @@ const (
 	CSISnapshotControllerImageName = "csi-snapshot-controller"
 	// CSIResizerImageName is the name of the CSI resizer image.
 	CSIResizerImageName = "csi-resizer"
+	// CSILivenessProbeImageName is the name of the CSI liveness probe image.
+	CSILivenessProbeImageName = "csi-liveness-probe"
 
 	// CSIPluginImageName is the name of the CSI plugin image.
 	CSIPluginImageName = "csi-plugin-alicloud"

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -158,6 +158,7 @@ var controlPlaneChart = &chart.Chart{
 				alicloud.CSISnapshotterImageName,
 				alicloud.CSIResizerImageName,
 				alicloud.CSIPluginImageName,
+				alicloud.CSILivenessProbeImageName,
 				alicloud.CSISnapshotControllerImageName,
 			},
 			Objects: []*chart.Object{
@@ -181,8 +182,12 @@ var controlPlaneShootChart = &chart.Chart{
 			},
 		},
 		{
-			Name:   "csi-alicloud",
-			Images: []string{alicloud.CSINodeDriverRegistrarImageName, alicloud.CSIPluginImageName},
+			Name: "csi-alicloud",
+			Images: []string{
+				alicloud.CSINodeDriverRegistrarImageName,
+				alicloud.CSIPluginImageName,
+				alicloud.CSILivenessProbeImageName,
+			},
 			Objects: []*chart.Object{
 				// csi-disk-plugin-alicloud
 				{Type: &appsv1.DaemonSet{}, Name: "csi-disk-plugin-alicloud"},


### PR DESCRIPTION
/kind bug
/platform alicloud

Currently the CSI driver is missing a livenessProbe. This PR adds the [livenessprobe](https://github.com/kubernetes-csi/livenessprobe/) sidecar - it performs a healthcheck on the CSI driver and exposes the information on a health endpoint.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The CSI driver does now have a liveness probe.
```
