### PR TITLE
add tags from pool to machine class

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -133,10 +133,13 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				"internetMaxBandwidthIn":  5,
 				"internetMaxBandwidthOut": 5,
 				"spotStrategy":            "NoSpot",
-				"tags": map[string]string{
-					fmt.Sprintf("kubernetes.io/cluster/%s", w.worker.Namespace):     "1",
-					fmt.Sprintf("kubernetes.io/role/worker/%s", w.worker.Namespace): "1",
-				},
+				"tags": utils.MergeStringMaps(
+					map[string]string{
+						fmt.Sprintf("kubernetes.io/cluster/%s", w.worker.Namespace):     "1",
+						fmt.Sprintf("kubernetes.io/role/worker/%s", w.worker.Namespace): "1",
+					},
+					pool.Labels,
+				),
 				"secret": map[string]interface{}{
 					"userData": string(pool.UserData),
 				},


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
Labels from work pool is not added to ECS instance. In this PR, we add these labels to machineclass so that they will be added to ECS as tag
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Copy labels from work pool to ECS instance Tags.
```
