### PR TITLE
Fix several issues in the alicloud mutating webhook 

### DIFF
--- a/charts/gardener-extension-admission-alicloud/charts/application/templates/mutatingwebhook-mutator.yaml
+++ b/charts/gardener-extension-admission-alicloud/charts/application/templates/mutatingwebhook-mutator.yaml
@@ -8,7 +8,6 @@ webhooks:
   - apiGroups:
     - core.gardener.cloud
     apiVersions:
-    - v1alpha1
     - v1beta1
     operations:
     - UPDATE

--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -17,6 +17,7 @@ package mutator
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -56,7 +57,7 @@ func (s *shootMutator) Mutate(_ context.Context, new, old client.Object) error {
 }
 
 func (s *shootMutator) mutateShootUpdate(oldShoot, shoot *corev1beta1.Shoot) error {
-	if !equality.Semantic.DeepEqual(oldShoot, shoot) {
+	if !equality.Semantic.DeepEqual(oldShoot.Spec, shoot.Spec) {
 		s.mutateForEncryptedSystemDiskChange(oldShoot, shoot)
 	}
 
@@ -91,7 +92,7 @@ func requireNewEncryptedImage(oldWorkers, newWorkers []corev1beta1.Worker) bool 
 			if w.Machine.Image != nil {
 				found := false
 				for _, image := range imagesEncrypted {
-					if w.Machine.Image.Name == image.Name && w.Machine.Image.Version == image.Version {
+					if w.Machine.Image.Name == image.Name && reflect.DeepEqual(w.Machine.Image.Version, image.Version) {
 						found = true
 						break
 					}


### PR DESCRIPTION
/area quality
/kind bug
/kind regression
/platform alicloud

Part of https://github.com/gardener/gardener-extension-provider-alicloud/issues/342

This PR:
- fixes the where UPDATE request to the  core.gardener.cloud/v1alpha1 API was failing always with 
  ```
  admission webhook "shoots.mutation.alicloud.provider.extensions.gardener.cloud" denied the request: unexpected request kind core.gardener.cloud/v1alpha1, Kind=Shoot
  ```

  This PR removes the v1alpha1 from the mutatingwebhook spec and relies on the `matchPolicy: Equivalent` field of the webhook that will take care to convert the v1alpha1 obj to v1beta1. Ref https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy

- fixes the version comparison https://github.com/gardener/gardener-extension-provider-alicloud/blob/87ef8fe10535e7bb77f9c247558f4e98b30d7026/pkg/admission/mutator/shoot.go#L94
  and unit tests related to it

- Only Shoot spec is checked by `reflect.DeepEqual`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing admission-alicloud to fail an UPDATE request to the core.gardener.cloud/v1alpha1 API is now fixed.
```

```bugfix operator
An issue in the version comparison logic in a mutating webhook in the admission-alicloud component is now fixed.
```
