### PR TITLE
set configure-cloud-route to true

### DIFF
--- a/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         - --v=2
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf
         - --cluster-name={{ .Values.clusterName }}
-        - --configure-cloud-routes=false
+        - --configure-cloud-routes=true
         {{- include "cloud-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
         livenessProbe:
           httpGet:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
Set configure-cloud-route to true required for https://github.com/gardener/gardener-extension-provider-alicloud/pull/518.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
none
```
