### PR TITLE
issue#394:Adopt API change of Ali nat gateway in terraformer

### DIFF
--- a/pkg/controller/infrastructure/templates/main.tpl.tf
+++ b/pkg/controller/infrastructure/templates/main.tpl.tf
@@ -17,7 +17,6 @@ resource "alicloud_vpc" "vpc" {
 
 resource "alicloud_nat_gateway" "nat_gateway" {
   vpc_id            = {{ .vpc.id }}
-  specification     = "Small"
   name              = "{{ .clusterName }}-natgw"
   nat_type          = "Enhanced"
   vswitch_id        = alicloud_vswitch.vsw_z0.id


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
Ali announces an API change about nat gateway which will take effect from 1st of January 2022. If payment type is pay as you go, the spec/specification field must be empty and InternetChargeType can only be PayByLcu
**Which issue(s) this PR fixes**:
Fixes #394

**Special notes for your reviewer**:
The change for garden/soil cluster will be done in internal repo
**Release note**:

-->
```other operator

```
