### PR TITLE
[release-v1.27] Automated cherry pick of #361: Use external-attacher@v2.2.0 for K8s < 1.17

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -18,7 +18,13 @@ images:
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: k8s.gcr.io/sig-storage/csi-attacher
+  tag: v2.2.0
+  targetVersion: "< 1.17"
+- name: csi-attacher
+  sourceRepository: https://github.com/kubernetes-csi/external-attacher
+  repository: k8s.gcr.io/sig-storage/csi-attacher
   tag: v3.3.0
+  targetVersion: ">= 1.17"
 - name: csi-node-driver-registrar
   sourceRepository: https://github.com/kubernetes-csi/node-driver-registrar
   repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-attacher-rbac.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-attacher-rbac.yaml
@@ -26,9 +26,11 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["volumeattachments"]
   verbs: ["get", "list", "watch", "update"]
+{{- if semverCompare ">= 1.17" .Values.kubernetesVersion }}
 - apiGroups: [ "storage.k8s.io" ]
   resources: [ "volumeattachments/status" ]
   verbs: [ "patch" ]
+{{- end }}
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create", "patch", "update"]


### PR DESCRIPTION
/kind/bug

Cherry pick of #361 on release-v1.27.

#361: Use external-attacher@v2.2.0 for K8s < 1.17

**Release Notes:**
```bugfix user
An issue preventing volumes to be successfully attached for alicloud Shoots with K8s < 1.17 is now fixed.
```