### PR TITLE
[release-v1.33] Automated cherry pick of #454: Allow projected volumes in PSP

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-plugin-psp.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-plugin-psp.yaml
@@ -7,6 +7,7 @@ spec:
   allowPrivilegeEscalation: true
   volumes:
   - hostPath
+  - projected
   - secret
   hostNetwork: true
   allowedHostPaths:


### PR DESCRIPTION
/area/security
/kind/bug

Cherry pick of #454 on release-v1.33.

#454: Allow projected volumes in PSP

**Release Notes:**
```bugfix operator
An issue has been fixed with the `csi-driver-node` PodSecurityPolicy which blocked the creation of new CSI-Driver pods because `projected` volumes are not permitted.
```