### PR TITLE
Improve grafana dashboards

### DIFF
--- a/charts/internal/machine-controller-manager/seed/mcm-monitoring-dashboard.json
+++ b/charts/internal/machine-controller-manager/seed/mcm-monitoring-dashboard.json
@@ -1168,7 +1168,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Machine Controller Manager",
   "uid": "machine-controller-manager",
   "version": 1

--- a/charts/internal/machine-controller-manager/seed/mcm-monitoring-dashboard.json
+++ b/charts/internal/machine-controller-manager/seed/mcm-monitoring-dashboard.json
@@ -1070,7 +1070,6 @@
       }
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/ccm-observability-dashboard.json
+++ b/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/ccm-observability-dashboard.json
@@ -359,7 +359,6 @@
       "type": "logs"
     }
   ],
-  "refresh": "1m",
   "schemaVersion": 26,
   "style": "dark",
   "tags": [

--- a/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/ccm-observability-dashboard.json
+++ b/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/ccm-observability-dashboard.json
@@ -476,7 +476,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Cloud Controller Manager",
   "uid": "cloud-controller-manager",
   "version": 1

--- a/charts/internal/seed-controlplane/charts/csi-alicloud/csi-plugin-controller-dashboard.json
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/csi-plugin-controller-dashboard.json
@@ -270,7 +270,6 @@
         "type": "logs"
       }
     ],
-    "refresh": "1m",
     "schemaVersion": 26,
     "style": "dark",
     "tags": [

--- a/charts/internal/seed-controlplane/charts/csi-alicloud/csi-plugin-controller-dashboard.json
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/csi-plugin-controller-dashboard.json
@@ -413,7 +413,7 @@
         "14d"
       ]
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "CSI Plugin Controller",
     "uid": "csi-plugin-controller",
     "version": 1

--- a/charts/internal/seed-controlplane/charts/csi-alicloud/csi-plugin-controller-dashboard.json
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/csi-plugin-controller-dashboard.json
@@ -1,419 +1,419 @@
 {
-    "annotations": {
-      "list": []
-    },
-    "editable": true,
-    "gnetId": null,
-    "graphTooltip": 0,
-    "iteration": 1606223885278,
-    "links": [],
-    "panels": [
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": null,
-        "description": "Shows the CPU usage and shows the requests and limits.",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {},
-            "links": []
-          },
-          "overrides": []
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1606223885278,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Shows the CPU usage and shows the requests and limits.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
         },
-        "fill": 0,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 7,
-          "w": 12,
-          "x": 0,
-          "y": 0
-        },
-        "hiddenSeries": false,
-        "id": 41,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "nullPointMode": "null",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": false,
-        "pluginVersion": "7.2.1",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"csi-plugin-controller-(.+)\"}[$__rate_interval])) by (pod)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "{{pod}}-current",
-            "refId": "A"
-          },
-          {
-            "expr": "sum(kube_pod_container_resource_limits_cpu_cores{pod=~\"csi-plugin-controller-(.+)\"}) by (pod)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "{{pod}}-limits",
-            "refId": "C"
-          },
-          {
-            "expr": "sum(kube_pod_container_resource_requests_cpu_cores{pod=~\"csi-plugin-controller-(.+)\"}) by (pod)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "{{pod}}-requests",
-            "refId": "B"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "CPU usage",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "decimals": null,
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "overrides": []
       },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": null,
