### PR TITLE
fix image name dup issue

### DIFF
--- a/pkg/controller/common/encryptimage.go
+++ b/pkg/controller/common/encryptimage.go
@@ -231,7 +231,7 @@ func (ie *imageEncryptor) getEncrytpedImageIDFromStack(stackId string) (string, 
 	}
 
 	if len(response.Outputs) != 1 {
-		return "", false, fmt.Errorf("the length output for stack %s should be 1 but got %v.\n Output is %v\n The length", stackId, len(response.Outputs), response.Outputs)
+		return "", false, fmt.Errorf("the length output for stack %s should be 1 but got %v.\n Output is %v", stackId, len(response.Outputs), response.Outputs)
 	}
 
 	if response.Outputs[0]["OutputKey"] != "ImageId" {

--- a/pkg/controller/common/encryptimage.go
+++ b/pkg/controller/common/encryptimage.go
@@ -147,7 +147,7 @@ func (ie *imageEncryptor) createStack() (string, error) {
 	parameters := []ros.CreateStackParameters{
 		{ParameterKey: "ImageId", ParameterValue: ie.sourceImageID},
 		{ParameterKey: "DestinationDescription", ParameterValue: fmt.Sprintf("copied from image %s", ie.sourceImageID)},
-		{ParameterKey: "DestinationImageName", ParameterValue: fmt.Sprintf("%s-%s-encrypted", ie.imageName, ie.imageVersion)},
+		{ParameterKey: "DestinationImageName", ParameterValue: fmt.Sprintf("%s-%s-encrypted-%s", ie.imageName, ie.imageVersion, ie.regionID)},
 		{ParameterKey: "DestinationRegionId", ParameterValue: ie.regionID},
 	}
 	stackRequest.Parameters = &parameters
@@ -231,10 +231,10 @@ func (ie *imageEncryptor) getEncrytpedImageIDFromStack(stackId string) (string, 
 	}
 
 	if len(response.Outputs) != 1 {
-		return "", false, fmt.Errorf("The length output for stack %s should be 1 but got %v.\n Output is %v\n The length", stackId, len(response.Outputs), response.Outputs)
+		return "", false, fmt.Errorf("the length output for stack %s should be 1 but got %v.\n Output is %v\n The length", stackId, len(response.Outputs), response.Outputs)
 	}
 
-	if "ImageId" != response.Outputs[0]["OutputKey"] {
+	if response.Outputs[0]["OutputKey"] != "ImageId" {
 		return "", false, fmt.Errorf("output doesn't contain key 'OutputKey' in stack %s", stackId)
 	}
 

--- a/pkg/controller/common/encryptimage.go
+++ b/pkg/controller/common/encryptimage.go
@@ -147,7 +147,7 @@ func (ie *imageEncryptor) createStack() (string, error) {
 	parameters := []ros.CreateStackParameters{
 		{ParameterKey: "ImageId", ParameterValue: ie.sourceImageID},
 		{ParameterKey: "DestinationDescription", ParameterValue: fmt.Sprintf("copied from image %s", ie.sourceImageID)},
-		{ParameterKey: "DestinationImageName", ParameterValue: fmt.Sprintf("%s-%s-encrypted-%s", ie.imageName, ie.imageVersion, ie.regionID)},
+		{ParameterKey: "DestinationImageName", ParameterValue: fmt.Sprintf("%s-%s-%s-encrypted", ie.imageName, ie.imageVersion, ie.regionID)},
 		{ParameterKey: "DestinationRegionId", ParameterValue: ie.regionID},
 	}
 	stackRequest.Parameters = &parameters


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform alicloud

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes issue introduced in https://github.com/gardener/gardener-extension-provider-alicloud/pull/410. The image name should be different if the stack name is different.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
