### PR TITLE
add region to image encryption ROS template name

### DIFF
--- a/.ci/test-integration.sh
+++ b/.ci/test-integration.sh
@@ -12,6 +12,6 @@ mkdir -p /tm
     --tm-kubeconfig-path=/tm/kubeconfig \
     --no-execution-group \
     --testrun-prefix tm-extension-alicloud- \
-    --timeout=3600 \
+    --timeout=5400 \
     --testruns-chart-path=.ci/testruns/default \
     --set revision="$(git rev-parse HEAD)"

--- a/.ci/testruns/default/templates/testrun.yaml
+++ b/.ci/testruns/default/templates/testrun.yaml
@@ -36,4 +36,4 @@ spec:
       config:
       - name: REGION
         type: env
-        value: cn-shanghai
+        value: ap-southeast-2

--- a/.ci/testruns/default/templates/testrun.yaml
+++ b/.ci/testruns/default/templates/testrun.yaml
@@ -36,4 +36,4 @@ spec:
       config:
       - name: REGION
         type: env
-        value: eu-central-1
+        value: cn-shanghai

--- a/.test-defs/infrastructure-test.yaml
+++ b/.test-defs/infrastructure-test.yaml
@@ -4,7 +4,7 @@ metadata:
 spec:
   owner: DL_5bac5a9aecb2116334000005@exchange.sap.corp
   description: Integration test for infrastructure creation and deletion
-  activeDeadlineSeconds: 3600
+  activeDeadlineSeconds: 5400
 
   command: [bash, -c]
   args:

--- a/.test-defs/provider-alicloud.yaml
+++ b/.test-defs/provider-alicloud.yaml
@@ -4,7 +4,7 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Generates the alicloud provider specific configurations
-  activeDeadlineSeconds: 3600
+  activeDeadlineSeconds: 5400
 
   command: [bash, -c]
   args:

--- a/pkg/controller/common/encryptimage.go
+++ b/pkg/controller/common/encryptimage.go
@@ -242,11 +242,11 @@ func (ie *imageEncryptor) getEncrytpedImageIDFromStack(stackId string) (string, 
 }
 
 func (ie *imageEncryptor) getStackName() string {
-	return GetEncryptImageStackName(ie.imageName, ie.imageVersion)
+	return GetEncryptImageStackName(ie.imageName, ie.imageVersion, ie.regionID)
 }
 
 // GetEncryptImageStackName returns the encrypt image stack name for the given image name and version.
-func GetEncryptImageStackName(imageName, imageVersion string) string {
-	var rosNameFormat = "encrypt_image_%s_%s"
-	return strings.ReplaceAll(fmt.Sprintf(rosNameFormat, imageName, imageVersion), ".", "-")
+func GetEncryptImageStackName(imageName, imageVersion, regionID string) string {
+	var rosNameFormat = "encrypt_image_%s_%s_%s"
+	return strings.ReplaceAll(fmt.Sprintf(rosNameFormat, imageName, imageVersion, regionID), ".", "-")
 }

--- a/pkg/controller/common/encryptimage_test.go
+++ b/pkg/controller/common/encryptimage_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Encrypt Image tools", func() {
 
 		Describe("#GetEncryptImageStackName", func() {
 			It("should compose correct name", func() {
-				Expect(GetEncryptImageStackName(imageName, imageVersion)).To(Equal("encrypt_image_GardenLinux_1-184-0"))
+				Expect(GetEncryptImageStackName(imageName, imageVersion, regionID)).To(Equal("encrypt_image_GardenLinux_1-184-0_cn-shanghai"))
 			})
 		})
 

--- a/test/integration/infrastructure/common.go
+++ b/test/integration/infrastructure/common.go
@@ -47,6 +47,15 @@ func validateFlags() {
 	}
 }
 
