### PR TITLE
CSI topology label on MachineDeployment creation to allow scale-up

### DIFF
--- a/pkg/alicloud/types.go
+++ b/pkg/alicloud/types.go
@@ -35,7 +35,7 @@ const (
 	CloudControllerManagerImageName = "alicloud-controller-manager"
 	// CSIAttacherImageName is the name of the CSI attacher image.
 	CSIAttacherImageName = "csi-attacher"
-	// CSITopologyZoneKey is the CSI topology label name that represents availability by zone.
+	// CSIDiskTopologyZoneKey is the CSI topology label name that represents availability by zone.
 	// See https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver/blob/v1.2.1/pkg/disk/disk.go#L45C1-L45C1
 	// See https://www.alibabacloud.com/help/en/elastic-container-instance/latest/mount-a-disk-as-a-statically-provisioned-volume
 	CSIDiskTopologyZoneKey = "topology.diskplugin.csi.alibabacloud.com/zone"

--- a/pkg/alicloud/types.go
+++ b/pkg/alicloud/types.go
@@ -35,6 +35,10 @@ const (
 	CloudControllerManagerImageName = "alicloud-controller-manager"
 	// CSIAttacherImageName is the name of the CSI attacher image.
 	CSIAttacherImageName = "csi-attacher"
+	// CSITopologyZoneKey is the CSI topology label name that represents availability by zone.
+	// See https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver/blob/v1.2.1/pkg/disk/disk.go#L45C1-L45C1
+	// See https://www.alibabacloud.com/help/en/elastic-container-instance/latest/mount-a-disk-as-a-statically-provisioned-volume
+	CSIDiskTopologyZoneKey = "topology.diskplugin.csi.alibabacloud.com/zone"
 	// CSINodeDriverRegistrarImageName is the name of the CSI driver registrar image.
 	CSINodeDriverRegistrarImageName = "csi-node-driver-registrar"
 	// CSIProvisionerImageName is the name of the CSI provisioner image.

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -264,5 +264,5 @@ func computeAdditionalHashData(pool extensionsv1alpha1.WorkerPool) []string {
 }
 
 func addTopologyLabel(labels map[string]string, zone string) map[string]string {
-	return utils.MergeStringMaps(labels, map[string]string{alicloud.CSITopologyZoneKey: zone})
+	return utils.MergeStringMaps(labels, map[string]string{alicloud.CSIDiskTopologyZoneKey: zone})
 }

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -156,7 +156,7 @@ func (w *workerDelegate) generateMachineConfig() error {
 				Maximum:              worker.DistributeOverZones(zoneIdx, pool.Maximum, zoneLen),
 				MaxSurge:             worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxSurge, zoneLen, pool.Maximum),
 				MaxUnavailable:       worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxUnavailable, zoneLen, pool.Minimum),
-				Labels:               pool.Labels,
+				Labels:               addTopologyLabel(pool.Labels, zone),
 				Annotations:          pool.Annotations,
 				Taints:               pool.Taints,
 				MachineConfiguration: genericworkeractuator.ReadMachineConfiguration(pool),
@@ -261,4 +261,8 @@ func computeAdditionalHashData(pool extensionsv1alpha1.WorkerPool) []string {
 	}
 
 	return additionalData
+}
+
+func addTopologyLabel(labels map[string]string, zone string) map[string]string {
+	return utils.MergeStringMaps(labels, map[string]string{alicloud.CSITopologyZoneKey: zone})
 }

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -505,6 +505,8 @@ var _ = Describe("Machines", func() {
 						machineClassPool2Zone2,
 					}}
 
+					labelsZone1 := map[string]string{alicloud.CSIDiskTopologyZoneKey: zone1}
+					labelsZone2 := map[string]string{alicloud.CSIDiskTopologyZoneKey: zone2}
 					machineDeployments = worker.MachineDeployments{
 						{
 							Name:                 machineClassNamePool1Zone1,
@@ -514,6 +516,7 @@ var _ = Describe("Machines", func() {
 							Maximum:              worker.DistributeOverZones(0, maxPool1, 2),
 							MaxSurge:             worker.DistributePositiveIntOrPercent(0, maxSurgePool1, 2, maxPool1),
 							MaxUnavailable:       worker.DistributePositiveIntOrPercent(0, maxUnavailablePool1, 2, minPool1),
+							Labels:               labelsZone1,
 							MachineConfiguration: machineConfiguration,
 						},
 						{
@@ -524,6 +527,7 @@ var _ = Describe("Machines", func() {
 							Maximum:              worker.DistributeOverZones(1, maxPool1, 2),
 							MaxSurge:             worker.DistributePositiveIntOrPercent(1, maxSurgePool1, 2, maxPool1),
 							MaxUnavailable:       worker.DistributePositiveIntOrPercent(1, maxUnavailablePool1, 2, minPool1),
+							Labels:               labelsZone2,
 							MachineConfiguration: machineConfiguration,
 						},
 						{
@@ -534,6 +538,7 @@ var _ = Describe("Machines", func() {
 							Maximum:              worker.DistributeOverZones(0, maxPool2, 2),
 							MaxSurge:             worker.DistributePositiveIntOrPercent(0, maxSurgePool2, 2, maxPool2),
 							MaxUnavailable:       worker.DistributePositiveIntOrPercent(0, maxUnavailablePool2, 2, minPool2),
+							Labels:               labelsZone1,
 							MachineConfiguration: machineConfiguration,
 						},
 						{
@@ -544,6 +549,7 @@ var _ = Describe("Machines", func() {
 							Maximum:              worker.DistributeOverZones(1, maxPool2, 2),
 							MaxSurge:             worker.DistributePositiveIntOrPercent(1, maxSurgePool2, 2, maxPool2),
 							MaxUnavailable:       worker.DistributePositiveIntOrPercent(1, maxUnavailablePool2, 2, minPool2),
+							Labels:               labelsZone2,
 							MachineConfiguration: machineConfiguration,
 						},
 					}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
adds CSI driver specific topology zone label `topology.diskplugin.csi.alibabacloud.com/zone` during machineDeployment creation, so that PV nodeAffinity matches.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
machineDeployment will have the label `topology.diskplugin.csi.alibabacloud.com/zone` when created.
```
