### PR TITLE
allow all communication from pod ip range

### DIFF
--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -196,8 +196,8 @@ func (a *actuator) getInitializerValues(
 	return a.terraformChartOps.ComputeUseVPCInitializerValues(config, vpcInfo), nil
 }
 
-func (a *actuator) newInitializer(infra *extensionsv1alpha1.Infrastructure, config *alicloudv1alpha1.InfrastructureConfig, values *InitializerValues, stateInitializer terraformer.StateConfigMapInitializer) (terraformer.Initializer, error) {
-	chartValues := a.terraformChartOps.ComputeChartValues(infra, config, values)
+func (a *actuator) newInitializer(infra *extensionsv1alpha1.Infrastructure, config *alicloudv1alpha1.InfrastructureConfig, podCIDR *string, values *InitializerValues, stateInitializer terraformer.StateConfigMapInitializer) (terraformer.Initializer, error) {
+	chartValues := a.terraformChartOps.ComputeChartValues(infra, config, podCIDR, values)
 
 	var mainTF bytes.Buffer
 	if err := tplMainTF.Execute(&mainTF, chartValues); err != nil {
@@ -558,7 +558,7 @@ func (a *actuator) reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 		return err
 	}
 
-	initializer, err := a.newInitializer(infra, config, initializerValues, stateInitializer)
+	initializer, err := a.newInitializer(infra, config, cluster.Shoot.Spec.Networking.Pods, initializerValues, stateInitializer)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/infrastructure/templates/main.tpl.tf
+++ b/pkg/controller/infrastructure/templates/main.tpl.tf
@@ -122,6 +122,16 @@ resource "alicloud_security_group_rule" "allow_all_internal_udp_in" {
   cidr_ip           = "{{ .vpc.cidr }}"
 }
 
+resource "alicloud_security_group_rule" "allow_all_internal_pod_traffic_in" {
+  type              = "ingress"
+  ip_protocol       = "all"
+  policy            = "accept"
+  port_range        = "-1/-1"
+  priority          = 1
+  security_group_id = alicloud_security_group.sg.id
+  cidr_ip           = "{{ .podCIDR }}"
+}
+
 // We have introduced new output variables. However, they are not applied for
 // existing clusters as Terraform won't detect a diff when we run `terraform plan`.
 // Workaround: Providing a null-resource for letting Terraform think that there are

--- a/pkg/controller/infrastructure/terraform.go
+++ b/pkg/controller/infrastructure/terraform.go
@@ -121,6 +121,7 @@ func (terraformOps) ComputeUseVPCInitializerValues(config *v1alpha1.Infrastructu
 func (terraformOps) ComputeChartValues(
 	infra *extensionsv1alpha1.Infrastructure,
 	config *v1alpha1.InfrastructureConfig,
+	podCIDR *string,
 	values *InitializerValues,
 ) map[string]interface{} {
 	zones := make([]map[string]interface{}, 0, len(config.Networks.Zones))
@@ -164,6 +165,7 @@ func (terraformOps) ComputeChartValues(
 		},
 		"clusterName": infra.Namespace,
 		"zones":       zones,
+		"podCIDR":     *podCIDR,
 		"outputKeys": map[string]interface{}{
 			"vpcID":              TerraformerOutputKeyVPCID,
 			"vpcCIDR":            TerraformerOutputKeyVPCCIDR,

--- a/pkg/controller/infrastructure/terraform_test.go
+++ b/pkg/controller/infrastructure/terraform_test.go
@@ -153,6 +153,7 @@ var _ = Describe("TerraformChartOps", func() {
 				natGatewayID       = "natGatewayID"
 				sNATTableIDs       = "sNATTableIDs"
 				internetChargeType = "internetChargeType"
+				podCIDR            = "100.96.0.0/11"
 
 				values = InitializerValues{
 					VPC: VPC{
@@ -171,7 +172,7 @@ var _ = Describe("TerraformChartOps", func() {
 				}
 			)
 
-			Expect(ops.ComputeChartValues(&infra, &config, &values)).To(Equal(map[string]interface{}{
+			Expect(ops.ComputeChartValues(&infra, &config, &podCIDR, &values)).To(Equal(map[string]interface{}{
 				"alicloud": map[string]interface{}{
 					"region": region,
 				},
@@ -204,6 +205,7 @@ var _ = Describe("TerraformChartOps", func() {
 						},
 					},
 				},
+				"podCIDR": podCIDR,
 				"outputKeys": map[string]interface{}{
 					"vpcID":              TerraformerOutputKeyVPCID,
 					"vpcCIDR":            TerraformerOutputKeyVPCCIDR,

--- a/pkg/controller/infrastructure/types.go
+++ b/pkg/controller/infrastructure/types.go
@@ -73,5 +73,5 @@ type InitializerValues struct {
 type TerraformChartOps interface {
 	ComputeCreateVPCInitializerValues(config *v1alpha1.InfrastructureConfig, internetChargeType string) *InitializerValues
 	ComputeUseVPCInitializerValues(config *v1alpha1.InfrastructureConfig, info *alicloudclient.VPCInfo) *InitializerValues
-	ComputeChartValues(infra *extensionsv1alpha1.Infrastructure, config *v1alpha1.InfrastructureConfig, values *InitializerValues) map[string]interface{}
+	ComputeChartValues(infra *extensionsv1alpha1.Infrastructure, config *v1alpha1.InfrastructureConfig, podCIDR *string, values *InitializerValues) map[string]interface{}
 }

--- a/pkg/mock/provider-alicloud/controller/infrastructure/mocks.go
+++ b/pkg/mock/provider-alicloud/controller/infrastructure/mocks.go
@@ -38,17 +38,17 @@ func (m *MockTerraformChartOps) EXPECT() *MockTerraformChartOpsMockRecorder {
 }
 
 // ComputeChartValues mocks base method.
-func (m *MockTerraformChartOps) ComputeChartValues(arg0 *v1alpha10.Infrastructure, arg1 *v1alpha1.InfrastructureConfig, arg2 *infrastructure.InitializerValues) map[string]interface{} {
+func (m *MockTerraformChartOps) ComputeChartValues(arg0 *v1alpha10.Infrastructure, arg1 *v1alpha1.InfrastructureConfig, arg2 *string, arg3 *infrastructure.InitializerValues) map[string]interface{} {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ComputeChartValues", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ComputeChartValues", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(map[string]interface{})
 	return ret0
 }
 
 // ComputeChartValues indicates an expected call of ComputeChartValues.
-func (mr *MockTerraformChartOpsMockRecorder) ComputeChartValues(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockTerraformChartOpsMockRecorder) ComputeChartValues(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeChartValues", reflect.TypeOf((*MockTerraformChartOps)(nil).ComputeChartValues), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeChartValues", reflect.TypeOf((*MockTerraformChartOps)(nil).ComputeChartValues), arg0, arg1, arg2, arg3)
 }
 
 // ComputeCreateVPCInitializerValues mocks base method.

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -64,6 +64,7 @@ const (
 	natGatewayType      = "Enhanced"
 	vpcCIDR             = "10.250.0.0/16"
 	natGatewayCIDR      = "10.250.128.0/21" // Enhanced NatGateway need bind with VSwitch, natGatewayCIDR is used for this VSwitch
+	podCIDR             = "100.96.0.0/11"
 	securityGroupSuffix = "-sg"
 	imageID             = "m-gw8iwwd4iiln01dj646s"
 )
@@ -431,6 +432,9 @@ func createShoot(infrastructureConfig []byte) *gardencorev1beta1.Shoot {
 				InfrastructureConfig: &runtime.RawExtension{
 					Raw: infrastructureConfig,
 				},
+			},
+			Networking: gardencorev1beta1.Networking{
+				Pods: pointer.String(podCIDR),
 			},
 		},
 	}

--- a/test/integration/infrastructure/common.go
+++ b/test/integration/infrastructure/common.go
@@ -20,6 +20,7 @@ const (
 	allCIDR     = "0.0.0.0/0"
 	vpcCIDR     = "10.250.0.0/16"
 	workersCIDR = "10.250.0.0/21"
+	podCIDR     = "100.96.0.0/11"
 
 	natGatewayCIDR = "10.250.128.0/21" // Enhanced NatGateway need bind with VSwitch, natGatewayCIDR is used for this VSwitch
 	natGatewayType = "Enhanced"

--- a/test/integration/infrastructure/encrypteimagehelper.go
+++ b/test/integration/infrastructure/encrypteimagehelper.go
@@ -109,6 +109,9 @@ func newCluster(namespace string) (*extensionsv1alpha1.Cluster, error) {
 					},
 				},
 			},
+			Networking: gardencorev1beta1.Networking{
+				Pods: pointer.String(podCIDR),
+			},
 		},
 	}
 	shootJSON, err := json.Marshal(shoot)

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -553,6 +553,14 @@ func verifyCreation(
 			Priority:     "1",
 			SourceCidrIp: vpcCIDR,
 		},
+		{
+			IpProtocol:   "ALL",
+			Direction:    "ingress",
+			Policy:       "Accept",
+			PortRange:    "-1/-1",
+			Priority:     "1",
+			SourceCidrIp: podCIDR,
+		},
 	}))
 
 	return


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
To get rid of the networking overlay we need to allow the pod ip range communication within the vpc network.
Prerequisite for https://github.com/gardener/backlog/issues/29.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
none
```
