### PR TITLE
Remove obsolete flag

### DIFF
--- a/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/deployment.yaml
@@ -42,7 +42,6 @@ spec:
         command:
         - /cloud-controller-manager
         - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
-        - --address=0.0.0.0
         - --allow-untagged-cloud=true
         - --allocate-node-cidrs=true
         - --cloud-provider=alicloud


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
This flag was removed by https://github.com/kubernetes/cloud-provider-alibaba-cloud/commit/4f7d027b7e3c8b01728a948cf2cee1a41f65655f.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-provider-alicloud/pull/654.

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
