### PR TITLE
Add wait-for-csi-node annotation to csi-driver-node Pods

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       annotations:
         checksum/secret-csi-diskplugin-alicloud: {{ include (print $.Template.BasePath "/csi-diskplugin-secret.yaml") . | sha256sum }}
+        node.gardener.cloud/wait-for-csi-node-alicloud: diskplugin.csi.alibabacloud.com
       labels:
         app: csi-disk-plugin-alicloud
         origin: gardener


### PR DESCRIPTION
**How to categorize this PR?**

/area robustness
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:

This PR adds the `wait-for-csi-node` annotation to `csi-driver-node` introduced in gardener/gardener#7621

**Which issue(s) this PR fixes**:
Parts of gardener/gardener#7117

**Special notes for your reviewer**:
/hold
until gardener/gardener#7621 is merged

**Release note**:

```feature operator
`csi-disk-plugin` is annotated with the `wait-for-csi-node` annotation. Gardener uses this to only schedule workload pods to a `Node` once the driver has been successfully registered with the `CSINode` object.
```
