### PR TITLE
just check whether snat entry is empty when checking snattable

### DIFF
--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -606,8 +606,7 @@ func verifyDeletion(ctx context.Context, clientFactory alicloudclient.ClientFact
 		describeSnatTableEntriesReq := vpc.CreateDescribeSnatTableEntriesRequest()
 		describeSnatTableEntriesReq.SnatTableId = *infrastructureIdentifier.snatTableId
 		describeSnatTableEntriesReq.SnatEntryId = *infrastructureIdentifier.snatEntryId
-		describeSnatTableEntriesOutput, err := vpcClient.DescribeSnatTableEntries(describeSnatTableEntriesReq)
-		Expect(err).To(MatchError(ContainSubstring("Specified SNAT table does not exist")))
+		describeSnatTableEntriesOutput, _ := vpcClient.DescribeSnatTableEntries(describeSnatTableEntriesReq)
 		Expect(describeSnatTableEntriesOutput.SnatTableEntries.SnatTableEntry).To(BeEmpty())
 	}
 

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -607,7 +607,7 @@ func verifyDeletion(ctx context.Context, clientFactory alicloudclient.ClientFact
 		describeSnatTableEntriesReq.SnatTableId = *infrastructureIdentifier.snatTableId
 		describeSnatTableEntriesReq.SnatEntryId = *infrastructureIdentifier.snatEntryId
 		describeSnatTableEntriesOutput, err := vpcClient.DescribeSnatTableEntries(describeSnatTableEntriesReq)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring("Specified SNAT table does not exist")))
 		Expect(describeSnatTableEntriesOutput.SnatTableEntries.SnatTableEntry).To(BeEmpty())
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
/area testing
/kind bug
/platform alicloud

**What this PR does / why we need it**:
Ali changes the behavior when snatable doesn't exist.  When creating infra with new VPC, snat table is deleted when destroying infra. In this case, an error is returned by alicloud
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
none
```
