### PR TITLE
Keep kubelet's `--cloud-provider` flag even for 1.23+

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -127,9 +127,9 @@ func ensureKubeletCommandLineArgs(command []string, kubeletVersion *semver.Versi
 	// reference environment variables like it's possible today with the CLI parameters.
 	// See https://github.com/kubernetes/kubernetes/pull/90494
 	command = extensionswebhook.EnsureStringWithPrefix(command, "--provider-id=", "${PROVIDER_ID}")
+	command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
 
 	if !version.ConstraintK8sGreaterEqual123.Check(kubeletVersion) {
-		command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
 		command = extensionswebhook.EnsureStringWithPrefix(command, "--enable-controller-attach-detach=", "true")
 	}
 

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -245,7 +245,7 @@ var _ = Describe("Ensurer", func() {
 			},
 
 			Entry("kubelet version < 1.23", eContext18, semver.MustParse("1.20.0"), "external", true),
-			Entry("kubelet version >= 1.23", eContext18, semver.MustParse("1.23.0"), "", false),
+			Entry("kubelet version >= 1.23", eContext18, semver.MustParse("1.23.0"), "external", false),
 		)
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/platform alicloud

**What this PR does / why we need it**:
Even for 1.23, the `providerID` field in the `NodeSpec` is not maintained without this field, making it impossible for load balancers to function correctly.

**Special notes for your reviewer**:
See for reference: https://github.com/gardener/gardener-extension-provider-aws/issues/514#issuecomment-1064163827 and https://github.com/gardener/gardener-extension-provider-aws/pull/515

/invite @ialidzhikov

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue preventing load balancers from being functional for K8s 1.23 clusters has been fixed.
```
