### PR TITLE
fetch infra information from worker's infrastructureProviderStatus

### DIFF
--- a/pkg/apis/alicloud/helper/scheme.go
+++ b/pkg/apis/alicloud/helper/scheme.go
@@ -36,6 +36,9 @@ var (
 	Scheme *runtime.Scheme
 
 	decoder runtime.Decoder
+
+	// lenientDecoder is a decoder that does not use strict mode.
+	lenientDecoder runtime.Decoder
 )
 
 func init() {
@@ -43,6 +46,7 @@ func init() {
 	utilruntime.Must(install.AddToScheme(Scheme))
 
 	decoder = serializer.NewCodecFactory(Scheme, serializer.EnableStrict).UniversalDecoder()
+	lenientDecoder = serializer.NewCodecFactory(Scheme).UniversalDecoder()
 }
 
 // InfrastructureConfigFromInfrastructure extracts the InfrastructureConfig from the
@@ -56,6 +60,19 @@ func InfrastructureConfigFromInfrastructure(infra *extensionsv1alpha1.Infrastruc
 		return config, nil
 	}
 	return nil, fmt.Errorf("provider config is not set on the infrastructure resource")
+}
+
+// InfrastructureStatusFromRaw extracts the InfrastructureStatus from the
+// ProviderStatus section of the given Infrastructure.
+func InfrastructureStatusFromRaw(raw *runtime.RawExtension) (*api.InfrastructureStatus, error) {
+	config := &api.InfrastructureStatus{}
+	if raw != nil && raw.Raw != nil {
+		if _, _, err := lenientDecoder.Decode(raw.Raw, nil, config); err != nil {
+			return nil, err
+		}
+		return config, nil
+	}
+	return nil, fmt.Errorf("provider status is not set on the infrastructure resource")
 }
 
 // CloudProfileConfigFromCluster decodes the provider specific cloud profile configuration for a cluster

--- a/pkg/controller/bastion/actuator.go
+++ b/pkg/controller/bastion/actuator.go
@@ -15,13 +15,8 @@
 package bastion
 
 import (
-	"encoding/json"
-	"errors"
-
 	alicloudclient "github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud/client"
-	alicloudApi "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
 
-	"github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/bastion"
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,77 +43,4 @@ func newActuator() bastion.Actuator {
 func (a *actuator) InjectClient(client client.Client) error {
 	a.client = client
 	return nil
-}
-
-func unmarshalClusterProviderConfig(bytes []byte) (*alicloudApi.CloudProfileConfig, error) {
-	cloudProfileConfig := &alicloudApi.CloudProfileConfig{}
-
-	err := json.Unmarshal(bytes, cloudProfileConfig)
-	if err != nil {
-		return nil, errors.New("failed to parse json for cloud ProfileConfig")
-	}
-	return cloudProfileConfig, nil
-}
-
-func getClusterImageID(cloudProfileConfig alicloudApi.CloudProfileConfig, name, version, regionName string) (string, error) {
-	var fallbackImageID string
-	for _, machineImage := range cloudProfileConfig.MachineImages {
-		if machineImage.Name != name {
-			continue
-		}
-
-		for _, machine := range machineImage.Versions {
-			if machine.Version != version {
-				continue
-			}
-
-			for _, region := range machine.Regions {
-				if region.Name == regionName {
-					return region.ID, nil
-				} else {
-					fallbackImageID = machine.Regions[0].ID
-				}
-			}
-
-		}
-
-	}
-
-	if fallbackImageID == "" {
-		return "", errors.New("fall back ImageID must be not empty")
-	}
-	return fallbackImageID, nil
-}
-
-func getImageID(cluster *controller.Cluster, opt *Options) (string, error) {
-	if cluster.CloudProfile.Spec.ProviderConfig == nil || cluster.CloudProfile.Spec.ProviderConfig.Raw == nil {
-		return "", errors.New("providerconfig Raw must be not empty")
-	}
-
-	clusterProviderConfig, err := unmarshalClusterProviderConfig(cluster.CloudProfile.Spec.ProviderConfig.Raw)
-	if err != nil {
-		return "", err
-	}
-
-	if len(cluster.Shoot.Spec.Provider.Workers) == 0 {
-		return "", errors.New("shoot worker must not be empty")
-	}
-
-	workerVersion := cluster.Shoot.Spec.Provider.Workers[0].Machine.Image.Version
-	imageName := cluster.Shoot.Spec.Provider.Workers[0].Machine.Image.Name
-
-	if clusterProviderConfig == nil {
-		return "", errors.New("clusterProviderConfig must be not empty")
-	}
-
-	if workerVersion == nil || *workerVersion == "" {
-		return "", errors.New("workerVersion must be not empty")
-	}
-
-	imageID, err := getClusterImageID(*clusterProviderConfig, imageName, *workerVersion, opt.Region)
-	if err != nil {
-		return "", err
-	}
-
-	return imageID, nil
 }

--- a/pkg/controller/bastion/bastion_suite_test.go
+++ b/pkg/controller/bastion/bastion_suite_test.go
@@ -16,11 +16,9 @@ package bastion
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"testing"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
-	alicloudApi "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -109,7 +107,6 @@ var _ = Describe("Bastion", func() {
 			},
 
 			Entry("security group name", securityGroupName(baseName), "clusterName-LetsExceed63LenLimit0-bastion-139c4-sg"),
-			Entry("vpc name", VpcName(baseName), "clusterName-LetsExceed63LenLimit0-bastion-139c4-vpc"),
 		)
 	})
 
