### PR TITLE
[release-v1.26] Automated cherry pick of #341: Fix several issues in the alicloud mutating webhook

### DIFF
--- a/charts/gardener-extension-admission-alicloud/charts/application/templates/mutatingwebhook-mutator.yaml
+++ b/charts/gardener-extension-admission-alicloud/charts/application/templates/mutatingwebhook-mutator.yaml
@@ -8,7 +8,6 @@ webhooks:
   - apiGroups:
     - core.gardener.cloud
     apiVersions:
-    - v1alpha1
     - v1beta1
     operations:
     - UPDATE

--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -17,6 +17,7 @@ package mutator
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -56,7 +57,7 @@ func (s *shootMutator) Mutate(_ context.Context, new, old client.Object) error {
 }
 
 func (s *shootMutator) mutateShootUpdate(oldShoot, shoot *corev1beta1.Shoot) error {
-	if !equality.Semantic.DeepEqual(oldShoot, shoot) {
+	if !equality.Semantic.DeepEqual(oldShoot.Spec, shoot.Spec) {
 		s.mutateForEncryptedSystemDiskChange(oldShoot, shoot)
 	}
 
@@ -91,7 +92,7 @@ func requireNewEncryptedImage(oldWorkers, newWorkers []corev1beta1.Worker) bool 
 			if w.Machine.Image != nil {
 				found := false
 				for _, image := range imagesEncrypted {
-					if w.Machine.Image.Name == image.Name && w.Machine.Image.Version == image.Version {
+					if w.Machine.Image.Name == image.Name && reflect.DeepEqual(w.Machine.Image.Version, image.Version) {
 						found = true
 						break
 					}


### PR DESCRIPTION
/area/quality
/kind/bug
/kind/regression

Cherry pick of #341 on release-v1.26.

#341: Fix several issues in the alicloud mutating webhook 

**Release Notes:**
```bugfix operator
An issue causing admission-alicloud to fail an UPDATE request to the core.gardener.cloud/v1alpha1 API is now fixed.
```
```bugfix operator
An issue in the version comparison logic in a mutating webhook in the admission-alicloud component is now fixed.
```