### PR TITLE
inject kube token to alicloud diskplugin in the controller deployment

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -59,8 +59,8 @@ images:
   tag: v0.5.0
 - name: csi-plugin-alicloud
   sourceRepository: https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver
-  repository: registry.eu-central-1.aliyuncs.com/acs/csi-plugin
-  tag: v1.22.8-e84838c-aliyun
+  repository: registry.eu-central-1.aliyuncs.com/gardener-de/alicloud-csi-plugin
+  tag: v1.16.9-11c14d43  # temp build for hotfix on v1.22.8-e84838c-aliyun, see PR https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pull/609
 - name: csi-liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: k8s.gcr.io/sig-storage/livenessprobe

--- a/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml
@@ -36,6 +36,11 @@ spec:
         - "--endpoint=$(CSI_ENDPOINT)"
         - "--nodeid=dummy"
         - "--run-as-controller=true"
+        {{- if .Values.global.useTokenRequestor }}
+        - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
+        {{- else }}
+        - "--kubeconfig=/var/lib/csi-controller-ali-plugin/kubeconfig"
+        {{- end }}
         - "--v=5"
         env:
 {{- if .Values.enableADController }}
@@ -46,6 +51,8 @@ spec:
           value: unix://var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com/csi.sock
         - name: SERVICE_TYPE
           value: provisioner
+        - name: INSTALL_SNAPSHOT_CRD
+          value: "false"
         - name: REGION_ID
           value: {{ .Values.regionID }}
         - name: ACCESS_KEY_ID
@@ -79,6 +86,14 @@ spec:
         volumeMounts:
         - name: socket-dir
           mountPath: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com
+        {{- if .Values.global.useTokenRequestor }}
+        - mountPath: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig
+          name: kubeconfig-csi-controller-ali-plugin
+          readOnly: true
+        {{- else }}
+        - name: csi-controller-ali-plugin
+          mountPath: /var/lib/csi-controller-ali-plugin
+        {{- end }}
       - name: alicloud-csi-attacher
         image: {{ index .Values.images "csi-attacher" }}
         args:
@@ -227,6 +242,22 @@ spec:
       - name: socket-dir
         emptyDir: {}
       {{- if .Values.global.useTokenRequestor }}
+      - name: kubeconfig-csi-controller-ali-plugin
+        projected:
+          defaultMode: 420
+          sources:
+            - secret:
+                items:
+                  - key: kubeconfig
+                    path: kubeconfig
+                name: generic-token-kubeconfig
+                optional: false
+            - secret:
+                items:
+                  - key: token
+                    path: token
+                name: shoot-access-csi-controller-ali-plugin
+                optional: false
       - name: kubeconfig-csi-attacher
         projected:
           defaultMode: 420
@@ -292,6 +323,9 @@ spec:
                 name: shoot-access-csi-resizer
                 optional: false
       {{- else }}
