### PR TITLE
Keep `cloud-controller-manager`'s `ClusterRoleBinding` on deletion

### DIFF
--- a/charts/internal/shoot-system-components/charts/alicloud-cloud-controller-manager/templates/rbac-cloud-controller-manager.yaml
+++ b/charts/internal/shoot-system-components/charts/alicloud-cloud-controller-manager/templates/rbac-cloud-controller-manager.yaml
@@ -2,7 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: extensions.gardener.cloud:{{ .Values.providerName }}:cloud-controller-manager
+  name: extensions.gardener.cloud:provider-alicloud:cloud-controller-manager
+  annotations:
+    resources.gardener.cloud/keep-object: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/platform alicloud

**What this PR does / why we need it**:
With #405, a new `ClusterRoleBinding` for the `cloud-controller-manager` was added which is deployed in case the token requestor is enabled.

When the `ControlPlane` resource gets deleted then this `ClusterRoleBinding` will also be deleted. However, when the `shoot-system-components` chart contains resource the `cloud-controller-manager` operates on then it gets locked out and looses the needed permissions.

In this case, there is no such example yet, however, it could be introduced tomorrow and we should be resilient against it. As an example: `provider-azure` is deploying load balancer `Service`s and deleting them without the `ClusterRoleBinding` is not possible.

Consequently, let's keep the resource in the system to ensure `cloud-controller-manager` is working as expected (we do this similarly also in other critical control plane components ([example](https://github.com/gardener/gardener/blob/0296476da3a3ee0c4e39acda2f563e09306385f6/pkg/operation/botanist/component/resourcemanager/resource_manager.go#L842)). 

On the way, the name of the resource was fixed (there is no `providerName` value in the chart).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
