### PR TITLE
Nit: make a non-nil check more idiomatic

### DIFF
--- a/pkg/apis/alicloud/validation/infrastructure.go
+++ b/pkg/apis/alicloud/validation/infrastructure.go
@@ -89,10 +89,10 @@ func ValidateInfrastructureConfig(infra *apisalicloud.InfrastructureConfig, node
 
 	// make sure that VPC cidrs don't overlap with each other
 	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(cidrs, false)...)
-	if podsCIDR != nil {
+	if pods != nil {
 		allErrs = append(allErrs, pods.ValidateNotOverlap(cidrs...)...)
 	}
-	if servicesCIDR != nil {
+	if services != nil {
 		allErrs = append(allErrs, services.ValidateNotOverlap(cidrs...)...)
 	}
 


### PR DESCRIPTION
Instead of checking `podsCIDR` or `servicesCIDR` vars we could directly check `pods` and `services` vars.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
