### PR TITLE
Do not use strict decoding for ControlPlaneConfig in admission-alicloud

### DIFF
--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -75,7 +75,12 @@ func (s *shoot) validateShoot(_ context.Context, shoot *core.Shoot, infraConfig 
 
 	// ControlPlaneConfig
 	if shoot.Spec.Provider.ControlPlaneConfig != nil {
-		if _, err := decodeControlPlaneConfig(s.decoder, shoot.Spec.Provider.ControlPlaneConfig, fldPath.Child("controlPlaneConfig")); err != nil {
+		// We use "lenientDecoder" because the "zone" field of "ControlPlaneConfig" was removed with https://github.com/gardener/gardener-extension-provider-alicloud/pull/64
+		// but still Shoots in Gardener environments may contain the legacy "zone" field.
+		// We cannot use strict "decoder" because it will complain that the "zone" field is specified but it is actually an invalid.
+		// Let's use "lenientDecoder" for now to make the migration smoother for such Shoots.
+		// TODO: consider enabling the strict "decoder" in a future release.
+		if _, err := decodeControlPlaneConfig(s.lenientDecoder, shoot.Spec.Provider.ControlPlaneConfig, fldPath.Child("controlPlaneConfig")); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
/kind bug
/platform alicloud

Similar to https://github.com/gardener/gardener-extension-provider-alicloud/pull/280.

admission-alicloud should be able to tolerate the `zone` field to make possible updating existing Shoots that still have the `zone` field. 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
