### PR TITLE
remove label from machine class if value is empty

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -138,7 +138,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 						fmt.Sprintf("kubernetes.io/cluster/%s", w.worker.Namespace):     "1",
 						fmt.Sprintf("kubernetes.io/role/worker/%s", w.worker.Namespace): "1",
 					},
-					removeLabelWithoutValue(pool.Labels),
+					getLabelsWithValue(pool.Labels),
 				),
 				"secret": map[string]interface{}{
 					"userData": string(pool.UserData),
@@ -183,7 +183,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 
 	return nil
 }
-func removeLabelWithoutValue(labels map[string]string) map[string]string {
+func getLabelsWithValue(labels map[string]string) map[string]string {
 	out := make(map[string]string)
 	for key, value := range labels {
 		if len(value) > 0 {

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -138,7 +138,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 						fmt.Sprintf("kubernetes.io/cluster/%s", w.worker.Namespace):     "1",
 						fmt.Sprintf("kubernetes.io/role/worker/%s", w.worker.Namespace): "1",
 					},
-					pool.Labels,
+					removeLabelWithoutValue(pool.Labels),
 				),
 				"secret": map[string]interface{}{
 					"userData": string(pool.UserData),
@@ -183,7 +183,15 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 
 	return nil
 }
-
+func removeLabelWithoutValue(labels map[string]string) map[string]string {
+	out := make(map[string]string)
+	for key, value := range labels {
+		if len(value) > 0 {
+			out[key] = value
+		}
+	}
+	return out
+}
 func computeDisks(namespace string, pool extensionsv1alpha1.WorkerPool) (map[string]interface{}, error) {
 	// handle root disk
 	volumeSize, err := worker.DiskSize(pool.Volume.Size)


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind bug
/platform alicloud

**What this PR does / why we need it**:
Ali doesn't accept empty value as tag value, but some gardener users such as hanacloud set empty value as label value in their shoot yaml. So we need to filter out such label
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bug user
Label without value won't be added as tag in ECS on alicloud
```
