### PR TITLE
Enable specifying a domain id in `DNSRecord` `spec.zone`

### DIFF
--- a/pkg/alicloud/client/client.go
+++ b/pkg/alicloud/client/client.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
@@ -43,7 +44,8 @@ func ComputeStorageEndpoint(region string) string {
 }
 
 type clientFactory struct {
-	domainsCache *cache.Expiring
+	domainsCache      *cache.Expiring
+	domainsCacheMutex sync.Mutex
 }
 
 // NewClientFactory creates a new clientFactory instance that can be used to instantiate Alicloud clients.

--- a/pkg/alicloud/client/client.go
+++ b/pkg/alicloud/client/client.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
@@ -41,11 +42,15 @@ func ComputeStorageEndpoint(region string) string {
 	return fmt.Sprintf("https://oss-%s.aliyuncs.com/", region)
 }
 
-type clientFactory struct{}
+type clientFactory struct {
+	domainsCache *cache.Expiring
+}
 
 // NewClientFactory creates a new clientFactory instance that can be used to instantiate Alicloud clients.
 func NewClientFactory() ClientFactory {
-	return &clientFactory{}
+	return &clientFactory{
+		domainsCache: cache.NewExpiring(),
+	}
 }
 
 // NewOSSClient creates an new OSS client with given endpoint, accessKeyID, and accessKeySecret.

--- a/pkg/alicloud/client/mock/mocks.go
+++ b/pkg/alicloud/client/mock/mocks.go
@@ -65,11 +65,26 @@ func (mr *MockDNSMockRecorder) DeleteDomainRecords(arg0, arg1, arg2, arg3 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDomainRecords", reflect.TypeOf((*MockDNS)(nil).DeleteDomainRecords), arg0, arg1, arg2, arg3)
 }
 
+// GetDomainName mocks base method.
+func (m *MockDNS) GetDomainName(arg0 context.Context, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDomainName", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDomainName indicates an expected call of GetDomainName.
+func (mr *MockDNSMockRecorder) GetDomainName(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomainName", reflect.TypeOf((*MockDNS)(nil).GetDomainName), arg0, arg1)
+}
+
 // GetDomainNames mocks base method.
-func (m *MockDNS) GetDomainNames(arg0 context.Context) ([]string, error) {
+func (m *MockDNS) GetDomainNames(arg0 context.Context) (map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDomainNames", arg0)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/alicloud/client/types.go
+++ b/pkg/alicloud/client/types.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"context"
+	"sync"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/alidns"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
@@ -154,8 +155,9 @@ type VPCInfo struct {
 // dnsClient implements the DNS interface.
 type dnsClient struct {
 	alidns.Client
-	accessKeyID  string
-	domainsCache *cache.Expiring
+	accessKeyID       string
+	domainsCache      *cache.Expiring
+	domainsCacheMutex *sync.Mutex
 }
 
 // DNS is an interface which declares DNS related methods.

--- a/pkg/alicloud/client/types.go
+++ b/pkg/alicloud/client/types.go
@@ -157,7 +157,8 @@ type dnsClient struct {
 
 // DNS is an interface which declares DNS related methods.
 type DNS interface {
-	GetDomainNames(context.Context) ([]string, error)
+	GetDomainNames(context.Context) (map[string]string, error)
+	GetDomainName(context.Context, string) (string, error)
 	CreateOrUpdateDomainRecords(context.Context, string, string, string, []string, int64) error
 	DeleteDomainRecords(context.Context, string, string, string) error
 }

--- a/pkg/alicloud/client/types.go
+++ b/pkg/alicloud/client/types.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	ros "github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud/client/ros"
+	"k8s.io/apimachinery/pkg/util/cache"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -153,6 +154,8 @@ type VPCInfo struct {
 // dnsClient implements the DNS interface.
 type dnsClient struct {
 	alidns.Client
+	accessKeyID  string
+	domainsCache *cache.Expiring
 }
 
 // DNS is an interface which declares DNS related methods.


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
Enables specifying a domain id, in addition to a domain name, in the `spec.zone` field of a `DNSRecord` resource. This is needed to ensure that explicitly configured zones in landscapes and shoot `spec.dns.providers` configurations work for both the `DNSRecord` controller and [external-dns-management](https://github.com/gardener/external-dns-management), which uses the domain id as the zone on Alicloud.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
* Specifying the domain name, and not the domain id, is still recommended if possible, since the Alicloud API uses the domain name, not the domain id. If the domain id is specified, the domain name has to be figured out at the price of additional API requests that could otherwise be avoided.
* Nevertheless, in order to avoid "overlapping zones" errors from `external-dns-management`, it is important to be able to configure zones explicitly in a way that works for both `external-dns-management` and the `DNSRecord` controller. Since the handling of zones in `external-dns-management` is harder to change, this PR proposes adapting the `DNSRecord` controller to the zone identification used by `external-dns-management`.

**Release note**:

```feature operator
It is now possible to specify a domain id, in addition to a domain name, in the `spec.zone` field of a `DNSRecord` resource.
```
