### PR TITLE
Update kubernetes-csi/external-snapshotter

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -11,15 +11,12 @@ images:
   sourceRepository: github.com/gardener/machine-controller-manager-provider-alicloud
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-alicloud
   tag: "v0.3.0"
+
 - name: alicloud-controller-manager
   sourceRepository: https://github.com/kubernetes/cloud-provider-alibaba-cloud
   repository: registry.eu-central-1.aliyuncs.com/gardener-de/alibaba-cloud-controller-manager
   tag: v1.9.3-372 # the upstream image is using non-semver tag (registry.cn-shanghai.aliyuncs.com/acs/cloud-controller-manager-amd64:v1.9.3.372-gcf3535b-aliyun).
-- name: csi-attacher
-  sourceRepository: https://github.com/kubernetes-csi/external-attacher
-  repository: k8s.gcr.io/sig-storage/csi-attacher
-  tag: v2.2.0
-  targetVersion: "< 1.17"
+
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: k8s.gcr.io/sig-storage/csi-attacher
@@ -32,27 +29,17 @@ images:
 - name: csi-provisioner
   sourceRepository: https://github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner
-  tag: v1.6.0
-  targetVersion: "< 1.17"
-- name: csi-provisioner
-  sourceRepository: https://github.com/kubernetes-csi/external-provisioner
-  repository: k8s.gcr.io/sig-storage/csi-provisioner
   tag: v2.1.2
   targetVersion: ">= 1.17"
 - name: csi-snapshotter
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
-  repository: quay.io/k8scsi/csi-snapshotter
-  tag: v1.2.2
-  targetVersion: "< 1.17"
-- name: csi-snapshotter
-  sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/csi-snapshotter
-  tag: v2.1.5
+  tag: v3.0.3
   targetVersion: ">= 1.17"
 - name: csi-snapshot-controller
   sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/snapshot-controller
-  tag: v2.1.5
+  tag: v3.0.3
 - name: csi-resizer
   sourceRepository: https://github.com/kubernetes-csi/external-resizer
   repository: k8s.gcr.io/sig-storage/csi-resizer


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following images are updated (see [CHANGELOG](https://github.com/kubernetes-csi/external-snapshotter/blob/v3.0.3/CHANGELOG/CHANGELOG-3.0.md) for more details):
- k8s.gcr.io/sig-storage/csi-snapshotter: v2.1.5 -> v3.0.3
- k8s.gcr.io/sig-storage/snapshot-controller: v2.1.5 -> v3.0.3
```
