### PR TITLE
[release-v1.33] Automated cherry pick of #459: Keep kubelet's `--cloud-provider` flag even for 1.23+

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -127,9 +127,9 @@ func ensureKubeletCommandLineArgs(command []string, kubeletVersion *semver.Versi
 	// reference environment variables like it's possible today with the CLI parameters.
 	// See https://github.com/kubernetes/kubernetes/pull/90494
 	command = extensionswebhook.EnsureStringWithPrefix(command, "--provider-id=", "${PROVIDER_ID}")
+	command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
 
 	if !version.ConstraintK8sGreaterEqual123.Check(kubeletVersion) {
-		command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
 		command = extensionswebhook.EnsureStringWithPrefix(command, "--enable-controller-attach-detach=", "true")
 	}
 

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -245,7 +245,7 @@ var _ = Describe("Ensurer", func() {
 			},
 
 			Entry("kubelet version < 1.23", eContext18, semver.MustParse("1.20.0"), "external", true),
-			Entry("kubelet version >= 1.23", eContext18, semver.MustParse("1.23.0"), "", false),
+			Entry("kubelet version >= 1.23", eContext18, semver.MustParse("1.23.0"), "external", false),
 		)
 	})
 


### PR DESCRIPTION
/area/usability
/kind/bug

Cherry pick of #459 on release-v1.33.

#459: Keep kubelet's `--cloud-provider` flag even for 1.23+

**Release Notes:**
```bugfix user
An issue preventing load balancers from being functional for K8s 1.23 clusters has been fixed.
```