### PR TITLE
Upgrade terraformer to a version that uses terraform 0.15

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer-alicloud
-  tag: "v2.9.0"
+  tag: "v2.13.0-dev-26820af821db1acb9bbc8086d6562c67babb472f"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer-alicloud
-  tag: "v2.13.0-dev-45dd48fcb2ee896a0b21d32f72f7ce4dd87d78fa"
+  tag: "v2.13.0-dev-29839f245b50f64835adaaf4b469a67b2e6bf5f1"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer-alicloud
-  tag: "v2.13.0-dev-26820af821db1acb9bbc8086d6562c67babb472f"
+  tag: "v2.13.0-dev-45dd48fcb2ee896a0b21d32f72f7ce4dd87d78fa"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/pkg/controller/common/terraform.go
+++ b/pkg/controller/common/terraform.go
@@ -34,7 +34,8 @@ import (
 const (
 	terraformVarAccessKeyID     = "TF_VAR_ACCESS_KEY_ID"
 	terraformVarAccessKeySecret = "TF_VAR_ACCESS_KEY_SECRET"
-	terraformProvider           = "provider.alicloud"
+	terraformProvider           = "provider[\"registry.terraform.io/hashicorp/alicloud\"]"
+	terraformProviderOld        = "provider.alicloud"
 )
 
 type tfState struct {
@@ -118,7 +119,7 @@ func IsStateEmpty(ctx context.Context, tf terraformer.Terraformer) (bool, error)
 	}
 
 	for _, res := range state.Resources {
-		if res.Provider == terraformProvider && len(res.Instances) > 0 {
+		if (res.Provider == terraformProvider || res.Provider == terraformProviderOld) && len(res.Instances) > 0 {
 			return false, nil
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
Upgrades `terraformer` image to a version that uses `terraform` 0.15 (see gardener/terraformer/pull/107).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR has been created mainly to validate the new terraformer version before it's released.

**Release note**:

```other operator
The `terraformer` image has been upgraded to a version that uses `terraform` 0.15.
```
