### PR TITLE
Revert "[ci:component:github.com/gardener/terraformer:v2.5.0->v2.6.0]"

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer-alicloud
-  tag: "v2.6.0"
+  tag: "v2.5.0"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager


### PR DESCRIPTION
Reverts gardener/gardener-extension-provider-alicloud#277

With TF provider of version >=1.119 , one new field named `enable_ipv6` would be added into the VPC resource, which will trigger a force replacement. It only impacts the VPC which has already been existing for a long time.

It its blocking the release of extension-provider-alicloud, so revert the change and will restore it when the issue is fixed.