### PR TITLE
Fix the --version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ IMAGE_PREFIX                := $(REGISTRY)/extensions
 REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 HACK_DIR                    := $(REPO_ROOT)/hack
 VERSION                     := $(shell cat "$(REPO_ROOT)/VERSION")
-LD_FLAGS                    := "-w -X github.com/gardener/$(EXTENSION_PREFIX)-$(NAME)/pkg/version.Version=$(IMAGE_TAG)"
+LD_FLAGS                    := "-w $(shell $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION $(EXTENSION_PREFIX))"
 VERIFY                      := true
 LEADER_ELECTION             := false
 IGNORE_OPERATION_ANNOTATION := true
@@ -81,7 +81,7 @@ start-admission:
 
 .PHONY: install
 install:
-	@LD_FLAGS="-w -X github.com/gardener/$(EXTENSION_PREFIX)-$(NAME)/pkg/version.Version=$(VERSION)" \
+	@LD_FLAGS=$(LD_FLAGS) \
 	$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/install.sh ./...
 
 .PHONY: docker-login


### PR DESCRIPTION
/area ops-productivity
/kind bug
/platform alicloud

It seems that https://github.com/gardener/gardener-extension-provider-alicloud/pull/247 is regressed with https://github.com/gardener/gardener-extension-provider-alicloud/pull/325.

Fixes https://github.com/gardener/gardener-extension-provider-alicloud/issues/431

```
$ docker run eu.gcr.io/gardener-project/gardener/extensions/admission-alicloud:v1.33.0-dev-7778b4239cc3389dcb6959ae669914aeee7896e0 --version
gardener-extension v1.33.0-dev
$ docker run eu.gcr.io/gardener-project/gardener/extensions/admission-alicloud:v1.33.0-dev-7778b4239cc3389dcb6959ae669914aeee7896e0 --version=raw
version.Info{Major:"1", Minor:"33+", GitVersion:"v1.33.0-dev", GitCommit:"7778b4239cc3389dcb6959ae669914aeee7896e0", GitTreeState:"clean", BuildDate:"2022-02-16T09:03:15+00:00", GoVersion:"go1.17.5", Compiler:"gc", Platform:"linux/amd64"}
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `--version` flag is now fixed to properly display the binary/component version and metadata.
```
