### PR TITLE
Update kubernetes-csi/external-provisioner to v3.0.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -26,7 +26,13 @@ images:
 - name: csi-provisioner
   sourceRepository: https://github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner
+  tag: v1.6.0
+  targetVersion: "< 1.20"
+- name: csi-provisioner
+  sourceRepository: https://github.com/kubernetes-csi/external-provisioner
+  repository: k8s.gcr.io/sig-storage/csi-provisioner
   tag: v3.0.0
+  targetVersion: ">= 1.20"
 - name: csi-snapshotter
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/csi-snapshotter

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -26,7 +26,7 @@ images:
 - name: csi-provisioner
   sourceRepository: https://github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner
-  tag: v1.6.0
+  tag: v3.0.0
 - name: csi-snapshotter
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/csi-snapshotter


### PR DESCRIPTION
**How to categorize this PR?**
/area storage
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:

Upgrade external-provisioner to v3  for being aligned with this pr: https://github.com/gardener/gardener-extension-provider-alicloud/pull/351

**Which issue(s) this PR fixes**:
We have a csi-provision driver that fails because of this issue:
kubernetes-csi/external-provisioner#582

**Special notes for your reviewer**:

**Release note**:
```other operator
The following images are updated:
- k8s.gcr.io/sig-storage/csi-provisioner v1.6.0 -> v3.0.0

```
