### PR TITLE
Enhance validation of cloud provider secrets

### DIFF
--- a/pkg/apis/alicloud/validation/secrets.go
+++ b/pkg/apis/alicloud/validation/secrets.go
@@ -16,6 +16,8 @@ package validation
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +29,12 @@ const (
 	accessKeySecretMinLen = 30
 )
 
+var (
+	// accessKeyID accepts only alphanumeric characters [0-9a-zA-Z] and several special characters [._=],
+	// see https://partners-intl.aliyun.com/help/doc-detail/185803.htm
+	accessKeyIDRegex = regexp.MustCompile(`^[0-9a-zA-Z._=]+$`)
+)
+
 // ValidateCloudProviderSecret checks whether the given secret contains a valid Alicloud access keys.
 func ValidateCloudProviderSecret(secret *corev1.Secret) error {
 	secretRef := fmt.Sprintf("%s/%s", secret.Namespace, secret.Name)
@@ -35,22 +43,28 @@ func ValidateCloudProviderSecret(secret *corev1.Secret) error {
 	if !ok {
 		return fmt.Errorf("missing %q field in secret %s", alicloud.AccessKeyID, secretRef)
 	}
-
 	if len(accessKeyID) < accessKeyIDMinLen {
 		return fmt.Errorf("field %q in secret %s must have at least %d characters", alicloud.AccessKeyID, secretRef, accessKeyIDMinLen)
 	}
-
 	if len(accessKeyID) > accessKeyIDMaxLen {
 		return fmt.Errorf("field %q in secret %s cannot be longer than %d characters", alicloud.AccessKeyID, secretRef, accessKeyIDMaxLen)
+	}
+	if !accessKeyIDRegex.Match(accessKeyID) {
+		return fmt.Errorf("field %q in secret %s must only contain alphanumeric characters and [._=]", alicloud.AccessKeyID, secretRef)
 	}
 
 	secretAccessKey, ok := secret.Data[alicloud.AccessKeySecret]
 	if !ok {
 		return fmt.Errorf("missing %q field in secret %s", alicloud.AccessKeySecret, secretRef)
 	}
-
 	if len(secretAccessKey) < accessKeySecretMinLen {
 		return fmt.Errorf("field %q in secret %s must have at least %d characters", alicloud.AccessKeySecret, secretRef, accessKeySecretMinLen)
+	}
+	// accessKeySecret must not contain leading or trailing new lines, as they are known to cause issues
+	// Other whitespace characters such as spaces are intentionally not checked for,
+	// since there is no documentation indicating that they would not be valid
+	if strings.Trim(string(secretAccessKey), "\n\r") != string(secretAccessKey) {
+		return fmt.Errorf("field %q in secret %s must not contain leading or traling new lines", alicloud.AccessKeySecret, secretRef)
 	}
 
 	return nil

--- a/pkg/apis/alicloud/validation/secrets_test.go
+++ b/pkg/apis/alicloud/validation/secrets_test.go
@@ -70,6 +70,14 @@ var _ = Describe("Secret validation", func() {
 			HaveOccurred(),
 		),
 
+		Entry("should return error when the access key does not contain only alphanumeric characters and [._=]",
+			map[string][]byte{
+				alicloud.AccessKeyID:     []byte(strings.Repeat("a", 16) + " "),
+				alicloud.AccessKeySecret: []byte(strings.Repeat("b", 30)),
+			},
+			HaveOccurred(),
+		),
+
 		Entry("should return error when the secret access key field is missing",
 			map[string][]byte{
 				alicloud.AccessKeyID: []byte(strings.Repeat("a", 16)),
@@ -89,6 +97,14 @@ var _ = Describe("Secret validation", func() {
 			map[string][]byte{
 				alicloud.AccessKeyID:     []byte(strings.Repeat("a", 16)),
 				alicloud.AccessKeySecret: []byte(strings.Repeat("b", 29)),
+			},
+			HaveOccurred(),
+		),
+
+		Entry("should return error when the secret access key contains a trailing new line",
+			map[string][]byte{
+				alicloud.AccessKeyID:     []byte(strings.Repeat("a", 16)),
+				alicloud.AccessKeySecret: []byte(strings.Repeat("b", 30) + "\n"),
 			},
 			HaveOccurred(),
 		),


### PR DESCRIPTION
**How to categorize this PR?**

/area usability
/area ops-productivity
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
Enhances the validation of Alicloud cloud provider secrets:
* `accessKeyID` must only contain alphanumeric and several special characters, see https://partners-intl.aliyun.com/help/doc-detail/185803.htm
* `accessKeySecret` must not contain leading or trailing new lines, as they are known to cause issues. Other whitespace characters such as spaces are intentionally not checked for, since there I couldn't find any documentation indicating that they would not be valid.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
Validation of Alicloud cloud provider secrets is enhanced to reject `accessKeyID` that does not only contain alphanumeric and several special characters, and `accessKeySecret` that contain leading or trailing new lines.
```