+func getImageId(region string) string {
+	regionImageMap := map[string]string{
+		"cn-shanghai":  "m-uf6a3012pcuemma21nfk",
+		"eu-central-1": "m-gw83xpc3q3yzpoahhckf",
+	}
+
+	return regionImageMap[region]
+}
+
 func getSingleZone(region string) string {
 	regionZoneMap := map[string]string{
 		"cn-shanghai":  "cn-shanghai-g",

--- a/test/integration/infrastructure/common.go
+++ b/test/integration/infrastructure/common.go
@@ -49,8 +49,9 @@ func validateFlags() {
 
 func getImageId(region string) string {
 	regionImageMap := map[string]string{
-		"cn-shanghai":  "m-uf6a3012pcuemma21nfk",
-		"eu-central-1": "m-gw83xpc3q3yzpoahhckf",
+		"cn-shanghai":    "m-uf6a3012pcuemma21nfk",
+		"ap-southeast-2": "m-p0w8c5rj528oj84nlise",
+		"eu-central-1":   "m-gw83xpc3q3yzpoahhckf",
 	}
 
 	return regionImageMap[region]
@@ -58,8 +59,9 @@ func getImageId(region string) string {
 
 func getSingleZone(region string) string {
 	regionZoneMap := map[string]string{
-		"cn-shanghai":  "cn-shanghai-g",
-		"eu-central-1": "eu-central-1a",
+		"cn-shanghai":    "cn-shanghai-g",
+		"ap-southeast-2": "ap-southeast-2a",
+		"eu-central-1":   "eu-central-1a",
 	}
 
 	return regionZoneMap[region]

--- a/test/integration/infrastructure/encrypteimagehelper.go
+++ b/test/integration/infrastructure/encrypteimagehelper.go
@@ -38,7 +38,6 @@ import (
 
 var imageName = "ubuntu"
 var imageVersion = "20.04"
-var plainImageID = "m-gw83xpc3q3yzpoahhckf"
 
 func newCluster(namespace string) (*extensionsv1alpha1.Cluster, error) {
 	providerConfig := &alicloudv1alpha1.CloudProfileConfig{
@@ -55,7 +54,7 @@ func newCluster(namespace string) (*extensionsv1alpha1.Cluster, error) {
 						Regions: []alicloudv1alpha1.RegionIDMapping{
 							{
 								Name: *region,
-								ID:   plainImageID,
+								ID:   getImageId(*region),
 							},
 						},
 					},
@@ -142,7 +141,7 @@ func newCluster(namespace string) (*extensionsv1alpha1.Cluster, error) {
 }
 
 func deleteEncryptedImageStackIfExists(ctx context.Context, clientFactory alicloudclient.ClientFactory) error {
-	stackName := common.GetEncryptImageStackName(imageName, imageVersion)
+	stackName := common.GetEncryptImageStackName(imageName, imageVersion, *region)
 	listRequest := ros.CreateListStacksRequest()
 	listRequest.StackName = &[]string{stackName}
 	listRequest.RegionId = *region
@@ -183,7 +182,7 @@ func deleteEncryptedImageStackIfExists(ctx context.Context, clientFactory aliclo
 }
 
 func verifyStackExists(ctx context.Context, clientFactory alicloudclient.ClientFactory) error {
-	stackName := common.GetEncryptImageStackName(imageName, imageVersion)
+	stackName := common.GetEncryptImageStackName(imageName, imageVersion, *region)
 	listRequest := ros.CreateListStacksRequest()
 	listRequest.StackName = &[]string{stackName}
 	listRequest.RegionId = *region


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug
/platform alicloud

**What this PR does / why we need it**:
Add region id to the name of Stack, which is used to encrypt a VM image. It fixes an issue when one AliCloud account is used to create shoot in 2+ regions. 

Reproduce steps:
1. Create a shoot in one region, whose system disk is encrypted. It will be success.
2. Create and shoot in another region, whose system disk is encrypted. It will fail.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Now it is possible to create shoots with encrypted system disk in more than one regions.
```
