### PR TITLE
[release-v1.36] Automated cherry pick of #483: [ci:component:github.com/gardener/machine-controller-manager-provider-alicloud:v0.4.0->v0.4.1]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: machine-controller-manager-provider-alicloud
   sourceRepository: github.com/gardener/machine-controller-manager-provider-alicloud
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-alicloud
-  tag: "v0.4.0"
+  tag: "v0.4.1"
 
 - name: alicloud-controller-manager
   sourceRepository: https://github.com/kubernetes/cloud-provider-alibaba-cloud


### PR DESCRIPTION
/kind/bug

Cherry pick of #483 on release-v1.36.

#483: [ci:component:github.com/gardener/machine-controller-manager-provider-alicloud:v0.4.0->v0.4.1]

**Release Notes:**
``` bugfix operator github.com/gardener/machine-controller-manager-provider-alicloud #27 @ialidzhikov
An issue causing machine-controller-manager-provider-alicloud on startup to panic with "duplicate metrics collector registration attempted" is now fixed.
```