### PR TITLE
Prevent nil pointer dereference in admission-alicloud

### DIFF
--- a/pkg/apis/alicloud/validation/infrastructure.go
+++ b/pkg/apis/alicloud/validation/infrastructure.go
@@ -89,8 +89,12 @@ func ValidateInfrastructureConfig(infra *apisalicloud.InfrastructureConfig, node
 
 	// make sure that VPC cidrs don't overlap with each other
 	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(cidrs, false)...)
-	allErrs = append(allErrs, pods.ValidateNotOverlap(cidrs...)...)
-	allErrs = append(allErrs, services.ValidateNotOverlap(cidrs...)...)
+	if podsCIDR != nil {
+		allErrs = append(allErrs, pods.ValidateNotOverlap(cidrs...)...)
+	}
+	if servicesCIDR != nil {
+		allErrs = append(allErrs, services.ValidateNotOverlap(cidrs...)...)
+	}
 
 	return allErrs
 }

--- a/pkg/apis/alicloud/validation/infrastructure_test.go
+++ b/pkg/apis/alicloud/validation/infrastructure_test.go
@@ -174,6 +174,16 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services)
 				Expect(errorList).To(BeEmpty())
 			})
+
+			It("should allow specifying valid config", func() {
+				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services)
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should allow specifying valid config with podsCIDR=nil and servicesCIDR=nil", func() {
+				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, nil, nil)
+				Expect(errorList).To(BeEmpty())
+			})
 		})
 	})
 


### PR DESCRIPTION
/area quality
/kind regression
/platform alicloud

`.spec.networking.pods` and `.spec.networking.services` are actually optional and, if omitted, can be defaulted to Seed defaults.

https://github.com/gardener/gardener/blob/87edba3e7d915c7c1376fcd430120f057436f704/plugin/pkg/shoot/validator/admission.go#L502-L516

https://github.com/gardener/gardener-extension-provider-alicloud/pull/393 adapted the code in such way that it does not consider the case when `.spec.networking.pods=nil` or `.spec.networking.services=nil`.

```
2021/12/15 08:41:54 http: panic serving 10.40.3.90:39322: runtime error: invalid memory address or nil pointer dereference
goroutine 29896 [running]:
net/http.(*conn).serve.func1(0xc000f52140)
	/usr/local/go/src/net/http/server.go:1824 +0x153
panic(0x1d82960, 0x30c4c00)
	/usr/local/go/src/runtime/panic.go:971 +0x499
github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/validation.ValidateInfrastructureConfig(0xc001c134f0, 0xc001a39820, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/validation/infrastructure.go:92 +0x84a
github.com/gardener/gardener-extension-provider-alicloud/pkg/admission/validator.(*shoot).validateShoot(0xc000887a00, 0x2288ff0, 0xc001a6d340, 0xc000e90380, 0xc001c134f0, 0xc000b50f30, 0x0, 0xc00196dcd0)
	/go/src/github.com/gardener/gardener-extension-provider-alicloud/pkg/admission/validator/shoot.go:97 +0x5b
github.com/gardener/gardener-extension-provider-alicloud/pkg/admission/validator.(*shoot).validateShootCreation(0xc000887a00, 0x2288ff0, 0xc001a6d340, 0xc000e90380, 0xc00011e470, 0x40a43f)
	/go/src/github.com/gardener/gardener-extension-provider-alicloud/pkg/admission/validator/shoot.go:175 +0xe5
github.com/gardener/gardener-extension-provider-alicloud/pkg/admission/validator.(*shoot).Validate(0xc000887a00, 0x2288ff0, 0xc001a6d340, 0x22adc40, 0xc000e90380, 0x0, 0x0, 0xc000e90300, 0x22adc40)
	/go/src/github.com/gardener/gardener-extension-provider-alicloud/pkg/admission/validator/shoot.go:91 +0x168
github.com/gardener/gardener/extensions/pkg/webhook.(*validationWrapper).Mutate(0xc00059f1f0, 0x2288ff0, 0xc001a6d340, 0x22adc40, 0xc000e90380, 0x0, 0x0, 0x224fb68, 0xc001183880)
	/go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/github.com/gardener/gardener/extensions/pkg/webhook/validator.go:36 +0x79
github.com/gardener/gardener/extensions/pkg/webhook.handle(0x2288ff0, 0xc001a6d340, 0xc001e01440, 0x24, 0xc0019e6f18, 0x13, 0xc0011f3348, 0x7, 0xc0011f3350, 0x5, ...)
	/go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/github.com/gardener/gardener/extensions/pkg/webhook/handler.go:185 +0x2a2
github.com/gardener/gardener/extensions/pkg/webhook.(*handler).Handle(0xc00011ddb0, 0x2288ff0, 0xc001a6d340, 0xc001e01440, 0x24, 0xc0019e6f18, 0x13, 0xc0011f3348, 0x7, 0xc0011f3350, ...)
	/go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/github.com/gardener/gardener/extensions/pkg/webhook/handler.go:153 +0x4e5
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle(0xc000526ba0, 0x2288ff0, 0xc001a6d340, 0xc001e01440, 0x24, 0xc0019e6f18, 0x13, 0xc0011f3348, 0x7, 0xc0011f3350, ...)
	/go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/webhook.go:146 +0xd5
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP(0xc000526ba0, 0x7f74150565f8, 0xc001c13270, 0xc000552000)
	/go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/http.go:99 +0x1045
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerInFlight.func1(0x7f74150565f8, 0xc001c13270, 0xc000552000)
	/go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_server.go:40 +0xab
net/http.HandlerFunc.ServeHTTP(0xc0003760f0, 0x7f74150565f8, 0xc001c13270, 0xc000552000)
	/usr/local/go/src/net/http/server.go:2069 +0x44
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1(0x2283f40, 0xc001805b20, 0xc000552000)
	/go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_server.go:101 +0xdf
net/http.HandlerFunc.ServeHTTP(0xc0003762d0, 0x2283f40, 0xc001805b20, 0xc000552000)
	/usr/local/go/src/net/http/server.go:2069 +0x44
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2(0x2283f40, 0xc001805b20, 0xc000552000)
	/go/src/github.com/gardener/gardener-extension-provider-alicloud/vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_server.go:76 +0xb2
net/http.HandlerFunc.ServeHTTP(0xc000376450, 0x2283f40, 0xc001805b20, 0xc000552000)
	/usr/local/go/src/net/http/server.go:2069 +0x44
net/http.(*ServeMux).ServeHTTP(0xc000887b40, 0x2283f40, 0xc001805b20, 0xc000552000)
	/usr/local/go/src/net/http/server.go:2448 +0x1ad
net/http.serverHandler.ServeHTTP(0xc000ddaa80, 0x2283f40, 0xc001805b20, 0xc000552000)
	/usr/local/go/src/net/http/server.go:2887 +0xa3
net/http.(*conn).serve(0xc000f52140, 0x2289098, 0xc0018b39c0)
	/usr/local/go/src/net/http/server.go:1952 +0x8cd
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:3013 +0x39b
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing admission-alicloud to deny a Shoot creation request with `.spec.networking.pods=nil` or `.spec.networking.services=nil` is now fixed.
```