-        "description": "Shows the memory usage.",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {},
-            "links": []
-          },
-          "overrides": []
-        },
-        "fill": 0,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 7,
-          "w": 12,
-          "x": 12,
-          "y": 0
-        },
-        "hiddenSeries": false,
-        "id": 24,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "nullPointMode": "null",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": false,
-        "pluginVersion": "7.2.1",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "sum(container_memory_working_set_bytes{pod=~\"csi-plugin-controller-(.+)\"}) by (pod)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "{{pod}}-current",
-            "refId": "A"
-          },
-          {
-            "expr": "sum(kube_pod_container_resource_limits_memory_bytes{pod=~\"csi-plugin-controller-(.+)\"}) by (pod)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "{{pod}}-limits",
-            "refId": "B"
-          },
-          {
-            "expr": "sum(kube_pod_container_resource_requests_memory_bytes{pod=~\"csi-plugin-controller-(.+)\"}) by (pod)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "{{pod}}-requests",
-            "refId": "C"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Memory Usage",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "bytes",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          },
-          {
-            "format": "none",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": false
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 0
       },
-      {
-        "datasource": "loki",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {}
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 17,
-          "w": 24,
-          "x": 0,
-          "y": 7
-        },
-        "id": 43,
-        "interval": "",
-        "options": {
-          "showLabels": false,
-          "showTime": true,
-          "sortOrder": "Descending",
-          "wrapLogMessage": false
-        },
-        "targets": [
-          {
-            "expr": "{pod_name=~\"csi-plugin-controller-(.+)\", container_name=~\"$container\", severity=~\"$severity\"} |~ \"$search\"",
-            "legendFormat": "",
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Logs",
-        "type": "logs"
-      }
-    ],
-    "schemaVersion": 26,
-    "style": "dark",
-    "tags": [
-      "controlplane",
-      "seed",
-      "logging"
-    ],
-    "templating": {
-      "list": [
+      "hiddenSeries": false,
+      "id": 41,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
         {
-          "allValue": null,
-          "current": {
-            "selected": false,
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"csi-plugin-controller-(.+)\"}[$__rate_interval])) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}-current",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(kube_pod_container_resource_limits_cpu_cores{pod=~\"csi-plugin-controller-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}-limits",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{pod=~\"csi-plugin-controller-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}-requests",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Shows the memory usage.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(container_memory_working_set_bytes{pod=~\"csi-plugin-controller-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}-current",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(kube_pod_container_resource_limits_memory_bytes{pod=~\"csi-plugin-controller-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}-limits",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(kube_pod_container_resource_requests_memory_bytes{pod=~\"csi-plugin-controller-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}-requests",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": "loki",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 17,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 43,
+      "interval": "",
+      "options": {
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "expr": "{pod_name=~\"csi-plugin-controller-(.+)\", container_name=~\"$container\", severity=~\"$severity\"} |~ \"$search\"",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Logs",
+      "type": "logs"
+    }
+  ],
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [
+    "controlplane",
+    "seed",
+    "logging"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "prometheus",
+        "definition": "label_values(kube_pod_container_info{type=~\"seed\", pod=~\"csi-plugin-controller.+\"}, container)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Container",
+        "multi": false,
+        "name": "container",
+        "options": [],
+        "query": "label_values(kube_pod_container_info{type=~\"seed\", pod=~\"csi-plugin-controller.+\"}, container)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Severity",
+        "multi": true,
+        "name": "severity",
+        "options": [
+          {
+            "selected": true,
             "text": "All",
             "value": "$__all"
           },
-          "datasource": "prometheus",
-          "definition": "label_values(kube_pod_container_info{type=~\"seed\", pod=~\"csi-plugin-controller.+\"}, container)",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Container",
-          "multi": false,
-          "name": "container",
-          "options": [],
-          "query": "label_values(kube_pod_container_info{type=~\"seed\", pod=~\"csi-plugin-controller.+\"}, container)",
-          "refresh": 2,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "tagValuesQuery": "",
-          "tags": [],
-          "tagsQuery": "",
-          "type": "query",
-          "useTags": false
-        },
-        {
-          "allValue": ".+",
-          "current": {
-            "selected": true,
-            "tags": [],
-            "text": "All",
-            "value": [
-              "$__all"
-            ]
-          },
-          "hide": 0,
-          "includeAll": true,
-          "label": "Severity",
-          "multi": true,
-          "name": "severity",
-          "options": [
-            {
-              "selected": true,
-              "text": "All",
-              "value": "$__all"
-            },
-            {
-              "selected": false,
-              "text": "INFO",
-              "value": "INFO"
-            },
-            {
-              "selected": false,
-              "text": "WARN",
-              "value": "WARN"
-            },
-            {
-              "selected": false,
-              "text": "ERR",
-              "value": "ERR"
-            },
-            {
-              "selected": false,
-              "text": "DBG",
-              "value": "DBG"
-            },
-            {
-              "selected": false,
-              "text": "NOTICE",
-              "value": "NOTICE"
-            },
-            {
-              "selected": false,
-              "text": "FATAL",
-              "value": "FATAL"
-            }
-          ],
-          "query": "INFO,WARN,ERR,DBG,NOTICE,FATAL",
-          "queryValue": "",
-          "skipUrlSync": false,
-          "type": "custom"
-        },
-        {
-          "current": {
+          {
             "selected": false,
+            "text": "INFO",
+            "value": "INFO"
+          },
+          {
+            "selected": false,
+            "text": "WARN",
+            "value": "WARN"
+          },
+          {
+            "selected": false,
+            "text": "ERR",
+            "value": "ERR"
+          },
+          {
+            "selected": false,
+            "text": "DBG",
+            "value": "DBG"
+          },
+          {
+            "selected": false,
+            "text": "NOTICE",
+            "value": "NOTICE"
+          },
+          {
+            "selected": false,
+            "text": "FATAL",
+            "value": "FATAL"
+          }
+        ],
+        "query": "INFO,WARN,ERR,DBG,NOTICE,FATAL",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "label": "Search",
+        "name": "search",
+        "options": [
+          {
+            "selected": true,
             "text": "",
             "value": ""
-          },
-          "hide": 0,
-          "label": "Search",
-          "name": "search",
-          "options": [
-            {
-              "selected": true,
-              "text": "",
-              "value": ""
-            }
-          ],
-          "query": "",
-          "skipUrlSync": false,
-          "type": "textbox"
-        }
-      ]
-    },
-    "time": {
-      "from": "now-30m",
-      "to": "now"
-    },
-    "timepicker": {
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h"
-      ],
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "3h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "14d"
-      ]
-    },
-    "timezone": "utc",
-    "title": "CSI Plugin Controller",
-    "uid": "csi-plugin-controller",
-    "version": 1
-  }
+          }
+        ],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "3h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "14d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "CSI Plugin Controller",
+  "uid": "csi-plugin-controller",
+  "version": 1
+}


### PR DESCRIPTION
/area monitoring
/kind enhancement
/platform alicloud
/squash

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/503.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The monitoring dashboards provided by this extension:
- are now using UTC by default (instead of the browser time)
- do no longer auto refresh by default
```