+      - name: csi-controller-ali-plugin
+        secret:
+          secretName: csi-controller-ali-plugin
       - name: csi-attacher
         secret:
           secretName: csi-attacher

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-attacher-rbac.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-attacher-rbac.yaml
@@ -16,7 +16,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["persistentvolumes"]
-  verbs: ["get", "list", "watch", "update"]
+  verbs: ["get", "list", "watch", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch", "update"]
@@ -25,7 +25,7 @@ rules:
   verbs: ["get", "list", "watch"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["volumeattachments"]
-  verbs: ["get", "list", "watch", "update"]
+  verbs: ["get", "list", "watch", "update", "patch"]
 {{- if semverCompare ">= 1.17" .Values.kubernetesVersion }}
 - apiGroups: [ "storage.k8s.io" ]
   resources: [ "volumeattachments/status" ]

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-controller-ali-plugin.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-controller-ali-plugin.yaml
@@ -1,0 +1,55 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "csi-disk-plugin.extensionsGroup" . }}:kube-system:csi-controller-ali-plugin
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["list", "watch", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "csi-disk-plugin.extensionsGroup" . }}:csi-controller-ali-plugin
+subjects:
+{{- if .Values.global.useTokenRequestor }}
+- kind: ServiceAccount
+  name: csi-controller-ali-plugin
+  namespace: kube-system
+{{- else }}
+- kind: User
+  name: system:csi-controller-ali-plugin
+{{- end }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "csi-disk-plugin.extensionsGroup" . }}:kube-system:csi-controller-ali-plugin
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kube-system
+  name: csi-controller-ali-plugin
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "nodes"]
+  verbs: ["get"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-controller-ali-plugin
+  namespace: kube-system
+subjects:
+{{- if .Values.global.useTokenRequestor }}
+- kind: ServiceAccount
+  name: csi-controller-ali-plugin
+  namespace: kube-system
+{{- else }}
+- kind: User
+  name: system:csi-controller-ali-plugin
+{{- end }}
+roleRef:
+  kind: Role
+  name: csi-controller-ali-plugin
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -201,7 +201,7 @@ func (s *shootMutator) getImageId(ctx context.Context, imageName string, imageVe
 }
 
 func (s *shootMutator) getCloudProfileConfig(cloudProfile *corev1beta1.CloudProfile) (*api.CloudProfileConfig, error) {
-	var cloudProfileConfig *api.CloudProfileConfig = &api.CloudProfileConfig{}
+	var cloudProfileConfig = &api.CloudProfileConfig{}
 	if _, _, err := s.decoder.Decode(cloudProfile.Spec.ProviderConfig.Raw, nil, cloudProfileConfig); err != nil {
 		return nil, fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", kutil.ObjectName(cloudProfile), err)
 	}

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -125,6 +125,7 @@ var _ = Describe("ValuesProvider", func() {
 
 		checksums = map[string]string{
 			v1beta1constants.SecretNameCloudProvider: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
+			"csi-controller-ali-plugin":              "88ec99cc8fe711ecb9090242ac1200020e5d8c4d398e4f8da67b8a5eaf7efdeb",
 			"cloud-controller-manager":               "3d791b164a808638da9a8df03924be2a41e34cd664e42231c00fe369e3588272",
 			"csi-attacher":                           "2da58ad61c401a2af779a909d22fb42eed93a1524cbfdab974ceedb413fcb914",
 			"csi-provisioner":                        "f75b42d40ab501428c383dfb2336cb1fc892bbee1fc1d739675171e4acc4d911",
@@ -162,11 +163,12 @@ var _ = Describe("ValuesProvider", func() {
 					"snapshotPrefix":         "myshoot",
 					"persistentVolumePrefix": "myshoot",
 					"podAnnotations": map[string]interface{}{
-						"checksum/secret-csi-attacher":    "2da58ad61c401a2af779a909d22fb42eed93a1524cbfdab974ceedb413fcb914",
-						"checksum/secret-csi-provisioner": "f75b42d40ab501428c383dfb2336cb1fc892bbee1fc1d739675171e4acc4d911",
-						"checksum/secret-csi-snapshotter": "bf417dd97dc3e8c2092bb5b2ba7b0f1093ebc4bb5952091ee554cf5b7ea74508",
-						"checksum/secret-csi-resizer":     "5df115bd53f09da2d6d27bfb048c14dabd14a66608cfdba5ecd2d0687889cc6a",
-						"checksum/secret-cloudprovider":   "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
+						"checksum/secret-csi-controller-ali-plugin": "88ec99cc8fe711ecb9090242ac1200020e5d8c4d398e4f8da67b8a5eaf7efdeb",
+						"checksum/secret-csi-attacher":              "2da58ad61c401a2af779a909d22fb42eed93a1524cbfdab974ceedb413fcb914",
+						"checksum/secret-csi-provisioner":           "f75b42d40ab501428c383dfb2336cb1fc892bbee1fc1d739675171e4acc4d911",
+						"checksum/secret-csi-snapshotter":           "bf417dd97dc3e8c2092bb5b2ba7b0f1093ebc4bb5952091ee554cf5b7ea74508",
+						"checksum/secret-csi-resizer":               "5df115bd53f09da2d6d27bfb048c14dabd14a66608cfdba5ecd2d0687889cc6a",
+						"checksum/secret-cloudprovider":             "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
 					},
 				},
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform alicloud

**What this PR does / why we need it**:
AliCloud CSI need kubeconfig to create k8s go-client, though no k8s authorization are needed to be granted.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
