### PR TITLE
Make the linter fail on missing or wrong doc comments

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,9 +5,19 @@ run:
 linters:
   disable:
   - unused
+  enable:
+  - revive
 
 issues:
+  exclude-use-default: false
+  exclude:
+  # revive
+  - var-naming # ((var|const|struct field|func) .* should be .*
+  - dot-imports # should not use dot imports
+  - package-comments # package comment should be of the form
+  - indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
+  - "exported: (type|func) name will be used as .* by other packages, and that stutters;"
   exclude-rules:
   - path: (pkg/apis/alicloud/v1alpha1/zz_generated.conversion.go)
     linters:
-    -  staticcheck
+    - staticcheck

--- a/hack/api-reference/config.md
+++ b/hack/api-reference/config.md
@@ -295,7 +295,7 @@ bool
 <a href="#alicloud.provider.extensions.config.gardener.cloud/v1alpha1.ControllerConfiguration">ControllerConfiguration</a>)
 </p>
 <p>
-<p>LoadBalancerService specifies Service configuration</p>
+<p>Service is a load balancer service configuration.</p>
 </p>
 <table>
 <thead>

--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -27,8 +27,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const ShootMutatorName = "shoots.mutator"
-const MutatorPath = "/webhooks/mutate"
+const (
+	// ShootMutatorName is the shoots mutator webhook name.
+	ShootMutatorName = "shoots.mutator"
+	// MutatorPath is the mutator webhook path.
+	MutatorPath = "/webhooks/mutate"
+)
 
 // NewShootMutator returns a new instance of a shoot validator.
 func NewShootMutator() extensionswebhook.Mutator {

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+// SecretsValidatorName is the name of the secrets validator.
 const SecretsValidatorName = "secrets." + extensionswebhook.ValidatorName
 
 var logger = log.Log.WithName("alicloud-validator-webhook")

--- a/pkg/alicloud/client/ros/create_stack.go
+++ b/pkg/alicloud/client/ros/create_stack.go
@@ -46,7 +46,7 @@ type CreateStackRequest struct {
 	Tags               *[]Tag                   `position:"Query" name:"Tags"  type:"Repeated"`
 }
 
-// Tags is a repeated param struct in CreateStackRequest
+// Tag is a repeated param struct in CreateStackRequest
 type Tag struct {
 	Value string `name:"Value"`
 	Key   string `name:"Key"`

--- a/pkg/alicloud/matchers/matchers.go
+++ b/pkg/alicloud/matchers/matchers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/onsi/gomega/types"
 )
 
+// BeSemanticallyEqualTo returns a matcher that checks if a ecs.Permission is semantically equal to the given value.
 func BeSemanticallyEqualTo(expected interface{}) types.GomegaMatcher {
 	if expected == nil {
 		return BeNil()

--- a/pkg/apis/alicloud/validation/infrastructure.go
+++ b/pkg/apis/alicloud/validation/infrastructure.go
@@ -104,6 +104,7 @@ func ValidateInfrastructureConfigUpdate(oldConfig, newConfig *apisalicloud.Infra
 	return allErrs
 }
 
+// ValidateNetworkZonesConfig validates a Zone slice.
 func ValidateNetworkZonesConfig(newZones, oldZones []apisalicloud.Zone, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 

--- a/pkg/apis/config/loader/loader.go
+++ b/pkg/apis/config/loader/loader.go
@@ -27,16 +27,16 @@ import (
 )
 
 var (
-	Codec  runtime.Codec
-	Scheme *runtime.Scheme
+	codec  runtime.Codec
+	scheme *runtime.Scheme
 )
 
 func init() {
-	Scheme = runtime.NewScheme()
-	install.Install(Scheme)
-	yamlSerializer := json.NewYAMLSerializer(json.DefaultMetaFactory, Scheme, Scheme)
-	Codec = versioning.NewDefaultingCodecForScheme(
-		Scheme,
+	scheme = runtime.NewScheme()
+	install.Install(scheme)
+	yamlSerializer := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme, scheme)
+	codec = versioning.NewDefaultingCodecForScheme(
+		scheme,
 		yamlSerializer,
 		yamlSerializer,
 		schema.GroupVersion{Version: "v1alpha1"},
@@ -63,7 +63,7 @@ func Load(data []byte) (*config.ControllerConfiguration, error) {
 		return cfg, nil
 	}
 
-	decoded, _, err := Codec.Decode(data, &schema.GroupVersionKind{Version: "v1alpha1", Kind: "Config"}, cfg)
+	decoded, _, err := codec.Decode(data, &schema.GroupVersionKind{Version: "v1alpha1", Kind: "Config"}, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apis/config/types.go
+++ b/pkg/apis/config/types.go
@@ -53,7 +53,7 @@ type KubeAPIServer struct {
 	MutateExternalTrafficPolicy bool
 }
 
-// LoadBalancerService specifies Service configuration
+// Service is a load balancer service configuration.
 type Service struct {
 	// BackendLoadBalancerSpec specifies the type of backend Alicloud load balancer, default is slb.s1.small.
 	BackendLoadBalancerSpec string

--- a/pkg/apis/config/v1alpha1/types.go
+++ b/pkg/apis/config/v1alpha1/types.go
@@ -56,7 +56,7 @@ type KubeAPIServer struct {
 	MutateExternalTrafficPolicy bool `json:"mutateExternalTrafficPolicy"`
 }
 
-// LoadBalancerService specifies Service configuration
+// Service is a load balancer service configuration.
 type Service struct {
 	// BackendLoadBalancerSpec specifies the type of backend Alicloud load balancer, default is slb.s1.small.
 	BackendLoadBalancerSpec string `json:"backendLoadBalancerSpec"`

--- a/pkg/controller/common/encryptimage.go
+++ b/pkg/controller/common/encryptimage.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"strings"
 	"time"
@@ -26,8 +27,6 @@ import (
 	gcorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/retry"
-
-	_ "embed"
 )
 
 // CopyImageROSTemplate contains the content of CopyImage ROS template. https://www.alibabacloud.com/help/doc-detail/116189.htm?spm=a2c63.l28256.b99.201.713413a3FkLSIx
@@ -244,6 +243,7 @@ func (ie *imageEncryptor) getStackName() string {
 	return GetEncryptImageStackName(ie.imageName, ie.imageVersion)
 }
 
+// GetEncryptImageStackName returns the encrypt image stack name for the given image name and version.
 func GetEncryptImageStackName(imageName, imageVersion string) string {
 	var rosNameFormat = "encrypt_image_%s_%s"
 	return strings.ReplaceAll(fmt.Sprintf(rosNameFormat, imageName, imageVersion), ".", "-")

--- a/pkg/controller/common/terraform.go
+++ b/pkg/controller/common/terraform.go
@@ -32,9 +32,9 @@ import (
 )
 
 const (
-	TerraformVarAccessKeyID     = "TF_VAR_ACCESS_KEY_ID"
-	TerraformVarAccessKeySecret = "TF_VAR_ACCESS_KEY_SECRET"
-	TerraformProvider           = "provider.alicloud"
+	terraformVarAccessKeyID     = "TF_VAR_ACCESS_KEY_ID"
+	terraformVarAccessKeySecret = "TF_VAR_ACCESS_KEY_SECRET"
+	terraformProvider           = "provider.alicloud"
 )
 
 type tfState struct {
@@ -80,7 +80,7 @@ func NewTerraformerWithAuth(logger logr.Logger, factory terraformer.Factory, con
 // TerraformerEnvVars computes the Terraformer environment variables from the given secret ref.
 func TerraformerEnvVars(secretRef corev1.SecretReference) []corev1.EnvVar {
 	return []corev1.EnvVar{{
-		Name: TerraformVarAccessKeyID,
+		Name: terraformVarAccessKeyID,
 		ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{
 				Name: secretRef.Name,
@@ -88,7 +88,7 @@ func TerraformerEnvVars(secretRef corev1.SecretReference) []corev1.EnvVar {
 			Key: alicloud.AccessKeyID,
 		}},
 	}, {
-		Name: TerraformVarAccessKeySecret,
+		Name: terraformVarAccessKeySecret,
 		ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{
 				Name: secretRef.Name,
@@ -118,7 +118,7 @@ func IsStateEmpty(ctx context.Context, tf terraformer.Terraformer) (bool, error)
 	}
 
 	for _, res := range state.Resources {
-		if res.Provider == TerraformProvider && len(res.Instances) > 0 {
+		if res.Provider == terraformProvider && len(res.Instances) > 0 {
 			return false, nil
 		}
 	}

--- a/pkg/controller/dnsrecord/actuator.go
+++ b/pkg/controller/dnsrecord/actuator.go
@@ -47,6 +47,7 @@ type actuator struct {
 	logger                logr.Logger
 }
 
+// NewActuator creates a new dnsrecord.Actuator.
 func NewActuator(alicloudClientFactory alicloudclient.ClientFactory, logger logr.Logger) dnsrecord.Actuator {
 	return &actuator{
 		alicloudClientFactory: alicloudClientFactory,

--- a/pkg/webhook/utils/service.go
+++ b/pkg/webhook/utils/service.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	AlicloudLoadBalancerSpecAnnotationKey = "service.beta.kubernetes.io/alibaba-cloud-loadbalancer-spec"
+	alicloudLoadBalancerSpecAnnotationKey = "service.beta.kubernetes.io/alibaba-cloud-loadbalancer-spec"
 )
 
 // MutateExternalTrafficPolicy mutates ServiceExternalTrafficPolicyType to Local of LoadBalancer type service
@@ -41,6 +41,6 @@ func MutateExternalTrafficPolicy(new, old *corev1.Service) {
 // MutateAnnotation mutates annotation of LoadBalancer type service
 func MutateAnnotation(new, old *corev1.Service, loadBalancerSpec string) {
 	if new.Spec.Type == corev1.ServiceTypeLoadBalancer {
-		metav1.SetMetaDataAnnotation(&new.ObjectMeta, AlicloudLoadBalancerSpecAnnotationKey, loadBalancerSpec)
+		metav1.SetMetaDataAnnotation(&new.ObjectMeta, alicloudLoadBalancerSpecAnnotationKey, loadBalancerSpec)
 	}
 }

--- a/test/tm/generator.go
+++ b/test/tm/generator.go
@@ -36,11 +36,11 @@ const (
 )
 
 var (
-	cfg    *GeneratorConfig
+	cfg    *generatorConfig
 	logger logr.Logger
 )
 
-type GeneratorConfig struct {
+type generatorConfig struct {
 	networkVPCCidr                   string
 	networkWorkerCidr                string
 	infrastructureProviderConfigPath string
@@ -49,7 +49,7 @@ type GeneratorConfig struct {
 }
 
 func addFlags() {
-	cfg = &GeneratorConfig{}
+	cfg = &generatorConfig{}
 	flag.StringVar(&cfg.infrastructureProviderConfigPath, "infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
 	flag.StringVar(&cfg.controlplaneProviderConfigPath, "controlplane-provider-config-filepath", "", "filepath to the provider specific controlplane config")
 


### PR DESCRIPTION
**How to categorize this PR?**

/area quality, dev-productivity
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
Makes the linter fail on missing or wrong doc comments and a few other common style errors, and fixes all such issues that already exist.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Making the linter fail on missing or wrong doc comments and a few other common style errors consists of enabling `revive` in the `golangci-lint` configuration and excluding certain `revive` errors that we are perhaps not interested in.

I have fixed the following `revive` errors (as regexes that could be included in the `golangci-lint` configuration if desired):

```
- "exported: comment on exported (var|const|type|method|function) .* should be of the form "
- "exported: exported (var|const|type|method|function) .* should have comment or be unexported"
- if-return # redundant if \.\.\.; err != nil check, just return error instead
```

I have disabled the following `revive` errors via the `golangci-lint` configuration:

```
- var-naming # ((var|const|struct field|func) .* should be .*
- dot-imports # should not use dot imports
- package-comments # package comment should be of the form
- indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
- "exported: (type|func) name will be used as .* by other packages, and that stutters;"
```

See also https://github.com/gardener/gardener/pull/4627 and https://github.com/gardener/gardener-extension-provider-aws/pull/410.

**Release note**:

```other developer
Missing or wrong doc comments and a few other common style errors will now be reported by the linter.
```
