### PR TITLE
Switch remaining images from `k8s.gcr.io` to `registry.k8s.io`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -62,7 +62,7 @@ images:
       availability_requirement: 'low'
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
-  repository: k8s.gcr.io/sig-storage/csi-provisioner
+  repository: registry.k8s.io/sig-storage/csi-provisioner
   tag: "v3.3.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -75,7 +75,7 @@ images:
       availability_requirement: 'low'
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
-  repository: k8s.gcr.io/sig-storage/csi-snapshotter
+  repository: registry.k8s.io/sig-storage/csi-snapshotter
   tag: "v6.1.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -88,7 +88,7 @@ images:
       availability_requirement: 'low'
 - name: csi-snapshot-validation-webhook
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
-  repository: k8s.gcr.io/sig-storage/snapshot-validation-webhook
+  repository: registry.k8s.io/sig-storage/snapshot-validation-webhook
   tag: "v6.1.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -101,7 +101,7 @@ images:
       availability_requirement: 'low'
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
-  repository: k8s.gcr.io/sig-storage/snapshot-controller
+  repository: registry.k8s.io/sig-storage/snapshot-controller
   tag: "v6.1.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform alicloud

**What this PR does / why we need it**:
https://github.com/gardener/gardener-extension-provider-alicloud/commit/9487c0babc7cbace45b53364522cb7bc3ed4763a introduced several `k8s.gcr.io` images. 
`k8s.gcr.io` should not be used anymore - see https://kubernetes.io/blog/2023/03/10/image-registry-redirect/

**Which issue(s) this PR fixes**:
See above

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following images are updated:
- k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0 -> registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
- k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0 -> registry.k8s.io/sig-storage/csi-snapshotter:v6.1.0
- k8s.gcr.io/sig-storage/snapshot-validation-webhook:v6.1.0 -> registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.1.0
- k8s.gcr.io/sig-storage/snapshot-controller:v6.1.0 -> registry.k8s.io/sig-storage/snapshot-controller:v6.1.0
```
