### PR TITLE
upgrade ali csi to v1.24.10-compatible-29f36f1-aliyun

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -128,7 +128,7 @@ images:
 - name: csi-plugin-alicloud
   sourceRepository: https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver
   repository: registry.eu-central-1.aliyuncs.com/acs/csi-plugin
-  tag: v1.24.7-48214b0-aliyun
+  tag: v1.24.10-compatible-29f36f1-aliyun
 - name: csi-liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: registry.k8s.io/sig-storage/livenessprobe

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
@@ -79,6 +79,11 @@ spec:
             secretKeyRef:
               name: csi-diskplugin-alicloud
               key: accessKeySecret
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
 {{- if .Values.resources.driver }}
         resources:
 {{ toYaml .Values.resources.driver | indent 10 }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind regression
/platform alicloud

**What this PR does / why we need it**:
Ali CSI introduces a mandatory env var but it doesn't make sense to gardener. In this new version, Ali makes it as optional 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
upgrade AliCloud CSI to v1.24.10-compatible-29f36f1-aliyun
```
