### PR TITLE
add new field in controlplaneconfig

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -97,6 +97,18 @@ string
 </tr>
 <tr>
 <td>
+<code>zone</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Zone is the zone ID of the control plane.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>cloudControllerManager</code></br>
 <em>
 <a href="#alicloud.provider.extensions.gardener.cloud/v1alpha1.CloudControllerManagerConfig">

--- a/pkg/apis/alicloud/types_controlplane.go
+++ b/pkg/apis/alicloud/types_controlplane.go
@@ -24,6 +24,9 @@ import (
 type ControlPlaneConfig struct {
 	metav1.TypeMeta
 
+	// Zone is the zone ID of the control plane.
+	Zone *string
+
 	// CloudControllerManager contains configuration settings for the cloud-controller-manager.
 	CloudControllerManager *CloudControllerManagerConfig
 }

--- a/pkg/apis/alicloud/v1alpha1/types_controlplane.go
+++ b/pkg/apis/alicloud/v1alpha1/types_controlplane.go
@@ -25,6 +25,10 @@ import (
 type ControlPlaneConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
+	// Zone is the zone ID of the control plane.
+	// +optional
+	Zone *string `json:"zone,omitempty"`
+
 	// CloudControllerManager contains configuration settings for the cloud-controller-manager.
 	// +optional
 	CloudControllerManager *CloudControllerManagerConfig `json:"cloudControllerManager,omitempty"`

--- a/pkg/apis/alicloud/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/alicloud/v1alpha1/zz_generated.conversion.go
@@ -249,6 +249,7 @@ func Convert_alicloud_CloudProfileConfig_To_v1alpha1_CloudProfileConfig(in *alic
 }
 
 func autoConvert_v1alpha1_ControlPlaneConfig_To_alicloud_ControlPlaneConfig(in *ControlPlaneConfig, out *alicloud.ControlPlaneConfig, s conversion.Scope) error {
+	out.Zone = (*string)(unsafe.Pointer(in.Zone))
 	out.CloudControllerManager = (*alicloud.CloudControllerManagerConfig)(unsafe.Pointer(in.CloudControllerManager))
 	return nil
 }
@@ -259,6 +260,7 @@ func Convert_v1alpha1_ControlPlaneConfig_To_alicloud_ControlPlaneConfig(in *Cont
 }
 
 func autoConvert_alicloud_ControlPlaneConfig_To_v1alpha1_ControlPlaneConfig(in *alicloud.ControlPlaneConfig, out *ControlPlaneConfig, s conversion.Scope) error {
+	out.Zone = (*string)(unsafe.Pointer(in.Zone))
 	out.CloudControllerManager = (*CloudControllerManagerConfig)(unsafe.Pointer(in.CloudControllerManager))
 	return nil
 }

--- a/pkg/apis/alicloud/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/alicloud/v1alpha1/zz_generated.deepcopy.go
@@ -83,6 +83,11 @@ func (in *CloudProfileConfig) DeepCopyObject() runtime.Object {
 func (in *ControlPlaneConfig) DeepCopyInto(out *ControlPlaneConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.Zone != nil {
+		in, out := &in.Zone, &out.Zone
+		*out = new(string)
+		**out = **in
+	}
 	if in.CloudControllerManager != nil {
 		in, out := &in.CloudControllerManager, &out.CloudControllerManager
 		*out = new(CloudControllerManagerConfig)

--- a/pkg/apis/alicloud/zz_generated.deepcopy.go
+++ b/pkg/apis/alicloud/zz_generated.deepcopy.go
@@ -83,6 +83,11 @@ func (in *CloudProfileConfig) DeepCopyObject() runtime.Object {
 func (in *ControlPlaneConfig) DeepCopyInto(out *ControlPlaneConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.Zone != nil {
+		in, out := &in.Zone, &out.Zone
+		*out = new(string)
+		**out = **in
+	}
 	if in.CloudControllerManager != nil {
 		in, out := &in.CloudControllerManager, &out.CloudControllerManager
 		*out = new(CloudControllerManagerConfig)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform alicloud

**What this PR does / why we need it**:
This PR is to fix the issue that failing to decode `ControlPlaneConfig` after strict decoder is enabled.
```
controlPlaneConfig:
  apiVersion: alicloud.provider.extensions.gardener.cloud/v1alpha1
  kind: ControlPlaneConfig
  zone: cn-shanghai-e
```

Currently `zone` under `controlPlaneConfig` is defaulted by dashboard template of alicloud.

Error message is as follow:

> strict decoder error for {"apiVersion":"alicloud.provider.extensions.gardener.cloud/v1alpha1","kind":"ControlPlaneConfig","zone":"cn-shanghai-e"}: v1alpha1.ControlPlaneConfig.ReadObject: found unknown field: zone, error found in #10 byte of ...|ig","zone":"cn-shang|..., bigger context ...|cloud/v1alpha1","kind":"ControlPlaneConfig","zone":"cn-shanghai-e"}|... stacktrace:github.com/go-logr/zapr.(*zapLogger).Error

**Which issue(s) this PR fixes**:
Fixes #
None
**Special notes for your reviewer**:
None
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
