### PR TITLE
Automated cherry pick of #478: removed validation blocking sfz

### DIFF
--- a/pkg/apis/alicloud/validation/shoot.go
+++ b/pkg/apis/alicloud/validation/shoot.go
@@ -99,10 +99,6 @@ func ValidateWorkers(workers []core.Worker, zones []apisalicloud.Zone, fldPath *
 			continue
 		}
 
-		if worker.Maximum != 0 && worker.Minimum == 0 {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Index(i).Child("minimum"), "minimum value must be >= 1 if maximum value > 0 (cluster-autoscaler cannot handle min=0)"))
-		}
-
 		allErrs = append(allErrs, validateZones(worker.Zones, alicloudZones, fldPath.Index(i).Child("zones"))...)
 	}
 

--- a/pkg/apis/alicloud/validation/shoot_test.go
+++ b/pkg/apis/alicloud/validation/shoot_test.go
@@ -267,20 +267,6 @@ var _ = Describe("Shoot validation", func() {
 				))
 			})
 
-			It("should forbid because worker setting maximum > 0 and minimum = 0", func() {
-				workers[0].Maximum = 1
-				workers[0].Minimum = 0
-
-				errorList := ValidateWorkers(workers, alicloudZones, field.NewPath("workers"))
-
-				Expect(errorList).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeForbidden),
-						"Field": Equal("workers[0].minimum"),
-					})),
-				))
-			})
-
 			It("should pass because worker setting maximum = 0 and minimum = 0", func() {
 				workers[0].Maximum = 0
 				workers[0].Minimum = 0


### PR DESCRIPTION
Cherry pick of #478 on release-v1.35.

#478: removed validation blocking sfz

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```bugfix user
Users could configure worker pools to have min 0
```