### PR TITLE
Use projected token mount for terraformer

### DIFF
--- a/cmd/gardener-extension-provider-alicloud/app/app.go
+++ b/cmd/gardener-extension-provider-alicloud/app/app.go
@@ -192,6 +192,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				controllercmd.LogErrAndExit(err, "Could not determine whether service account token volume projection should be used")
 			}
 			alicloudcontrolplane.DefaultAddOptions.UseProjectedTokenMount = useProjectedTokenMount
+			alicloudinfrastructure.DefaultAddOptions.UseProjectedTokenMount = useProjectedTokenMount
 			alicloudworker.DefaultAddOptions.UseProjectedTokenMount = useProjectedTokenMount
 
 			configFileOpts.Completed().ApplyMachineImageOwnerSecretRef(&alicloudinfrastructure.DefaultAddOptions.MachineImageOwnerSecretRef)

--- a/pkg/controller/common/terraform.go
+++ b/pkg/controller/common/terraform.go
@@ -51,8 +51,17 @@ type tfStateResource struct {
 }
 
 // NewTerraformer creates a new Terraformer.
-func NewTerraformer(logger logr.Logger, factory terraformer.Factory, config *rest.Config, purpose string, infra *extensionsv1alpha1.Infrastructure) (terraformer.Terraformer, error) {
-
+func NewTerraformer(
+	logger logr.Logger,
+	factory terraformer.Factory,
+	config *rest.Config,
+	purpose string,
+	infra *extensionsv1alpha1.Infrastructure,
+	useProjectedTokenMount bool,
+) (
+	terraformer.Terraformer,
+	error,
+) {
 	tf, err := factory.NewForConfig(logger, config, purpose, infra.Namespace, infra.Name, imagevector.TerraformerImage())
 	if err != nil {
 		return nil, err
@@ -60,6 +69,7 @@ func NewTerraformer(logger logr.Logger, factory terraformer.Factory, config *res
 
 	owner := metav1.NewControllerRef(infra, extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.InfrastructureResource))
 	return tf.
+		UseProjectedTokenMount(useProjectedTokenMount).
 		SetLogLevel("info").
 		SetTerminationGracePeriodSeconds(630).
 		SetDeadlineCleaning(5 * time.Minute).
@@ -68,8 +78,18 @@ func NewTerraformer(logger logr.Logger, factory terraformer.Factory, config *res
 }
 
 // NewTerraformerWithAuth creates a new Terraformer and initializes it with the credentials.
-func NewTerraformerWithAuth(logger logr.Logger, factory terraformer.Factory, config *rest.Config, purpose string, infra *extensionsv1alpha1.Infrastructure) (terraformer.Terraformer, error) {
-	tf, err := NewTerraformer(logger, factory, config, purpose, infra)
+func NewTerraformerWithAuth(
+	logger logr.Logger,
+	factory terraformer.Factory,
+	config *rest.Config,
+	purpose string,
+	infra *extensionsv1alpha1.Infrastructure,
+	useProjectedTokenMount bool,
+) (
+	terraformer.Terraformer,
+	error,
+) {
+	tf, err := NewTerraformer(logger, factory, config, purpose, infra, useProjectedTokenMount)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/common/terraform_test.go
+++ b/pkg/controller/common/terraform_test.go
@@ -66,15 +66,17 @@ var _ = Describe("Terraform", func() {
 	Describe("#NewTerraformer", func() {
 		It("should create a new terraformer", func() {
 			var (
-				factory = mockterraformer.NewMockFactory(ctrl)
-				tf      = mockterraformer.NewMockTerraformer(ctrl)
-				config  rest.Config
+				factory                = mockterraformer.NewMockFactory(ctrl)
+				tf                     = mockterraformer.NewMockTerraformer(ctrl)
+				config                 rest.Config
+				useProjectedTokenMount = false
 			)
 
 			gomock.InOrder(
 				factory.EXPECT().
 					NewForConfig(gomock.Any(), &config, purpose, infra.Namespace, infra.Name, imagevector.TerraformerImage()).
 					Return(tf, nil),
+				tf.EXPECT().UseProjectedTokenMount(useProjectedTokenMount).Return(tf),
 				tf.EXPECT().SetLogLevel("info").Return(tf),
 				tf.EXPECT().SetTerminationGracePeriodSeconds(int64(630)).Return(tf),
 				tf.EXPECT().SetDeadlineCleaning(5*time.Minute).Return(tf),
@@ -82,7 +84,7 @@ var _ = Describe("Terraform", func() {
 				tf.EXPECT().SetOwnerRef(owner).Return(tf),
 			)
 
-			actual, err := NewTerraformer(logger, factory, &config, purpose, infra)
+			actual, err := NewTerraformer(logger, factory, &config, purpose, infra, useProjectedTokenMount)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(actual).To(BeIdenticalTo(tf))
 		})
@@ -91,15 +93,17 @@ var _ = Describe("Terraform", func() {
 	Describe("#NewTerraformerWithAuth", func() {
 		It("should create a new terraformer and initialize it with the credentials", func() {
 			var (
-				factory = mockterraformer.NewMockFactory(ctrl)
-				tf      = mockterraformer.NewMockTerraformer(ctrl)
-				config  rest.Config
+				factory                = mockterraformer.NewMockFactory(ctrl)
+				tf                     = mockterraformer.NewMockTerraformer(ctrl)
+				config                 rest.Config
+				useProjectedTokenMount = false
 			)
 
 			gomock.InOrder(
 				factory.EXPECT().
 					NewForConfig(gomock.Any(), &config, purpose, infra.Namespace, infra.Name, imagevector.TerraformerImage()).
 					Return(tf, nil),
+				tf.EXPECT().UseProjectedTokenMount(useProjectedTokenMount).Return(tf),
 				tf.EXPECT().SetLogLevel("info").Return(tf),
 				tf.EXPECT().SetTerminationGracePeriodSeconds(int64(630)).Return(tf),
 				tf.EXPECT().SetDeadlineCleaning(5*time.Minute).Return(tf),
@@ -108,7 +112,7 @@ var _ = Describe("Terraform", func() {
 				tf.EXPECT().SetEnvVars(TerraformerEnvVars(infra.Spec.SecretRef)).Return(tf),
 			)
 
-			actual, err := NewTerraformerWithAuth(logger, factory, &config, purpose, infra)
+			actual, err := NewTerraformerWithAuth(logger, factory, &config, purpose, infra, useProjectedTokenMount)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(actual).To(BeIdenticalTo(tf))
 		})

--- a/pkg/controller/infrastructure/actuator_test.go
+++ b/pkg/controller/infrastructure/actuator_test.go
@@ -141,6 +141,7 @@ var _ = Describe("Actuator", func() {
 					terraformChartOps,
 					nil,
 					nil,
+					false,
 				)
 				c = mockclient.NewMockClient(ctrl)
 				initializer = mockterraformer.NewMockInitializer(ctrl)
@@ -250,6 +251,7 @@ var _ = Describe("Actuator", func() {
 					terraformerFactory.EXPECT().NewForConfig(gomock.Any(), &restConfig, TerraformerPurpose, infra.Namespace, infra.Name, imagevector.TerraformerImage()).
 						Return(terraformer, nil),
 
+					terraformer.EXPECT().UseProjectedTokenMount(false).Return(terraformer),
 					terraformer.EXPECT().SetLogLevel("info").Return(terraformer),
 					terraformer.EXPECT().SetTerminationGracePeriodSeconds(int64(630)).Return(terraformer),
 					terraformer.EXPECT().SetDeadlineCleaning(5*time.Minute).Return(terraformer),
@@ -347,6 +349,7 @@ var _ = Describe("Actuator", func() {
 					terraformerFactory.EXPECT().NewForConfig(gomock.Any(), &restConfig, TerraformerPurpose, infra.Namespace, infra.Name, imagevector.TerraformerImage()).
 						Return(terraformer, nil),
 
+					terraformer.EXPECT().UseProjectedTokenMount(false).Return(terraformer),
 					terraformer.EXPECT().SetLogLevel("info").Return(terraformer),
 					terraformer.EXPECT().SetTerminationGracePeriodSeconds(int64(630)).Return(terraformer),
 					terraformer.EXPECT().SetDeadlineCleaning(5*time.Minute).Return(terraformer),

--- a/pkg/controller/infrastructure/add.go
+++ b/pkg/controller/infrastructure/add.go
@@ -38,13 +38,15 @@ type AddOptions struct {
 	MachineImageOwnerSecretRef *corev1.SecretReference
 	// ToBeSharedImageIDs specifies custom image IDs which need to be shared by shoots
 	ToBeSharedImageIDs []string
+	// UseProjectedTokenMount specifies whether the projected token mount shall be used for the terraformer.
+	UseProjectedTokenMount bool
 }
 
 // AddToManagerWithOptions adds a controller with the given AddOptions to the given manager.
 // The opts.Reconciler is being set with a newly instantiated actuator.
 func AddToManagerWithOptions(mgr manager.Manager, options AddOptions) error {
 	return infrastructure.Add(mgr, infrastructure.AddArgs{
-		Actuator:          NewActuator(options.MachineImageOwnerSecretRef, options.ToBeSharedImageIDs),
+		Actuator:          NewActuator(options.MachineImageOwnerSecretRef, options.ToBeSharedImageIDs, options.UseProjectedTokenMount),
 		ControllerOptions: options.Controller,
 		Predicates:        infrastructure.DefaultPredicates(options.IgnoreOperationAnnotation),
 		Type:              alicloud.Type,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR enables projected token mounts for the `terraformer` pods.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#4659
Part of gardener/gardener#4878

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `terraformer` pod deployed as part of shoot control planes is now using auto-rotated `ServiceAccount` tokens when communicating with the seed cluster.
```
