### PR TITLE
[release-v1.27] Automated cherry pick of #365: Add VPA for control plane CSI components

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller-vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller-vpa.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: csi-plugin-controller-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        memory: 25Mi
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: csi-plugin-controller
+  updatePolicy:
+    updateMode: Auto

--- a/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-snapshot-controller-vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-snapshot-controller-vpa.yaml
@@ -1,0 +1,20 @@
+{{- if semverCompare ">= 1.17" .Values.kubernetesVersion }}
+---
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: csi-snapshot-controller-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: csi-snapshot-controller
+      minAllowed:
+        memory: 25Mi
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: csi-snapshot-controller
+  updatePolicy:
+    updateMode: Auto
+{{- end }}

--- a/cmd/gardener-extension-provider-alicloud/app/app.go
+++ b/cmd/gardener-extension-provider-alicloud/app/app.go
@@ -42,6 +42,7 @@ import (
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -159,6 +160,9 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				controllercmd.LogErrAndExit(err, "Could not update manager scheme")
 			}
 			if err := druidv1alpha1.AddToScheme(scheme); err != nil {
+				controllercmd.LogErrAndExit(err, "Could not update manager scheme")
+			}
+			if err := autoscalingv1beta2.AddToScheme(scheme); err != nil {
 				controllercmd.LogErrAndExit(err, "Could not update manager scheme")
 			}
 			if err := machinev1alpha1.AddToScheme(scheme); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.21.2
 	k8s.io/apimachinery v0.21.2
 	k8s.io/apiserver v0.21.2
+	k8s.io/autoscaler v0.0.0-20190805135949-100e91ba756e
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/code-generator v0.21.2
 	k8s.io/component-base v0.21.2

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -42,6 +42,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/authentication/user"
+	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 )
 
 var controlPlaneSecrets = &secrets.Secrets{
@@ -160,6 +161,7 @@ var controlPlaneChart = &chart.Chart{
 				{Type: &appsv1.Deployment{}, Name: "cloud-controller-manager"},
 				{Type: &corev1.Secret{}, Name: "cloud-provider-config"},
 				{Type: &corev1.ConfigMap{}, Name: "cloud-controller-manager-observability-config"},
+				{Type: &autoscalingv1beta2.VerticalPodAutoscaler{}, Name: "cloud-controller-manager-vpa"},
 			},
 		},
 		{
@@ -175,7 +177,9 @@ var controlPlaneChart = &chart.Chart{
 			},
 			Objects: []*chart.Object{
 				{Type: &appsv1.Deployment{}, Name: "csi-plugin-controller"},
+				{Type: &autoscalingv1beta2.VerticalPodAutoscaler{}, Name: "csi-plugin-controller-vpa"},
 				{Type: &appsv1.Deployment{}, Name: "csi-snapshot-controller"},
+				{Type: &autoscalingv1beta2.VerticalPodAutoscaler{}, Name: "csi-snapshot-controller-vpa"},
 				{Type: &corev1.ConfigMap{}, Name: "csi-plugin-controller-observability-config"},
 			},
 		},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -752,6 +752,7 @@ k8s.io/apiserver/pkg/authentication/serviceaccount
 k8s.io/apiserver/pkg/authentication/user
 k8s.io/apiserver/pkg/util/feature
 # k8s.io/autoscaler v0.0.0-20190805135949-100e91ba756e
+## explicit
 k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2
 # k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible => k8s.io/client-go v0.21.2
 ## explicit


### PR DESCRIPTION
/area/storage
/kind/enhancement

Cherry pick of #365 on release-v1.27.

#365: Add VPA for control plane CSI components

**Release Notes:**
```other operator
The control plane CSI components (`csi-plugin-controller` and `csi-snapshot-controller`) are now auto-scaled by VPA.
```