### PR TITLE
Extend encryption image to 120 minutes

### DIFF
--- a/pkg/controller/common/encryptimage.go
+++ b/pkg/controller/common/encryptimage.go
@@ -22,11 +22,12 @@ import (
 	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
-	alicloudclient "github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud/client"
-	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud/client/ros"
 	gcorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/retry"
+
+	alicloudclient "github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud/client"
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud/client/ros"
 )
 
 // CopyImageROSTemplate contains the content of CopyImage ROS template. https://www.alibabacloud.com/help/doc-detail/116189.htm?spm=a2c63.l28256.b99.201.713413a3FkLSIx
@@ -126,6 +127,7 @@ func (ie *imageEncryptor) createStack() (string, error) {
 
 	stackRequest := ros.CreateCreateStackRequest()
 	stackRequest.StackName = stackName
+	stackRequest.TimeoutInMinutes = "120"
 	stackRequest.TemplateBody = CopyImageROSTemplate
 	stackRequest.Tags = &[]ros.Tag{
 		{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
In some time, it takes more than an hour for AliCloud to finish VM image encryption. The default timeout of ROS stack is 1 hour. We need to extend it longer.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Sometimes user fails to create a shoot with encrypted system volume. Now this issue is mitigated for most cases.
```
