### PR TITLE
Fix usage of deprecated fields in the terraform configuration file

### DIFF
--- a/pkg/controller/infrastructure/templates/main.tpl.tf
+++ b/pkg/controller/infrastructure/templates/main.tpl.tf
@@ -60,9 +60,9 @@ resource "alicloud_snat_entry" "snat_z{{ $index }}" {
 {{ else -}}
 // Create a new EIP.
 resource "alicloud_eip" "eip_natgw_z{{ $index }}" {
-  name                 = "{{ $.clusterName }}-eip-natgw-z{{ $index }}"
+  address_name         = "{{ $.clusterName }}-eip-natgw-z{{ $index }}"
   bandwidth            = "100"
-  instance_charge_type = "PostPaid"
+  payment_type         = "PayAsYouGo"
   internet_charge_type = "{{ $.eip.internetChargeType }}"
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/platform alicloud

**What this PR does / why we need it**:
After https://github.com/gardener/terraformer/pull/116 on Infrastructure creation there are the following deprecations:
```
Warning: "name": [DEPRECATED] Field 'name' has been deprecated from provider version 1.126.0 and it will be remove in the future version. Please use the new attribute 'address_name' instead.

  with alicloud_eip.eip_natgw_z0,
  on main.tf line 39, in resource "alicloud_eip" "eip_natgw_z0":
  39: resource "alicloud_eip" "eip_natgw_z0" {

(and one more similar warning elsewhere)

Warning: "instance_charge_type": [DEPRECATED] Field 'instance_charge_type' has been deprecated from provider version 1.126.0 and it will be remove in the future version. Please use the new attribute 'payment_type' instead.

  with alicloud_eip.eip_natgw_z0,
  on main.tf line 39, in resource "alicloud_eip" "eip_natgw_z0":
  39: resource "alicloud_eip" "eip_natgw_z0" {

(and one more similar warning elsewhere)
```

**Special notes for your reviewer**:
- `alicloud_eip` `name` field is deprecated in favour of `address_name` - https://github.com/aliyun/terraform-provider-alicloud/blob/1d74cdbc3ad6670e8b84588fc050cb9437a203a2/alicloud/resource_alicloud_eip_address.go#L39-L53
- `alicloud_eip` `instance_charge_type` field is deprecated is favour of `payment_type`- ref https://github.com/aliyun/terraform-provider-alicloud/blob/1d74cdbc3ad6670e8b84588fc050cb9437a203a2/alicloud/resource_alicloud_eip_address.go#L94-L110

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
