### PR TITLE
[release-v1.46] Automated cherry pick of #607: [ci:component:github.com/gardener/machine-controller-manager:v0.49.0->v0.49.2] #621: [ci:component:github.com/gardener/machine-controller-manager:v0.49.2->v0.49.3]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.49.0"
+  tag: "v0.49.2"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.49.2"
+  tag: "v0.49.3"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area ops-productivity
/kind bug

Cherry pick of #607 #621 on release-v1.46.

#607: [ci:component:github.com/gardener/machine-controller-manager:v0.49.0->v0.49.2]
#621: [ci:component:github.com/gardener/machine-controller-manager:v0.49.2->v0.49.3]

**Release Notes:**
``` bugfix operator github.com/gardener/machine-controller-manager #817 @himanshu-kun
An issue causing nil pointer panic on scaleup of the machinedeployment along with trigger of rolling update, is fixed
```
``` bugfix user github.com/gardener/machine-controller-manager #822 @rishabh-11
An edge case where outdated DesiredReplicas annotation blocked a rolling update is fixed.
```

``` bugfix operator github.com/gardener/machine-controller-manager #834 @ialidzhikov
Included `UnavailableReplicas` in determining if a machine deployment status update is needed
```
