### PR TITLE
Don't deploy `PSP`s when `PodSecurityPolicy` plugin is disabled 

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-plugin-psp.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-plugin-psp.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pspDisabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -22,3 +23,4 @@ spec:
   fsGroup:
     rule: RunAsAny
   readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-plugin-rbac.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-plugin-rbac.yaml
@@ -8,7 +8,11 @@ automountServiceAccountToken: false
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  {{- if not .Values.pspDisabled }}
   name: {{ include "csi-disk-plugin.extensionsGroup" . }}:psp:kube-system:csi-disk-plugin-alicloud
+  {{- else }}
+  name: {{ include "csi-disk-plugin.extensionsGroup" . }}:kube-system:csi-disk-plugin-alicloud
+  {{- end }}
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
@@ -22,6 +26,7 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["volumeattachments"]
   verbs: ["get", "list", "watch", "update"]
+{{- if not .Values.pspDisabled }}
 - apiGroups:
   - policy
   - extensions
@@ -31,16 +36,25 @@ rules:
   - podsecuritypolicies
   verbs:
   - use
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  {{- if not .Values.pspDisabled }}
   name: {{ include "csi-disk-plugin.extensionsGroup" . }}:psp:csi-disk-plugin-alicloud
+  {{- else }}
+  name: {{ include "csi-disk-plugin.extensionsGroup" . }}:csi-disk-plugin-alicloud
+  {{- end }}
 subjects:
 - kind: ServiceAccount
   name: csi-disk-plugin-alicloud
   namespace: kube-system
 roleRef:
   kind: ClusterRole
+  {{- if not .Values.pspDisabled }}
   name: {{ include "csi-disk-plugin.extensionsGroup" . }}:psp:kube-system:csi-disk-plugin-alicloud
+  {{- else }}
+  name: {{ include "csi-disk-plugin.extensionsGroup" . }}:kube-system:csi-disk-plugin-alicloud
+  {{- end }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/values.yaml
@@ -37,3 +37,5 @@ resources:
       memory: 32Mi
     limits:
       memory: 300Mi
+
+pspDisabled: false

--- a/example/10-fake-shoot-controlplane.yaml
+++ b/example/10-fake-shoot-controlplane.yaml
@@ -128,7 +128,7 @@ spec:
       - command:
         - /hyperkube
         - apiserver
-        - --enable-admission-plugins=Priority,NamespaceLifecycle,LimitRanger,PodSecurityPolicy,ServiceAccount,NodeRestriction,DefaultStorageClass,Initializers,DefaultTolerationSeconds,ResourceQuota,StorageObjectInUseProtection,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+        - --enable-admission-plugins=Priority,NamespaceLifecycle,LimitRanger,ServiceAccount,NodeRestriction,DefaultStorageClass,Initializers,DefaultTolerationSeconds,ResourceQuota,StorageObjectInUseProtection,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
         - --disable-admission-plugins=PersistentVolumeLabel
         - --allow-privileged=true
         - --anonymous-auth=false

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -474,6 +474,7 @@ func (vp *valuesProvider) getControlPlaneShootChartValues(
 				"url":      "https://" + alicloud.CSISnapshotValidation + "." + cp.Namespace + "/volumesnapshot",
 				"caBundle": string(caSecret.Data[secretutils.DataKeyCertificateBundle]),
 			},
+			"pspDisabled": gardencorev1beta1helper.IsPSPDisabled(cluster.Shoot),
 		},
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
`PodSecurityPolicy` is deprecated and will be disabled in kubernetes v1.25+.
End-users are provided an option to migrate their PSPs before upgrading and disable the `PodSecurityPolicy` admission plugin in the ShootSpec. 
In that case, we should stop deploying our PSPs as well.

- This PR stops deploying PSPs related to `provider-alicloud` if the plugin is disabled in the Shoot.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5250

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/587
/hold Depends on #521 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Please make sure you're running gardener@v1.52 or above before upgrading to this version.
```

