### PR TITLE
add deploy infra task when encrypted disk is enabled

### DIFF
--- a/charts/gardener-extension-admission-alicloud/charts/application/templates/mutatingwebhook-mutator.yaml
+++ b/charts/gardener-extension-admission-alicloud/charts/application/templates/mutatingwebhook-mutator.yaml
@@ -1,0 +1,35 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "name" . }}
+webhooks:
+- name: shoots.mutation.alicloud.provider.extensions.gardener.cloud
+  rules:
+  - apiGroups:
+    - core.gardener.cloud
+    apiVersions:
+    - v1alpha1
+    - v1beta1
+    operations:
+    - UPDATE
+    resources:
+    - shoots
+  admissionReviewVersions:
+    - v1
+    - v1beta1
+  clientConfig:
+    {{- if .Values.global.virtualGarden.enabled }}
+    url: {{ printf "https://%s.%s/webhooks/validate" (include "name" .) (.Release.Namespace) }}
+    {{- else }}
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ include "name" . }}
+      path: /webhooks/validate
+    {{- end }}
+    caBundle: {{ required ".Values.webhookConfig.caBundle is required" (b64enc .Values.global.webhookConfig.caBundle) }}
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  namespaceSelector: {}
+  objectSelector: {}
+  sideEffects: None
+  timeoutSeconds: 10

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -166,6 +166,7 @@ By default (if not stated otherwise), all the disks are unencrypted.
 For each data volume, you have to specify a name.
 It also supports encrypted system disk. 
 However, only [Customized image](https://www.alibabacloud.com/help/doc-detail/172789.htm?spm=a2c63.l28256.b99.244.5da67453bNBrCt) is currently supported to be used as a basic image for encrypted system disk.
+Please be noted that the change of system disk encryption flag will cause reconciliation of a shoot, and it will result in nodes rolling update within the worker group.
 
 The following YAML is a snippet of a `Shoot` resource:
 

--- a/pkg/admission/mutator/mutator_test.go
+++ b/pkg/admission/mutator/mutator_test.go
@@ -12,21 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package mutator
 
 import (
-	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
-	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
+	"testing"
 
-	"github.com/gardener/gardener-extension-provider-alicloud/pkg/admission/mutator"
-	"github.com/gardener/gardener-extension-provider-alicloud/pkg/admission/validator"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-// GardenWebhookSwitchOptions are the webhookcmd.SwitchOptions for the admission webhooks.
-func GardenWebhookSwitchOptions() *webhookcmd.SwitchOptions {
-	return webhookcmd.NewSwitchOptions(
-		webhookcmd.Switch(extensionswebhook.ValidatorName, validator.New),
-		webhookcmd.Switch(validator.SecretsValidatorName, validator.NewSecretsWebhook),
-		webhookcmd.Switch(mutator.ShootMutatorName, mutator.NewShootsWebhook),
-	)
+func TestMutator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Suite")
 }

--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -65,7 +65,7 @@ func (s *shootMutator) mutateShootUpdate(oldShoot, shoot *corev1beta1.Shoot) err
 
 func (s *shootMutator) mutateForEncryptedSystemDiskChange(oldShoot, shoot *corev1beta1.Shoot) {
 	if requireNewEncryptedImage(oldShoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers) {
-		logger.Info("Need to reconcile infra as new encrypted disk worker found", "name", shoot.Name, "namespace", shoot.Namespace)
+		logger.Info("Need to reconcile infra as new encrypted system disk found in workers", "name", shoot.Name, "namespace", shoot.Namespace)
 		if shoot.Annotations == nil {
 			shoot.Annotations = make(map[string]string)
 		}

--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutator
+
+import (
+	"context"
+	"fmt"
+	"encoding/json"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"gomodules.xyz/jsonpatch/v2"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const ShootMutatorName = "shoots.mutator"
+const MutatorPath = "/webhooks/mutate"
+
+// NewShootMutator returns a new instance of a shoot validator.
+func NewShootMutator() extensionswebhook.Mutator {
+	return &shootMutator{}
+}
+
+type shootMutator struct {
+}
+
+func (s *shootMutator) Mutate(_ context.Context, new, old client.Object) error {
+	shoot, ok := new.(*core.Shoot)
+	if !ok {
+		return fmt.Errorf("wrong object type %T", new)
+	}
+
+	if old != nil {
+		oldShoot, ok := old.(*core.Shoot)
+		if !ok {
+			return fmt.Errorf("wrong object type %T for old object", old)
+		}
+		return s.mutateShootUpdate(oldShoot, shoot)
+	}
+
+	// Only consider update for now.
+	return nil
+}
+
+func (s *shootMutator) mutateShootUpdate(oldShoot, shoot *core.Shoot) error {
+	if !equality.Semantic.DeepEqual(oldShoot, shoot) {
+		s.mutateForEncryptedSystemDiskChange(oldShoot, shoot)
+	}
+
+	return nil
+}
+
+func (s *shootMutator) mutateForEncryptedSystemDiskChange(oldShoot, shoot *core.Shoot) {
+	if requireNewEncryptedImage(oldShoot.Spec.Provider.Workers, shoot.Spec.Provider.Workers) {
+		if shoot.Annotations == nil {
+			shoot.Annotations = make(map[string]string)
+		}
+
+		shoot.Annotations["test"] = v1beta1constants.ShootTaskDeployInfrastructure
+		//controllerutils.AddTasks(shoot.Annotations, v1beta1constants.ShootTaskDeployInfrastructure)
+		logger.Info("After annotation", "Annotations", shoot.Annotations, "name", shoot.Name, "ns", shoot.Namespace)
+
+
+		oldObjMarshaled, _ := json.Marshal(oldShoot)
+
+		newObjMarshaled, _ := json.Marshal(shoot)
+
+		logger.Info("Pure JSON", "json", newObjMarshaled)
+		patches, _ := jsonpatch.CreatePatch(oldObjMarshaled, newObjMarshaled)
+		for _, p := range patches {
+			logger.Info("Patches", "patch", p)
+		}
+
+	}
+}
+
+// Check encrypted flag in new workers' volumes. If it is changed to be true, check for old workers
+// if there is already a volume is set to be encrypted and also the OS version is the same.
+func requireNewEncryptedImage(oldWorkers, newWorkers []core.Worker) bool {
+	var imagesEncrypted []*core.ShootMachineImage
+	for _, w := range oldWorkers {
+		if w.Volume != nil && w.Volume.Encrypted != nil && *w.Volume.Encrypted {
+			if w.Machine.Image != nil {
+				imagesEncrypted = append(imagesEncrypted, w.Machine.Image)
+			}
+		}
+	}
+
+	for _, w := range newWorkers {
+		if w.Volume != nil && w.Volume.Encrypted != nil && *w.Volume.Encrypted {
+			if w.Machine.Image != nil {
+				found := false
+				for _, image := range imagesEncrypted {
+					if w.Machine.Image.Name == image.Name && w.Machine.Image.Version == image.Version {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/admission/mutator/shoot_test.go
+++ b/pkg/admission/mutator/shoot_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutator
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/controllerutils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("Mutating Shoot", func() {
+	var (
+		oldShoot *core.Shoot
+		newShoot *core.Shoot
+		shoot    = &shootMutator{}
+	)
+
+	BeforeEach(func() {
+		oldShoot = &core.Shoot{
+			Spec: core.ShootSpec{
+				Provider: core.Provider{
+					Workers: []core.Worker{
+						{
+							Machine: core.Machine{
+								Image: &core.ShootMachineImage{
+									Name:    "GardenLinux",
+									Version: "1.0",
+								},
+							},
+							Volume: &core.Volume{
+								Encrypted: pointer.BoolPtr(true),
+							},
+						},
+					},
+				},
+			},
+		}
+
+		newShoot = &core.Shoot{
+			Spec: core.ShootSpec{
+				Provider: core.Provider{
+					Workers: []core.Worker{
+						{
+							Machine: core.Machine{
+								Image: &core.ShootMachineImage{
+									Name:    "GardenLinux",
+									Version: "1.0",
+								},
+							},
+							Volume: &core.Volume{},
+						},
+						{
+							Machine: core.Machine{
+								Image: &core.ShootMachineImage{
+									Name:    "GardenLinux",
+									Version: "1.0",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+	Context("#Encrypted System Disk", func() {
+		It("should not reconcile infra if no system disk is encrypted", func() {
+			err := shoot.Mutate(nil, oldShoot, newShoot)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(!checkReconcileInfraAnnotation(newShoot.Annotations))
+		})
+
+		It("should not reconcile infra if system disk is already encrypted", func() {
+			newShoot.Spec.Provider.Workers[0].Volume.Encrypted = pointer.BoolPtr(true)
+			err := shoot.Mutate(nil, oldShoot, newShoot)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(!checkReconcileInfraAnnotation(newShoot.Annotations))
+		})
+
+		It("should not reconcile infra if new version of machine is not encrypted", func() {
+			newShoot.Spec.Provider.Workers[1].Machine.Image.Version = "2.0"
+			newShoot.Spec.Provider.Workers[0].Volume.Encrypted = pointer.BoolPtr(true)
+			err := shoot.Mutate(nil, oldShoot, newShoot)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(!checkReconcileInfraAnnotation(newShoot.Annotations))
+		})
+
+		It("should reconcile infra if new version of machine is added and it is encrypted", func() {
+			newShoot.Spec.Provider.Workers[0].Machine.Image.Version = "2.0"
+			newShoot.Spec.Provider.Workers[0].Volume.Encrypted = pointer.BoolPtr(true)
+			err := shoot.Mutate(nil, oldShoot, newShoot)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(checkReconcileInfraAnnotation(newShoot.Annotations))
+		})
+
+		It("should reconcile infra if machine is changed to be encrypted", func() {
+			oldShoot.Spec.Provider.Workers[0].Volume.Encrypted = nil
+			newShoot.Spec.Provider.Workers[0].Volume.Encrypted = pointer.BoolPtr(true)
+			err := shoot.Mutate(nil, oldShoot, newShoot)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(checkReconcileInfraAnnotation(newShoot.Annotations))
+		})
+	})
+})
+
+func checkReconcileInfraAnnotation(annotations map[string]string) bool {
+	tasks := controllerutils.GetTasks(annotations)
+	for _, t := range tasks {
+		if t == v1beta1constants.ShootTaskDeployInfrastructure {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/admission/mutator/webhook.go
+++ b/pkg/admission/mutator/webhook.go
@@ -16,7 +16,7 @@ package mutator
 
 import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
-	"github.com/gardener/gardener/pkg/apis/core"
+	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -33,7 +33,7 @@ func NewShootsWebhook(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Name:     ShootMutatorName,
 		Path:     MutatorPath + "/shoots",
 		Mutators: map[extensionswebhook.Mutator][]client.Object{
-			NewShootMutator(): {&core.Shoot{}},
+			NewShootMutator(): {&corev1beta1.Shoot{}},
 		},
 	})
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #335 

**Special notes for your reviewer**:

In AliCloud, to support encrypted system disk, we have to make an encrypted customer VM image based on an existing plain one. Then we use this encrypted image to deploy a machine.

In the infra reconciliation, we check if there already is an encrypted image. Otherwise, in the controller loop, it will create an encrypted image. If the encrypted image is ready, the image id will be put in  the status of the infrastructure resource.

In the worker reconciliation phase, the controller will find the suitable encrypted image id from the infra status. If it doesn't exist, the worker reconciliation will fail.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
When user changes system volume to encrypted in a shoot, infrastructure will be reconciled automatically so that workers can be reconciled successfully afterwards. This is achieved by the extension webhook, which adds an annotation shoot.gardener.cloud/tasks= deployInfrastructure when the shoot is changed. 
```