@@ -331,35 +328,6 @@ var _ = Describe("Bastion", func() {
 				true),
 		)
 
-	})
-
-	Describe("check getClusterImageID getClusterProviderConfig ,", func() {
-		It("should return machineID", func() {
-			bytes, _ := json.Marshal(alicloudApi.CloudProfileConfig{
-				MachineImages: []alicloudApi.MachineImages{
-					{
-						Name: "linux",
-						Versions: []alicloudApi.MachineImageVersion{
-							{
-								Version: "version-1",
-								Regions: []alicloudApi.RegionIDMapping{
-									{
-										Name: "abc",
-										ID:   "machine-id1",
-									},
-								},
-							},
-						},
-					},
-				},
-			})
-
-			profileConfig, err := unmarshalClusterProviderConfig(bytes)
-			Expect(err).To(Not(HaveOccurred()))
-			machineID, err := getClusterImageID(*profileConfig, "linux", "version-1", "abc")
-			Expect(err).To(Not(HaveOccurred()))
-			Expect(machineID).To(Equal("machine-id1"))
-		})
 	})
 })
 

--- a/pkg/controller/bastion/options.go
+++ b/pkg/controller/bastion/options.go
@@ -45,14 +45,12 @@ const (
 // bastion instance name with the IDs of pre-existing cloud provider
 // resources, like the vpc name, shoot security group name etc.
 type Options struct {
-	BastionInstanceName    string
-	Region                 string
-	SecretReference        corev1.SecretReference
-	SecurityGroupName      string
-	VpcName                string
-	ShootName              string
-	ShootSecurityGroupName string
-	UserData               string
+	BastionInstanceName string
+	Region              string
+	SecretReference     corev1.SecretReference
+	SecurityGroupName   string
+	ShootName           string
+	UserData            string
 }
 
 // DetermineOptions determines the information that are required to reconcile a Bastion on Alicloud. This
@@ -72,14 +70,12 @@ func DetermineOptions(bastion *extensionsv1alpha1.Bastion, cluster *controller.C
 	}
 
 	return &Options{
-		ShootName:              clusterName,
-		BastionInstanceName:    baseResourceName,
-		SecretReference:        secretReference,
-		Region:                 region,
-		VpcName:                VpcName(clusterName),
-		SecurityGroupName:      securityGroupName(baseResourceName),
-		ShootSecurityGroupName: fmt.Sprintf("%s-sg", clusterName),
-		UserData:               base64.StdEncoding.EncodeToString(bastion.Spec.UserData),
+		ShootName:           clusterName,
+		BastionInstanceName: baseResourceName,
+		SecretReference:     secretReference,
+		Region:              region,
+		SecurityGroupName:   securityGroupName(baseResourceName),
+		UserData:            base64.StdEncoding.EncodeToString(bastion.Spec.UserData),
 	}, nil
 }
 
@@ -107,11 +103,6 @@ func generateBastionBaseResourceName(clusterName string, bastionName string) (st
 // securityGroupName is security group name
 func securityGroupName(baseName string) string {
 	return fmt.Sprintf("%s-sg", baseName)
-}
-
-// VpcName is shoot vpc name
-func VpcName(baseName string) string {
-	return fmt.Sprintf("%s-vpc", baseName)
 }
 
 // IngressPermission holds the IPv4 and IPv6 ranges that should be allowed to access the bastion.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
fetch exist values from infrastructure status 
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-alicloud/issues/498

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
fetch exist values from infrastructure status 
```
