### PR TITLE
Stop using `github.com/pkg/errors`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/pierrec/lz4 v2.5.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/pkg/apis/alicloud/helper/scheme.go
+++ b/pkg/apis/alicloud/helper/scheme.go
@@ -26,7 +26,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -65,7 +64,7 @@ func CloudProfileConfigFromCluster(cluster *controller.Cluster) (*api.CloudProfi
 	if cluster != nil && cluster.CloudProfile != nil && cluster.CloudProfile.Spec.ProviderConfig != nil && cluster.CloudProfile.Spec.ProviderConfig.Raw != nil {
 		cloudProfileConfig = &api.CloudProfileConfig{}
 		if _, _, err := decoder.Decode(cluster.CloudProfile.Spec.ProviderConfig.Raw, nil, cloudProfileConfig); err != nil {
-			return nil, errors.Wrapf(err, "could not decode providerConfig of cloudProfile for '%s'", kutil.ObjectName(cluster.CloudProfile))
+			return nil, fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", kutil.ObjectName(cluster.CloudProfile), err)
 		}
 	}
 	return cloudProfileConfig, nil

--- a/pkg/controller/worker/helper.go
+++ b/pkg/controller/worker/helper.go
@@ -16,13 +16,13 @@ package worker
 
 import (
 	"context"
+	"fmt"
 
 	api "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/v1alpha1"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
@@ -36,7 +36,7 @@ func (w *workerDelegate) decodeWorkerProviderStatus() (*api.WorkerStatus, error)
 	}
 
 	if _, _, err := w.Decoder().Decode(w.worker.Status.ProviderStatus.Raw, nil, workerStatus); err != nil {
-		return nil, errors.Wrapf(err, "could not decode WorkerStatus '%s'", kutil.ObjectName(w.worker))
+		return nil, fmt.Errorf("could not decode WorkerStatus '%s': %w", kutil.ObjectName(w.worker), err)
 	}
 
 	return workerStatus, nil

--- a/pkg/controller/worker/machine_images.go
+++ b/pkg/controller/worker/machine_images.go
@@ -16,6 +16,7 @@ package worker
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/utils/pointer"
 
@@ -26,26 +27,25 @@ import (
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/helper"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
-	"github.com/pkg/errors"
 )
 
 // UpdateMachineImagesStatus implements genericactuator.WorkerDelegate.
 func (w *workerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
 	if w.machineImages == nil {
 		if err := w.generateMachineConfig(ctx); err != nil {
-			return errors.Wrapf(err, "unable to generate the machine config")
+			return fmt.Errorf("unable to generate the machine config: %w", err)
 		}
 	}
 
 	// Decode the current worker provider status.
 	workerStatus, err := w.decodeWorkerProviderStatus()
 	if err != nil {
-		return errors.Wrapf(err, "unable to decode the worker provider status")
+		return fmt.Errorf("unable to decode the worker provider status: %w", err)
 	}
 
 	workerStatus.MachineImages = w.machineImages
 	if err := w.updateWorkerProviderStatus(ctx, workerStatus); err != nil {
-		return errors.Wrapf(err, "unable to update worker provider status")
+		return fmt.Errorf("unable to update worker provider status: %w", err)
 	}
 
 	return nil

--- a/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/pkg/webhook/controlplaneexposure/ensurer.go
@@ -16,6 +16,7 @@ package controlplaneexposure
 
 import (
 	"context"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -31,7 +32,6 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -99,7 +99,7 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx gconte
 	// Get load balancer address of the kube-apiserver service
 	address, err := kutil.GetLoadBalancerIngress(ctx, e.client, service)
 	if err != nil {
-		return errors.Wrap(err, "could not get kube-apiserver service load balancer address")
+		return fmt.Errorf("could not get kube-apiserver service load balancer address: %w", err)
 	}
 
 	if c := extensionswebhook.ContainerWithName(new.Spec.Template.Spec.Containers, "kube-apiserver"); c != nil {

--- a/pkg/webhook/shoot/mutator.go
+++ b/pkg/webhook/shoot/mutator.go
@@ -16,13 +16,13 @@ package shoot
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/config"
 
 	webhookutils "github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/utils"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -47,7 +47,7 @@ func NewMutator(service *config.Service) extensionswebhook.Mutator {
 func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 	acc, err := meta.Accessor(new)
 	if err != nil {
-		return errors.Wrapf(err, "could not create accessor during webhook")
+		return fmt.Errorf("could not create accessor during webhook: %w", err)
 	}
 	// If the object does have a deletion timestamp then we don't want to mutate anything.
 	if acc.GetDeletionTimestamp() != nil {
@@ -62,7 +62,7 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 				var ok bool
 				oldSvc, ok = old.(*corev1.Service)
 				if !ok {
-					return errors.Wrapf(err, "could not cast old object to corev1.Service")
+					return fmt.Errorf("could not cast old object to corev1.Service: %w", err)
 				}
 			}
 

--- a/test/tm/generator.go
+++ b/test/tm/generator.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"reflect"
 
@@ -24,7 +25,6 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/gardener/gardener/extensions/test/tm/generator"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -107,13 +107,13 @@ func main() {
 
 func validate() error {
 	if err := generator.ValidateString(&cfg.infrastructureProviderConfigPath); err != nil {
-		return errors.Wrap(err, "error validating infrastructure provider config path")
+		return fmt.Errorf("error validating infrastructure provider config path: %w", err)
 	}
 	if err := generator.ValidateString(&cfg.controlplaneProviderConfigPath); err != nil {
-		return errors.Wrap(err, "error validating controlplane provider config path")
+		return fmt.Errorf("error validating controlplane provider config path: %w", err)
 	}
 	if err := generator.ValidateString(&cfg.zone); err != nil {
-		return errors.Wrap(err, "error validating zone")
+		return fmt.Errorf("error validating zone: %w", err)
 	}
 	//Optional Parameters
 	if err := generator.ValidateString(&cfg.networkVPCCidr); err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -430,7 +430,6 @@ github.com/pelletier/go-toml
 github.com/pierrec/lz4
 github.com/pierrec/lz4/internal/xxh32
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.11.0 => github.com/prometheus/client_golang v1.11.0
 github.com/prometheus/client_golang/prometheus


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/platform alicloud

**What this PR does / why we need it**:
Similar to gardener/gardener#4280 we should be using Go native error wrapping (available since GO 1.13).

**Which issue(s) this PR fixes**:
Fixes #324

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```NONE

```

/invite @vanjiii 
