### PR TITLE
[release-v1.36] Automated cherry pick of #481: Allow MCM to list VolumeAttachments

### DIFF
--- a/charts/internal/machine-controller-manager/shoot/templates/clusterrole-machine-controller-manager.yaml
+++ b/charts/internal/machine-controller-manager/shoot/templates/clusterrole-machine-controller-manager.yaml
@@ -62,8 +62,16 @@ rules:
   - watch
 - apiGroups:
   - policy
+  resources:
+  - poddisruptionbudgets
   verbs:
   - list
   - watch
+- apiGroups:
+  - storage.k8s.io
   resources:
-  - poddisruptionbudgets
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
/area/control-plane
/kind/regression

Cherry pick of #481 on release-v1.36.

#481: Allow MCM to list VolumeAttachments

**Release Notes:**
```other operator
machine-controller-manager-provider-alicloud RBAC does now allow get/list/watch on VolumeAttachments.
```