### PR TITLE
Issue386:Make encrypted option to true for system or data disk by default

### DIFF
--- a/charts/gardener-extension-admission-alicloud/charts/application/templates/mutatingwebhook-mutator.yaml
+++ b/charts/gardener-extension-admission-alicloud/charts/application/templates/mutatingwebhook-mutator.yaml
@@ -10,6 +10,7 @@ webhooks:
     apiVersions:
     - v1beta1
     operations:
+    - CREATE
     - UPDATE
     resources:
     - shoots

--- a/pkg/admission/mutator/mutator_test.go
+++ b/pkg/admission/mutator/mutator_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestMutator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Suite")
+	RunSpecs(t, "Shoot mutation Suite")
 }

--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -115,7 +115,7 @@ func (s *shootMutator) isCustomizedImage(ctx context.Context, shoot *corev1beta1
 	logger.Info("Checking in cloudProfie", "CloudProfile", cloudProfile, "Region", region)
 	imageId, err := s.getImageId(ctx, imageName, imageVersion, region, cloudProfile)
 	if err != nil || imageId == "" {
-		return false, fmt.Errorf("can't find imageID")
+		return false, err
 	}
 	logger.Info("Got ImageID", "ImageID", imageId)
 	isOwnedByAli, err := s.isOwnedbyAliCloud(ctx, shoot, imageId, region)
@@ -167,16 +167,14 @@ func (s *shootMutator) getImageId(ctx context.Context, imageName string, imageVe
 		cloudProfile    = &corev1beta1.CloudProfile{}
 		cloudProfileKey = kutil.Key(cloudProfileName)
 	)
-	imageId := ""
 	if err := kutil.LookupObject(ctx, s.virtualGardenclient, s.apiReader, cloudProfileKey, cloudProfile); err != nil {
-		return imageId, err
+		return "", err
 	}
 	cloudProfileConfig, err := s.getCloudProfileConfig(cloudProfile)
 	if err != nil {
-		return imageId, err
+		return "", err
 	}
-	imageId, err = helper.FindImageForRegionFromCloudProfile(cloudProfileConfig, imageName, *imageVersion, imageRegion)
-	return imageId, err
+	return helper.FindImageForRegionFromCloudProfile(cloudProfileConfig, imageName, *imageVersion, imageRegion)
 }
 func (s *shootMutator) getCloudProfileConfig(cloudProfile *corev1beta1.CloudProfile) (*api.CloudProfileConfig, error) {
 	var cloudProfileConfig *api.CloudProfileConfig = &api.CloudProfileConfig{}

--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -50,7 +50,7 @@ func NewShootMutator() extensionswebhook.Mutator {
 	return &shootMutator{alicloudClientFactory: alicloudclientFactory}
 }
 
-// NewShootMutator with parameter returns a new instance of a shoot validator.
+// NewShootMutatorWithDeps with parameter returns a new instance of a shoot validator.
 func NewShootMutatorWithDeps(alicloudclientFactory alicloudclient.ClientFactory) extensionswebhook.Mutator {
 
 	return &shootMutator{alicloudClientFactory: alicloudclientFactory}

--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -19,11 +19,17 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
+	alicloudclient "github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud/client"
+	api "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -35,14 +41,20 @@ const (
 )
 
 // NewShootMutator returns a new instance of a shoot validator.
-func NewShootMutator() extensionswebhook.Mutator {
-	return &shootMutator{}
+func NewShootMutator(virtualGardenclient client.Client, apiReader client.Reader, decoder runtime.Decoder) extensionswebhook.Mutator {
+
+	alicloudclientFactory := alicloudclient.NewClientFactory()
+	return &shootMutator{virtualGardenclient: virtualGardenclient, apiReader: apiReader, decoder: decoder, alicloudClientFactory: alicloudclientFactory}
 }
 
 type shootMutator struct {
+	virtualGardenclient   client.Client
+	apiReader             client.Reader
+	decoder               runtime.Decoder
+	alicloudClientFactory alicloudclient.ClientFactory
 }
 
-func (s *shootMutator) Mutate(_ context.Context, new, old client.Object) error {
+func (s *shootMutator) Mutate(ctx context.Context, new, old client.Object) error {
 	shoot, ok := new.(*corev1beta1.Shoot)
 	if !ok {
 		return fmt.Errorf("wrong object type %T", new)
@@ -54,12 +66,142 @@ func (s *shootMutator) Mutate(_ context.Context, new, old client.Object) error {
 			return fmt.Errorf("wrong object type %T for old object", old)
 		}
 		return s.mutateShootUpdate(oldShoot, shoot)
+	} else {
+		return s.mutateShootCreation(ctx, shoot)
 	}
 
-	// Only consider update for now.
+}
+func (s *shootMutator) mutateShootCreation(ctx context.Context, shoot *corev1beta1.Shoot) error {
+	logger.Info("Starting Shoot Creation Mutation")
+	for _, worker := range shoot.Spec.Provider.Workers {
+		imageName := worker.Machine.Image.Name
+		imageVersion := worker.Machine.Image.Version
+		logger.Info("Check ImageName: " + imageName + "; ImageVesion: " + *imageVersion)
+		if worker.DataVolumes != nil {
+			for i := range worker.DataVolumes {
+				volume := &worker.DataVolumes[i]
+				if volume.Encrypted == nil {
+					logger.Info("set encrypted disk by default for data disk")
+					encrypted := true
+					volume.Encrypted = &encrypted
+				}
+			}
+		}
+		if worker.Volume != nil && worker.Volume.Encrypted == nil {
+			//don't set encrypted disk by default if image is system image
+			isCustomizeImage, err := s.isCustomizedImage(ctx, shoot, imageName, imageVersion)
+			if err != nil {
+				return err
+			}
+			if !isCustomizeImage {
+				continue
+			}
+			logger.Info("Customized Image is used and we set encrypted disk by default for system disk")
+			encrypted := true
+			worker.Volume.Encrypted = &encrypted
+		}
+
+	}
 	return nil
 }
+func (s *shootMutator) isCustomizedImage(ctx context.Context, shoot *corev1beta1.Shoot, imageName string, imageVersion *string) (bool, error) {
+	cloudProfile := shoot.Spec.CloudProfileName
+	region := shoot.Spec.Region
+	logger.Info("Checking in cloudProfie", "CloudProfile", cloudProfile, "Region", region)
+	imageId, err := s.getImageId(ctx, imageName, imageVersion, region, cloudProfile)
+	if err != nil || imageId == "" {
+		return false, fmt.Errorf("can't find imageID")
+	}
+	logger.Info("Got ImageID", "ImageID", imageId)
+	s.isOwnedbyAliCloud(ctx, shoot, imageId, region)
+	return true, nil
+}
+func (s *shootMutator) isOwnedbyAliCloud(ctx context.Context, shoot *corev1beta1.Shoot, imageId string, region string) (bool, error) {
 
+	var (
+		secretBinding    = &corev1beta1.SecretBinding{}
+		secretBindingKey = kutil.Key(shoot.Namespace, shoot.Spec.SecretBindingName)
+	)
+	if err := kutil.LookupObject(ctx, s.virtualGardenclient, s.apiReader, secretBindingKey, secretBinding); err != nil {
+		return false, err
+	}
+
+	var (
+		secret    = &corev1.Secret{}
+		secretRef = secretBinding.SecretRef.Name
+		secretKey = kutil.Key(secretBinding.SecretRef.Namespace, secretRef)
+	)
+	// Explicitly use the client.Reader to prevent controller-runtime to start Informer for Secrets
+	// under the hood. The latter increases the memory usage of the component.
+	if err := s.apiReader.Get(ctx, secretKey, secret); err != nil {
+		return false, err
+	}
+	accessKeyID, ok := secret.Data[alicloud.AccessKeyID]
+	if !ok {
+		return false, fmt.Errorf("missing %q field in secret %s", alicloud.AccessKeyID, secretRef)
+	}
+	accessKeySecret, ok := secret.Data[alicloud.AccessKeySecret]
+	if !ok {
+		return false, fmt.Errorf("missing %q field in secret %s", alicloud.AccessKeySecret, secretRef)
+	}
+	shootECSClient, err := s.alicloudClientFactory.NewECSClient(region, string(accessKeyID), string(accessKeySecret))
+	if err != nil {
+		return false, err
+	}
+	if exist, err := shootECSClient.CheckIfImageExists(ctx, imageId); err != nil {
+		return false, err
+	} else if exist {
+		if ownedByAliCloud, err := shootECSClient.CheckIfImageOwnedByAliCloud(imageId); err != nil {
+			return false, err
+		} else if ownedByAliCloud {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+func (s *shootMutator) getImageId(ctx context.Context, imageName string, imageVersion *string, imageRegion string, cloudProfileName string) (string, error) {
+	var (
+		cloudProfile    = &corev1beta1.CloudProfile{}
+		cloudProfileKey = kutil.Key(cloudProfileName)
+	)
+	imageId := ""
+	if err := kutil.LookupObject(ctx, s.virtualGardenclient, s.apiReader, cloudProfileKey, cloudProfile); err != nil {
+		return imageId, err
+	}
+	//logger.Info("Got CloudProfile", "profile Detail", cloudProfile)
+	cloudProfileConfig, err := s.getCloudProfileConfig(cloudProfile)
+	if err != nil {
+		return imageId, err
+	}
+	//	logger.Info("Got CloudProfileConfig", "Config", cloudProfileConfig)
+	//	logger.Info("Images in Config", "Images", cloudProfileConfig.MachineImages)
+	for _, machineImage := range cloudProfileConfig.MachineImages {
+		name := machineImage.Name
+		if imageName == name {
+			versions := machineImage.Versions
+			for _, version := range versions {
+				if version.Version == *imageVersion {
+					regions := version.Regions
+					for _, region := range regions {
+						if region.Name == imageRegion {
+							imageId = region.ID
+						}
+					}
+				}
+			}
+		}
+	}
+	return imageId, nil
+}
+func (s *shootMutator) getCloudProfileConfig(cloudProfile *corev1beta1.CloudProfile) (*api.CloudProfileConfig, error) {
+	var cloudProfileConfig *api.CloudProfileConfig = &api.CloudProfileConfig{}
+	//	logger.Info("ProvideConfig", "Raw", cloudProfile.Spec.ProviderConfig.Raw)
+	if _, _, err := s.decoder.Decode(cloudProfile.Spec.ProviderConfig.Raw, nil, cloudProfileConfig); err != nil {
+		return nil, fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", kutil.ObjectName(cloudProfile), err)
+	}
+
+	return cloudProfileConfig, nil
+}
 func (s *shootMutator) mutateShootUpdate(oldShoot, shoot *corev1beta1.Shoot) error {
 	if !equality.Semantic.DeepEqual(oldShoot.Spec, shoot.Spec) {
 		s.mutateForEncryptedSystemDiskChange(oldShoot, shoot)

--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -43,14 +43,14 @@ const (
 	MutatorPath = "/webhooks/mutate"
 )
 
-// NewShootMutator returns a new instance of a shoot validator.
+// NewShootMutator returns a new instance of a shoot mutator.
 func NewShootMutator() extensionswebhook.Mutator {
 
 	alicloudclientFactory := alicloudclient.NewClientFactory()
 	return &shootMutator{alicloudClientFactory: alicloudclientFactory}
 }
 
-// NewShootMutatorWithDeps with parameter returns a new instance of a shoot validator.
+// NewShootMutatorWithDeps with parameter returns a new instance of a shoot mutator.
 func NewShootMutatorWithDeps(alicloudclientFactory alicloudclient.ClientFactory) extensionswebhook.Mutator {
 
 	return &shootMutator{alicloudClientFactory: alicloudclientFactory}
@@ -64,20 +64,20 @@ type shootMutator struct {
 	alicloudClientFactory alicloudclient.ClientFactory
 }
 
-// InjectScheme injects the given scheme into the validator.
+// InjectScheme injects the given scheme into the mutator.
 func (s *shootMutator) InjectScheme(scheme *runtime.Scheme) error {
 	s.decoder = serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder()
 	s.lenientDecoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
 	return nil
 }
 
-// InjectClient injects the given client into the validator.
+// InjectClient injects the given client into the mutator.
 func (s *shootMutator) InjectClient(client client.Client) error {
 	s.client = client
 	return nil
 }
 
-// InjectAPIReader injects the given apiReader into the validator.
+// InjectAPIReader injects the given apiReader into the mutator.
 func (s *shootMutator) InjectAPIReader(apiReader client.Reader) error {
 	s.apiReader = apiReader
 	return nil

--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -181,11 +181,7 @@ func (s *shootMutator) isOwnedbyAliCloud(ctx context.Context, shoot *corev1beta1
 	if exist, err := shootECSClient.CheckIfImageExists(ctx, imageId); err != nil {
 		return false, err
 	} else if exist {
-		if ownedByAliCloud, err := shootECSClient.CheckIfImageOwnedByAliCloud(imageId); err != nil {
-			return false, err
-		} else if ownedByAliCloud {
-			return true, nil
-		}
+		return shootECSClient.CheckIfImageOwnedByAliCloud(imageId)
 	}
 	return false, nil
 }
@@ -214,7 +210,7 @@ func (s *shootMutator) getCloudProfileConfig(cloudProfile *corev1beta1.CloudProf
 }
 func (s *shootMutator) mutateShootUpdate(ctx context.Context, oldShoot, shoot *corev1beta1.Shoot) error {
 	if !equality.Semantic.DeepEqual(oldShoot.Spec, shoot.Spec) {
-		if err := s.mutateShootUpdateForEncryptedDisk(ctx, oldShoot, shoot); err != nil {
+		if err := s.triggerInfraUpdateForNewEncryptedSystemDisk(ctx, oldShoot, shoot); err != nil {
 			return err
 		}
 	}
@@ -223,7 +219,7 @@ func (s *shootMutator) mutateShootUpdate(ctx context.Context, oldShoot, shoot *c
 	}
 	return nil
 }
-func (s *shootMutator) mutateShootUpdateForEncryptedDisk(ctx context.Context, oldshoot, shoot *corev1beta1.Shoot) error {
+func (s *shootMutator) triggerInfraUpdateForNewEncryptedSystemDisk(ctx context.Context, oldshoot, shoot *corev1beta1.Shoot) error {
 	for _, worker := range shoot.Spec.Provider.Workers {
 		oldWorker := getWorkerByName(oldshoot, worker.Name)
 		if oldWorker == nil {

--- a/pkg/admission/mutator/shoot_test.go
+++ b/pkg/admission/mutator/shoot_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Mutating Shoot", func() {
 
 		scheme = runtime.NewScheme()
 		install.Install(scheme)
-		controller.AddToScheme(scheme)
+		Expect(controller.AddToScheme(scheme)).To(Succeed())
 		serializer = json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{Yaml: true})
 		alicloudClientFactory = mockalicloudclient.NewMockClientFactory(ctrl)
 		ecsClient = mockalicloudclient.NewMockECS(ctrl)

--- a/pkg/admission/mutator/shoot_test.go
+++ b/pkg/admission/mutator/shoot_test.go
@@ -18,8 +18,8 @@ import (
 	"context"
 
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
+	api "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/install"
-	alicloudv1alpha1 "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/v1alpha1"
 	mockalicloudclient "github.com/gardener/gardener-extension-provider-alicloud/pkg/mock/provider-alicloud/alicloud/client"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
@@ -83,7 +83,7 @@ var _ = Describe("Mutating Shoot", func() {
 		secretBinding         *corev1beta1.SecretBinding
 		secret                *corev1.Secret
 
-		config       *alicloudv1alpha1.CloudProfileConfig
+		config       *api.CloudProfileConfig
 		configYAML   []byte
 		cloudProfile *corev1beta1.CloudProfile
 	)
@@ -125,14 +125,14 @@ var _ = Describe("Mutating Shoot", func() {
 			},
 		}
 
-		config = &alicloudv1alpha1.CloudProfileConfig{
-			MachineImages: []alicloudv1alpha1.MachineImages{
+		config = &api.CloudProfileConfig{
+			MachineImages: []api.MachineImages{
 				{
 					Name: imageName,
-					Versions: []alicloudv1alpha1.MachineImageVersion{
+					Versions: []api.MachineImageVersion{
 						{
 							Version: imageVersionStr,
-							Regions: []alicloudv1alpha1.RegionIDMapping{
+							Regions: []api.RegionIDMapping{
 								{
 									Name: regionId,
 									ID:   imageId,
@@ -144,8 +144,6 @@ var _ = Describe("Mutating Shoot", func() {
 			},
 		}
 
-		//config.APIVersion = "alicloud.provider.extensions.gardener.cloud/v1alpha1"
-		//config.Kind = "CloudProfileConfig"
 		configYAML = expectEncode(runtime.Encode(serializer, config))
 		cloudProfile = &corev1beta1.CloudProfile{
 			Spec: corev1beta1.CloudProfileSpec{
@@ -167,6 +165,9 @@ var _ = Describe("Mutating Shoot", func() {
 							},
 							Volume: &corev1beta1.Volume{
 								Encrypted: pointer.BoolPtr(true),
+							},
+							DataVolumes: []corev1beta1.DataVolume{
+								{},
 							},
 						},
 					},
@@ -244,6 +245,139 @@ var _ = Describe("Mutating Shoot", func() {
 			Expect(*newShoot.Spec.Provider.Workers[0].Volume.Encrypted).To(BeTrue())
 			Expect(*newShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted).To(BeTrue())
 			Expect(controllerutils.HasTask(newShoot.Annotations, v1beta1constants.ShootTaskDeployInfrastructure)).To(BeFalse())
+		})
+		It("should set encrypted flag as false for system disk if image is owned by alicloud", func() {
+			gomock.InOrder(
+				c.EXPECT().Get(ctx, kutil.Key("alicloud"), gomock.AssignableToTypeOf(&corev1beta1.CloudProfile{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, obj *corev1beta1.CloudProfile) error {
+						*obj = *cloudProfile
+						return nil
+					},
+				),
+				c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&corev1beta1.SecretBinding{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, obj *corev1beta1.SecretBinding) error {
+						*obj = *secretBinding
+						return nil
+					},
+				),
+				apiReader.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+						*obj = *secret
+						return nil
+					},
+				),
+
+				alicloudClientFactory.EXPECT().NewECSClient(regionId, accessKeyID, accessKeySecret).Return(ecsClient, nil),
+				ecsClient.EXPECT().CheckIfImageExists(ctx, imageId).Return(true, nil),
+				ecsClient.EXPECT().CheckIfImageOwnedByAliCloud(imageId).Return(true, nil),
+			)
+			err := shoot.Mutate(ctx, newShoot, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(newShoot.Spec.Provider.Workers[0].Volume.Encrypted == nil).To(BeTrue())
+			Expect(*newShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted).To(BeTrue())
+		})
+		It("should set encrypted flag as true for newly added worker or datavolume", func() {
+			sameName := "worker1"
+			newName := "newWorker"
+
+			oldShoot.Spec.Provider.Workers[0].Volume.Encrypted = nil
+			newShoot.Spec.Provider.Workers[0].Volume.Encrypted = nil
+			oldShoot.Spec.Provider.Workers[0].Name = sameName
+			newShoot.Spec.Provider.Workers[0].Name = sameName
+
+			newShoot.Spec.Provider.Workers[1].Name = newName
+			newShoot.Spec.Provider.Workers[1].Volume = &corev1beta1.Volume{}
+			newShoot.Spec.Provider.Workers[1].DataVolumes = []corev1beta1.DataVolume{{}}
+			//simulate to add datavolume disk
+			oldShoot.Spec.Provider.Workers[0].DataVolumes[0].Name = "old"
+			newShoot.Spec.Provider.Workers[0].DataVolumes[0].Name = newName
+			oldShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted = nil
+			newShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted = nil
+
+			gomock.InOrder(
+
+				c.EXPECT().Get(ctx, kutil.Key("alicloud"), gomock.AssignableToTypeOf(&corev1beta1.CloudProfile{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, obj *corev1beta1.CloudProfile) error {
+						*obj = *cloudProfile
+						return nil
+					},
+				),
+				c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&corev1beta1.SecretBinding{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, obj *corev1beta1.SecretBinding) error {
+						*obj = *secretBinding
+						return nil
+					},
+				),
+				apiReader.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+						*obj = *secret
+						return nil
+					},
+				),
+
+				alicloudClientFactory.EXPECT().NewECSClient(regionId, accessKeyID, accessKeySecret).Return(ecsClient, nil),
+				ecsClient.EXPECT().CheckIfImageExists(ctx, imageId).Return(false, nil),
+				//ecsClient.EXPECT().CheckIfImageOwnedByAliCloud(imageId).Return(false, nil)
+			)
+			err := shoot.Mutate(ctx, newShoot, oldShoot)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*newShoot.Spec.Provider.Workers[1].Volume.Encrypted).To(BeTrue())
+			Expect(*newShoot.Spec.Provider.Workers[1].DataVolumes[0].Encrypted).To(BeTrue())
+			Expect(*newShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted).To(BeTrue())
+		})
+		It("Should Keep encrypted flag unchanged if shoot was created in old version and this flag is not set explictly", func() {
+			oldShoot.Spec.Provider.Workers[0].Volume.Encrypted = nil
+			newShoot.Spec.Provider.Workers[0].Volume.Encrypted = nil
+			sameName := "worker1"
+			oldShoot.Spec.Provider.Workers[0].Name = sameName
+			newShoot.Spec.Provider.Workers[0].Name = sameName
+
+			oldShoot.Spec.Provider.Workers[0].DataVolumes[0].Name = sameName
+			newShoot.Spec.Provider.Workers[0].DataVolumes[0].Name = sameName
+			oldShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted = nil
+			newShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted = nil
+
+			err := shoot.Mutate(ctx, newShoot, oldShoot)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(newShoot.Spec.Provider.Workers[0].Volume.Encrypted == nil).To(BeTrue())
+			Expect(newShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted == nil).To(BeTrue())
+
+		})
+		It("Should keep default encrypted flag unchanged if shoot is created in new version and this flag is not set explictly", func() {
+			oldShoot.Spec.Provider.Workers[0].Volume.Encrypted = pointer.BoolPtr(true)
+			newShoot.Spec.Provider.Workers[0].Volume.Encrypted = nil
+			sameName := "worker1"
+			oldShoot.Spec.Provider.Workers[0].Name = sameName
+			newShoot.Spec.Provider.Workers[0].Name = sameName
+
+			oldShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted = pointer.BoolPtr(true)
+			newShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted = nil
+			oldShoot.Spec.Provider.Workers[0].DataVolumes[0].Name = sameName
+			newShoot.Spec.Provider.Workers[0].DataVolumes[0].Name = sameName
+
+			err := shoot.Mutate(ctx, newShoot, oldShoot)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*newShoot.Spec.Provider.Workers[0].Volume.Encrypted).To(BeTrue())
+			Expect(*newShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted).To(BeTrue())
+
+		})
+		It("Should use set encrypted flag if it's specified in new shoot", func() {
+			oldShoot.Spec.Provider.Workers[0].Volume.Encrypted = pointer.BoolPtr(true)
+			newShoot.Spec.Provider.Workers[0].Volume.Encrypted = pointer.BoolPtr(false)
+			sameName := "worker1"
+			oldShoot.Spec.Provider.Workers[0].Name = sameName
+			newShoot.Spec.Provider.Workers[0].Name = sameName
+
+			oldShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted = pointer.BoolPtr(false)
+			newShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted = pointer.BoolPtr(true)
+			oldShoot.Spec.Provider.Workers[0].DataVolumes[0].Name = sameName
+			newShoot.Spec.Provider.Workers[0].DataVolumes[0].Name = sameName
+
+			err := shoot.Mutate(ctx, newShoot, oldShoot)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*newShoot.Spec.Provider.Workers[0].Volume.Encrypted).To(BeFalse())
+			Expect(*newShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted).To(BeTrue())
+
 		})
 		It("should not reconcile infra if no system disk is encrypted", func() {
 			err := shoot.Mutate(ctx, newShoot, oldShoot)

--- a/pkg/admission/mutator/shoot_test.go
+++ b/pkg/admission/mutator/shoot_test.go
@@ -17,23 +17,143 @@ package mutator
 import (
 	"context"
 
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/install"
+	alicloudv1alpha1 "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/v1alpha1"
+	mockalicloudclient "github.com/gardener/gardener-extension-provider-alicloud/pkg/mock/provider-alicloud/alicloud/client"
+	"github.com/gardener/gardener/extensions/pkg/controller"
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
+
+const (
+	name      = "alicloud"
+	namespace = "garden"
+
+	regionId        = "cn-shanghai"
+	accessKeyID     = "accessKeyID"
+	accessKeySecret = "accessKeySecret"
+
+	imageName       = "gardenlinux"
+	imageVersionStr = "318.9.0"
+	imageId         = "m-uf6htf9lstsi99xr2out"
+)
+
+func expectInject(ok bool, err error) {
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ok).To(BeTrue(), "no injection happened")
+}
+
+func expectEncode(data []byte, err error) []byte {
+	Expect(err).NotTo(HaveOccurred())
+	Expect(data).NotTo(BeNil())
+	return data
+}
 
 var _ = Describe("Mutating Shoot", func() {
 	var (
-		oldShoot *corev1beta1.Shoot
-		newShoot *corev1beta1.Shoot
-		shoot    = &shootMutator{}
-		ctx      = context.TODO()
+		oldShoot              *corev1beta1.Shoot
+		newShoot              *corev1beta1.Shoot
+		shoot                 extensionswebhook.Mutator
+		ctx                   context.Context
+		ctrl                  *gomock.Controller
+		c                     *mockclient.MockClient
+		scheme                *runtime.Scheme
+		apiReader             *mockclient.MockReader
+		serializer            runtime.Serializer
+		alicloudClientFactory *mockalicloudclient.MockClientFactory
+		ecsClient             *mockalicloudclient.MockECS
+		secretBinding         *corev1beta1.SecretBinding
+		secret                *corev1.Secret
+
+		config       *alicloudv1alpha1.CloudProfileConfig
+		configYAML   []byte
+		cloudProfile *corev1beta1.CloudProfile
 	)
 
 	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		c = mockclient.NewMockClient(ctrl)
+		apiReader = mockclient.NewMockReader(ctrl)
+
+		scheme = runtime.NewScheme()
+		install.Install(scheme)
+		controller.AddToScheme(scheme)
+		serializer = json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{Yaml: true})
+		alicloudClientFactory = mockalicloudclient.NewMockClientFactory(ctrl)
+		ecsClient = mockalicloudclient.NewMockECS(ctrl)
+		ctx = context.TODO()
+
+		shoot = NewShootMutatorWithDeps(alicloudClientFactory)
+		expectInject(inject.ClientInto(c, shoot))
+		expectInject(inject.SchemeInto(scheme, shoot))
+		expectInject(inject.APIReaderInto(apiReader, shoot))
+
+		secretBinding = &corev1beta1.SecretBinding{
+			SecretRef: corev1.SecretReference{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				alicloud.AccessKeyID:     []byte(accessKeyID),
+				alicloud.AccessKeySecret: []byte(accessKeySecret),
+			},
+		}
+
+		config = &alicloudv1alpha1.CloudProfileConfig{
+			MachineImages: []alicloudv1alpha1.MachineImages{
+				{
+					Name: imageName,
+					Versions: []alicloudv1alpha1.MachineImageVersion{
+						{
+							Version: imageVersionStr,
+							Regions: []alicloudv1alpha1.RegionIDMapping{
+								{
+									Name: regionId,
+									ID:   imageId,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		//config.APIVersion = "alicloud.provider.extensions.gardener.cloud/v1alpha1"
+		//config.Kind = "CloudProfileConfig"
+		configYAML = expectEncode(runtime.Encode(serializer, config))
+		cloudProfile = &corev1beta1.CloudProfile{
+			Spec: corev1beta1.CloudProfileSpec{
+				ProviderConfig: &runtime.RawExtension{
+					Raw: configYAML,
+				},
+			},
+		}
 		oldShoot = &corev1beta1.Shoot{
 			Spec: corev1beta1.ShootSpec{
 				Provider: corev1beta1.Provider{
@@ -41,8 +161,8 @@ var _ = Describe("Mutating Shoot", func() {
 						{
 							Machine: corev1beta1.Machine{
 								Image: &corev1beta1.ShootMachineImage{
-									Name:    "GardenLinux",
-									Version: pointer.StringPtr("1.0"),
+									Name:    imageName,
+									Version: pointer.StringPtr(imageVersionStr),
 								},
 							},
 							Volume: &corev1beta1.Volume{
@@ -55,32 +175,76 @@ var _ = Describe("Mutating Shoot", func() {
 		}
 
 		newShoot = &corev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
 			Spec: corev1beta1.ShootSpec{
+				SecretBindingName: name,
 				Provider: corev1beta1.Provider{
 					Workers: []corev1beta1.Worker{
 						{
 							Machine: corev1beta1.Machine{
 								Image: &corev1beta1.ShootMachineImage{
-									Name:    "GardenLinux",
-									Version: pointer.StringPtr("1.0"),
+									Name:    imageName,
+									Version: pointer.StringPtr(imageVersionStr),
 								},
 							},
 							Volume: &corev1beta1.Volume{},
+							DataVolumes: []corev1beta1.DataVolume{
+								{},
+							},
 						},
 						{
 							Machine: corev1beta1.Machine{
 								Image: &corev1beta1.ShootMachineImage{
-									Name:    "GardenLinux",
-									Version: pointer.StringPtr("1.0"),
+									Name:    imageName,
+									Version: pointer.StringPtr(imageVersionStr),
 								},
 							},
 						},
 					},
 				},
+				CloudProfileName: "alicloud",
+				Region:           regionId,
 			},
 		}
 	})
+	AfterEach(func() {
+		ctrl.Finish()
+	})
 	Context("#Encrypted System Disk", func() {
+		It("should set encrypted flag as true for new shoot ", func() {
+			gomock.InOrder(
+				c.EXPECT().Get(ctx, kutil.Key("alicloud"), gomock.AssignableToTypeOf(&corev1beta1.CloudProfile{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, obj *corev1beta1.CloudProfile) error {
+						*obj = *cloudProfile
+						return nil
+					},
+				),
+				c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&corev1beta1.SecretBinding{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, obj *corev1beta1.SecretBinding) error {
+						*obj = *secretBinding
+						return nil
+					},
+				),
+				apiReader.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+						*obj = *secret
+						return nil
+					},
+				),
+
+				alicloudClientFactory.EXPECT().NewECSClient(regionId, accessKeyID, accessKeySecret).Return(ecsClient, nil),
+				ecsClient.EXPECT().CheckIfImageExists(ctx, imageId).Return(false, nil),
+				//ecsClient.EXPECT().CheckIfImageOwnedByAliCloud(imageId).Return(false, nil)
+			)
+			err := shoot.Mutate(ctx, newShoot, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*newShoot.Spec.Provider.Workers[0].Volume.Encrypted).To(BeTrue())
+			Expect(*newShoot.Spec.Provider.Workers[0].DataVolumes[0].Encrypted).To(BeTrue())
+			Expect(controllerutils.HasTask(newShoot.Annotations, v1beta1constants.ShootTaskDeployInfrastructure)).To(BeFalse())
+		})
 		It("should not reconcile infra if no system disk is encrypted", func() {
 			err := shoot.Mutate(ctx, newShoot, oldShoot)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/admission/mutator/shoot_test.go
+++ b/pkg/admission/mutator/shoot_test.go
@@ -317,7 +317,6 @@ var _ = Describe("Mutating Shoot", func() {
 
 				alicloudClientFactory.EXPECT().NewECSClient(regionId, accessKeyID, accessKeySecret).Return(ecsClient, nil),
 				ecsClient.EXPECT().CheckIfImageExists(ctx, imageId).Return(false, nil),
-				//ecsClient.EXPECT().CheckIfImageOwnedByAliCloud(imageId).Return(false, nil)
 			)
 			err := shoot.Mutate(ctx, newShoot, oldShoot)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/admission/mutator/webhook.go
+++ b/pkg/admission/mutator/webhook.go
@@ -18,7 +18,6 @@ import (
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -31,17 +30,13 @@ var logger = log.Log.WithName("alicloud-mutator-webhook")
 
 // NewShootsWebhook creates a new mutation webhook for shoots.
 func NewShootsWebhook(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
-	virtualGardenclient := mgr.GetClient()
-	apiReader := mgr.GetAPIReader()
-	scheme := mgr.GetScheme()
-	decoder := serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder()
 	return extensionswebhook.New(mgr, extensionswebhook.Args{
 		Provider:   alicloud.Type,
 		Name:       ShootMutatorName,
 		Path:       MutatorPath + "/shoots",
 		Predicates: []predicate.Predicate{extensionspredicate.GardenCoreProviderType(alicloud.Type)},
 		Mutators: map[extensionswebhook.Mutator][]client.Object{
-			NewShootMutator(virtualGardenclient, apiReader, decoder): {&corev1beta1.Shoot{}},
+			NewShootMutator(): {&corev1beta1.Shoot{}},
 		},
 	})
 }


### PR DESCRIPTION
**How to categorize this PR?**
/area security
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #386

**Special notes for your reviewer**:

**Release note**:
```feature user
For data disk of new created shoot or newly added data disk for existing shoot, it will be set as encrypted.
For system disk of new created shoot or newly added worker group of existing shoot, if the image is custom image(this is a precondition for alicloud to encrypt a system disk), it will be set as encrypted.
For old system disk or data disk created before, encrypted flag for it won't be changed.
```
