### PR TITLE
Remove the cleanup logic for AlicloudMachineClasses

### DIFF
--- a/charts/internal/machineclass/Chart.yaml
+++ b/charts/internal/machineclass/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
-description: A Helm chart for AlicloudMachineClasses controlled by the machine-controller-manager in the shoot cluster
+description: A Helm chart for MachineClasses controlled by the machine-controller-manager in the shoot cluster
 name: machineclass
 version: 0.1.0

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -58,11 +58,6 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 		}
 	}
 
-	// Delete any older version of AlicloudMachineClass CRs.
-	if err := w.Client().DeleteAllOf(ctx, &machinev1alpha1.AlicloudMachineClass{}, client.InNamespace(w.worker.Namespace)); err != nil {
-		return err
-	}
-
 	return w.seedChartApplier.Apply(ctx, filepath.Join(alicloud.InternalChartsPath, "machineclass"), w.worker.Namespace, "machineclass", kubernetes.Values(map[string]interface{}{"machineClasses": w.machineClasses}))
 }
 


### PR DESCRIPTION
/area control-plane
/kind cleanup
/platform alicloud

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/456

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
