### PR TITLE
Allow MCM to list VolumeAttachments

### DIFF
--- a/charts/internal/machine-controller-manager/shoot/templates/clusterrole-machine-controller-manager.yaml
+++ b/charts/internal/machine-controller-manager/shoot/templates/clusterrole-machine-controller-manager.yaml
@@ -62,8 +62,16 @@ rules:
   - watch
 - apiGroups:
   - policy
+  resources:
+  - poddisruptionbudgets
   verbs:
   - list
   - watch
+- apiGroups:
+  - storage.k8s.io
   resources:
-  - poddisruptionbudgets
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
/area control-plane
/kind regression
/platform alicloud

Currently machine-controller-manager-provider-alicloud fails with:
```
E0517 06:37:37.953070       1 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1.VolumeAttachment: failed to list *v1.VolumeAttachment: volumeattachments.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:machine-controller-manager" cannot list resource "volumeattachments" in API group "storage.k8s.io" at the cluster scope
I0517 06:38:12.703224       1 reflector.go:255] Listing and watching *v1.VolumeAttachment from k8s.io/client-go/informers/factory.go:134
E0517 06:38:12.705445       1 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1.VolumeAttachment: failed to list *v1.VolumeAttachment: volumeattachments.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:machine-controller-manager" cannot list resource "volumeattachments" in API group "storage.k8s.io" at the cluster scope
```

It looks like when the component version was updated the required RBAC changes were not reflected.

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/388

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
machine-controller-manager-provider-alicloud RBAC does now allow get/list/watch on VolumeAttachments.
```
