### PR TITLE
[release-v1.24] Automated cherry pick of #298: Specify the provider field for the MachineClasses

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -45,4 +45,5 @@ secretRef:
 credentialsSecretRef:
   name: {{ $machineClass.credentialsSecretRef.name }}
   namespace: {{ $machineClass.credentialsSecretRef.namespace }}
+provider: "Alicloud"
 {{- end }}


### PR DESCRIPTION
/kind/bug
/kind/regression

Cherry pick of #298 on release-v1.24.

#298: Specify the provider field for the MachineClasses

**Release Notes:**
```breaking user
An issue preventing Shoot to be successfully created is now fixed.
```