### PR TITLE
Include encrypted field of volume when calculating worker hash

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -230,7 +230,7 @@ func computeDisks(namespace string, pool extensionsv1alpha1.WorkerPool) (map[str
 func computeAdditionalHashData(pool extensionsv1alpha1.WorkerPool) []string {
 	var additionalData []string
 
-	// Volume.Encrypted is not included when calculating the hash
+	// Volume.Encrypted need to be included when calculating the hash
 	if pool.Volume.Encrypted != nil {
 		additionalData = append(additionalData, strconv.FormatBool(*pool.Volume.Encrypted))
 	}

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -230,7 +230,7 @@ func computeDisks(namespace string, pool extensionsv1alpha1.WorkerPool) (map[str
 func computeAdditionalHashData(pool extensionsv1alpha1.WorkerPool) []string {
 	var additionalData []string
 
-	// Volume.Encrypted need to be included when calculating the hash
+	// Volume.Encrypted needs to be included when calculating the hash
 	if pool.Volume.Encrypted != nil {
 		additionalData = append(additionalData, strconv.FormatBool(*pool.Volume.Encrypted))
 	}

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -94,6 +94,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 	}
 
 	for _, pool := range w.worker.Spec.Pools {
+
 		zoneLen := int32(len(pool.Zones))
 
 		workerPoolHash, err := worker.WorkerPoolHash(pool, w.cluster, computeAdditionalHashData(pool)...)
@@ -228,6 +229,11 @@ func computeDisks(namespace string, pool extensionsv1alpha1.WorkerPool) (map[str
 
 func computeAdditionalHashData(pool extensionsv1alpha1.WorkerPool) []string {
 	var additionalData []string
+
+	// Volume.Encrypted is not included when calculating the hash
+	if pool.Volume.Encrypted != nil {
+		additionalData = append(additionalData, strconv.FormatBool(*pool.Volume.Encrypted))
+	}
 
 	for _, dv := range pool.DataVolumes {
 		additionalData = append(additionalData, dv.Size)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform alicloud

**What this PR does / why we need it**:
When enduser sets workers[].volume.encrypted=true, we need to create a new MachineClass so that related nodes will be recreated.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
When user set encrypted value for volume in workers, all affected nodes will be recreated. 
```
