### PR TITLE
Add validation of Kubernetes feature gates

### DIFF
--- a/pkg/apis/alicloud/validation/controlplane.go
+++ b/pkg/apis/alicloud/validation/controlplane.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	apisalicloud "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
+
+	corevalidation "github.com/gardener/gardener/pkg/apis/core/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateControlPlaneConfig validates a ControlPlaneConfig object.
+func ValidateControlPlaneConfig(controlPlaneConfig *apisalicloud.ControlPlaneConfig, version string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if controlPlaneConfig.CloudControllerManager != nil {
+		allErrs = append(allErrs, corevalidation.ValidateFeatureGates(controlPlaneConfig.CloudControllerManager.FeatureGates, version, fldPath.Child("cloudControllerManager", "featureGates"))...)
+	}
+
+	return allErrs
+}

--- a/pkg/apis/alicloud/validation/controlplane_test.go
+++ b/pkg/apis/alicloud/validation/controlplane_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation_test
+
+import (
+	apisalicloud "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
+	. "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/validation"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var _ = Describe("ControlPlaneConfig validation", func() {
+	var (
+		controlPlane *apisalicloud.ControlPlaneConfig
+		fldPath      *field.Path
+	)
+
+	BeforeEach(func() {
+		controlPlane = &apisalicloud.ControlPlaneConfig{}
+	})
+
+	Describe("#ValidateControlPlaneConfig", func() {
+		It("should return no errors for a valid configuration", func() {
+			Expect(ValidateControlPlaneConfig(controlPlane, "", fldPath)).To(BeEmpty())
+		})
+
+		It("should fail with invalid CCM feature gates", func() {
+			controlPlane.CloudControllerManager = &apisalicloud.CloudControllerManagerConfig{
+				FeatureGates: map[string]bool{
+					"AnyVolumeDataSource":      true,
+					"CustomResourceValidation": true,
+					"Foo":                      true,
+				},
+			}
+
+			errorList := ValidateControlPlaneConfig(controlPlane, "1.18.14", fldPath)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("cloudControllerManager.featureGates.CustomResourceValidation"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("cloudControllerManager.featureGates.Foo"),
+				})),
+			))
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**

/area usability
/area ops-productivity
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
Adds validation of Kubernetes feature gates (in `CloudControllerManager` field of the `ControlPlaneConfig` custom resource), as requested in https://github.com/gardener/gardener/issues/3987 and https://github.com/gardener/gardener-extension-provider-gcp/issues/263. Similar to https://github.com/gardener/gardener-extension-provider-gcp/pull/280 but for alicloud.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-gcp/issues/263 for alicloud.

**Special notes for your reviewer**:

* Also vendors g/g v1.24.1-0.20210608063816-580010846480 to be able to use the `ValidateFeatureGates` function.

**Release note**:

```other operator
When creating or updating shoots, any Kubernetes feature gates mentioned are validated against the Kubernetes version. If any feature gates are unknown or not supported in the Kubernetes version, the validation fails.
```
