### PR TITLE
Removed validation blocking sfz

### DIFF
--- a/pkg/apis/alicloud/validation/shoot.go
+++ b/pkg/apis/alicloud/validation/shoot.go
@@ -99,10 +99,6 @@ func ValidateWorkers(workers []core.Worker, zones []apisalicloud.Zone, fldPath *
 			continue
 		}
 
-		if worker.Maximum != 0 && worker.Minimum == 0 {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Index(i).Child("minimum"), "minimum value must be >= 1 if maximum value > 0 (cluster-autoscaler cannot handle min=0)"))
-		}
-
 		allErrs = append(allErrs, validateZones(worker.Zones, alicloudZones, fldPath.Index(i).Child("zones"))...)
 	}
 

--- a/pkg/apis/alicloud/validation/shoot_test.go
+++ b/pkg/apis/alicloud/validation/shoot_test.go
@@ -267,20 +267,6 @@ var _ = Describe("Shoot validation", func() {
 				))
 			})
 
-			It("should forbid because worker setting maximum > 0 and minimum = 0", func() {
-				workers[0].Maximum = 1
-				workers[0].Minimum = 0
-
-				errorList := ValidateWorkers(workers, alicloudZones, field.NewPath("workers"))
-
-				Expect(errorList).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeForbidden),
-						"Field": Equal("workers[0].minimum"),
-					})),
-				))
-			})
-
 			It("should pass because worker setting maximum = 0 and minimum = 0", func() {
 				workers[0].Maximum = 0
 				workers[0].Minimum = 0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug
/platform alicloud

**What this PR does / why we need it**:
Removed a validation which stopped worker grp from having min 0.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
A patch release would be needed as the other changes related to same feature are already out in the last release.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Users could configure worker pools to have min 0
```
