### PR TITLE
add ccm network flag to public

### DIFF
--- a/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/deployment.yaml
@@ -52,6 +52,7 @@ spec:
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf
         - --cluster-name={{ .Values.clusterName }}
         - --configure-cloud-routes=true
+        - --network=public
         {{- include "cloud-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
         livenessProbe:
           httpGet:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
use alicloud CCM out of alicloud env need add flag --network=public

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-provider-alicloud/pull/654.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
