### PR TITLE
[release-v1.27] Automated cherry pick of #360: Use external-provisioner@v2.1.2 for K8s >= 1.17

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -27,6 +27,12 @@ images:
   sourceRepository: https://github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner
   tag: v1.6.0
+  targetVersion: "< 1.17"
+- name: csi-provisioner
+  sourceRepository: https://github.com/kubernetes-csi/external-provisioner
+  repository: k8s.gcr.io/sig-storage/csi-provisioner
+  tag: v2.1.2
+  targetVersion: ">= 1.17"
 - name: csi-snapshotter
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/csi-snapshotter

--- a/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml
@@ -103,10 +103,15 @@ spec:
         - "--csi-address=$(CSI_ENDPOINT)"
         - "--kubeconfig=/var/lib/csi-provisioner/kubeconfig"
         - "--feature-gates=Topology=True"
-        - "--enable-leader-election=true"
-        - "--leader-election-type=leases"
         - "--leader-election-namespace=kube-system"
         - "--volume-name-prefix=pv-{{ .Values.csiPluginController.persistentVolumePrefix }}"
+        {{- if semverCompare ">= 1.17" .Values.kubernetesVersion }}
+        - "--default-fstype=ext4"
+        - "--leader-election=true"
+        {{- else }}
+        - "--enable-leader-election=true"
+        - "--leader-election-type=leases"
+        {{- end }}
 {{- if .Values.csiPluginController.podResources.provisioner }}
         resources:
 {{ toYaml .Values.csiPluginController.podResources.provisioner | indent 12 }}

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-provisioner-rbac.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-provisioner-rbac.yaml
@@ -27,6 +27,11 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]
+{{- if semverCompare ">= 1.17" .Values.kubernetesVersion }}
+- apiGroups: ["storage.k8s.io"]
+  resources: ["volumeattachments"]
+  verbs: ["get", "list", "watch"]
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -39,7 +44,7 @@ roleRef:
   kind: ClusterRole
   name: {{ include "csi-disk-plugin.extensionsGroup" . }}:kube-system:csi-provisioner
   apiGroup: rbac.authorization.k8s.io
-
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -50,7 +55,6 @@ rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "watch", "list", "delete", "update", "create"]
-
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
/kind/bug

Cherry pick of #360 on release-v1.27.

#360: Use external-provisioner@v2.1.2 for K8s >= 1.17

**Release Notes:**
```bugfix user
An issue preventing volumes to be successfully provisioned for alicloud Shoots with K8s 1.22 is now fixed. 
```