### PR TITLE
Add release milestone check action

### DIFF
--- a/.github/workflows/release-milestone.yaml
+++ b/.github/workflows/release-milestone.yaml
@@ -1,0 +1,66 @@
+name: 'Release Milestone Check'
+on:
+  pull_request_target:
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
+    - unlabeled
+
+jobs:
+  check-release-milestone:
+    name: Check Release Milestone
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: './'
+
+    - id: version
+      run: |
+        echo "::set-output name=version::$(cat ./VERSION)"
+
+    - name: Block merge if release milestone is missing
+      uses: actions/github-script@v4
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const nextMinorRegex = /^(v[0-9]+\.[0-9]+)\.0-dev/gmi;
+
+          let match = nextMinorRegex.exec('${{ steps.version.outputs.version }}');
+          if (match == null) {
+            core.info('VERSION does not indicate that the next version is a new minor release - skipping check');
+            return;
+          }
+          const nextMinorVersion = match[1];
+
+          const milestones = await github.issues.listMilestones({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            sort: 'due_on',
+            direction: 'desc'
+          });
+
+          let milestoneForNextMinorReleaseFound = false;
+
+          for (const milestone of milestones.data) {
+            if (milestone.title != nextMinorVersion) {
+              continue;
+            }
+
+            // milestone found, check if PR is associated
+            milestoneForNextMinorReleaseFound = true;
+
+            if (context.payload.pull_request.milestone == null) {
+              core.setFailed('Milestone for next minor release ' + nextMinorVersion + ' found, however, PR is not milestoned for it. Merge is not allowed.');
+              return
+            }
+          }
+
+          if (milestoneForNextMinorReleaseFound) {
+            core.info('Milestone for next minor release ' + nextMinorVersion + ' found and PR is milestoned for it. Merge is allowed.');
+          } else {
+            core.info('Milestone for next minor release ' + nextMinorVersion + ' not found. Merge is allowed.');
+          }


### PR DESCRIPTION
/area delivery
/kind enhancement
/platform alicloud

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/385

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
