### PR TITLE
[release-v1.31] Automated cherry pick of #400: Prevent nil pointer dereference in admission-alicloud

### DIFF
--- a/pkg/apis/alicloud/validation/infrastructure.go
+++ b/pkg/apis/alicloud/validation/infrastructure.go
@@ -89,8 +89,12 @@ func ValidateInfrastructureConfig(infra *apisalicloud.InfrastructureConfig, node
 
 	// make sure that VPC cidrs don't overlap with each other
 	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(cidrs, false)...)
-	allErrs = append(allErrs, pods.ValidateNotOverlap(cidrs...)...)
-	allErrs = append(allErrs, services.ValidateNotOverlap(cidrs...)...)
+	if podsCIDR != nil {
+		allErrs = append(allErrs, pods.ValidateNotOverlap(cidrs...)...)
+	}
+	if servicesCIDR != nil {
+		allErrs = append(allErrs, services.ValidateNotOverlap(cidrs...)...)
+	}
 
 	return allErrs
 }

--- a/pkg/apis/alicloud/validation/infrastructure_test.go
+++ b/pkg/apis/alicloud/validation/infrastructure_test.go
@@ -174,6 +174,16 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services)
 				Expect(errorList).To(BeEmpty())
 			})
+
+			It("should allow specifying valid config", func() {
+				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services)
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should allow specifying valid config with podsCIDR=nil and servicesCIDR=nil", func() {
+				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, nil, nil)
+				Expect(errorList).To(BeEmpty())
+			})
 		})
 	})
 


### PR DESCRIPTION
/area/quality
/kind/regression

Cherry pick of #400 on release-v1.31.

#400: Prevent nil pointer dereference in admission-alicloud

**Release Notes:**
```bugfix operator
An issue causing admission-alicloud to deny a Shoot creation request with `.spec.networking.pods=nil` or `.spec.networking.services=nil` is now fixed.
```