### PR TITLE
Change volumeBindingMode to WaitForFirstConsumer

### DIFF
--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -7,6 +7,7 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
     resources.gardener.cloud/delete-on-invalid-update: "true"
 provisioner: diskplugin.csi.alibabacloud.com
+volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 parameters:
   csi.storage.k8s.io/fstype: ext4


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
~3 years ago we changed the default StorageClass across providers from `volumeBindingMode: Immediate` to `volumeBindingMode: WaitForFirstConsumer`:
- provider-aws: https://github.com/gardener/gardener-extension-provider-aws/pull/179
- provider-gcp: https://github.com/gardener/gardener-extension-provider-gcp/pull/169
- provider-azure: https://github.com/gardener/gardener-extension-provider-azure/pull/159
- provider-openstack: https://github.com/gardener/gardener-extension-provider-openstack/pull/137 and https://github.com/gardener/gardener-extension-provider-openstack/pull/140

It seems that back then we missed provider-alicloud.

For disadvantages of ``, see https://github.com/gardener/gardener/issues/8563 and https://github.com/gardener/gardener-extension-provider-aws/issues/152.

**Which issue(s) this PR fixes**:
Related to https://github.com/gardener/gardener/issues/8563 (because right now the for ManagedSeeds the default StorageClass is used for the etcd-events PVC).

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The `volumeBindingMode` of the default StorageClass managed by the provider-alicloud extension is now switched from `Immediate` to `WaitForFirstConsumer`.
```
