### PR TITLE
Optimize CCM network flag by seed provider

### DIFF
--- a/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf
         - --cluster-name={{ .Values.clusterName }}
         - --configure-cloud-routes=true
-        - --network=public
+        - --network={{ .Values.ccmNetworkFalg }}
         {{- include "cloud-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
         livenessProbe:
           httpGet:

--- a/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/values.yaml
@@ -4,6 +4,7 @@ podNetwork: 192.168.0.0/16
 podAnnotations: {}
 podLabels: {}
 featureGates: {}
+ccmNetworkFalg: public
   # RotateKubeletServerCertificate: false
 images:
   alicloud-controller-manager: image-repository

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -406,7 +406,7 @@ func (vp *valuesProvider) getControlPlaneChartValues(
 	}
 
 	ccmNetworkFalg := "public"
-	if cluster.Seed.Spec.Provider.Type == alicloud.Type {
+	if cluster.Seed != nil && cluster.Seed.Spec.Provider.Type == alicloud.Type {
 		ccmNetworkFalg = "vpc"
 	}
 	values := map[string]interface{}{

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -405,6 +405,10 @@ func (vp *valuesProvider) getControlPlaneChartValues(
 		return nil, fmt.Errorf("secret %q not found", csiSnapshotValidationServerName)
 	}
 
+	ccmNetworkFalg := "public"
+	if cluster.Seed.Spec.Provider.Type == alicloud.Type {
+		ccmNetworkFalg = "vpc"
+	}
 	values := map[string]interface{}{
 		"global": map[string]interface{}{
 			"genericTokenKubeconfigSecretName": extensionscontroller.GenericTokenKubeconfigSecretNameFromCluster(cluster),
@@ -416,7 +420,8 @@ func (vp *valuesProvider) getControlPlaneChartValues(
 			"podLabels": map[string]interface{}{
 				v1beta1constants.LabelPodMaintenanceRestart: "true",
 			},
-			"cloudConfig": ccmConfig,
+			"cloudConfig":    ccmConfig,
+			"ccmNetworkFalg": ccmNetworkFalg,
 		},
 		"csi-alicloud": map[string]interface{}{
 			"regionID":           cp.Spec.Region,

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -140,6 +140,7 @@ var _ = Describe("ValuesProvider", func() {
 				"featureGates": map[string]bool{
 					"RotateKubeletServerCertificate": true,
 				},
+				"ccmNetworkFalg": "public",
 			},
 			"csi-alicloud": map[string]interface{}{
 				"replicas":           1,
@@ -247,6 +248,21 @@ var _ = Describe("ValuesProvider", func() {
 			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, fakeSecretsManager, checksums, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(controlPlaneChartValues))
+		})
+
+		It("should set chart values ccmNetworkFalg vpc when seed provider type is alicloud", func() {
+			// Call GetControlPlaneChartValues method and check the result
+			cluster.Seed = &gardencorev1beta1.Seed{
+				Spec: gardencorev1beta1.SeedSpec{
+					Provider: gardencorev1beta1.SeedProvider{
+						Type: "alicloud",
+					},
+				},
+			}
+			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, fakeSecretsManager, checksums, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(values).To(HaveKey("alicloud-cloud-controller-manager"))
+			Expect(values["alicloud-cloud-controller-manager"]).To(HaveKeyWithValue("ccmNetworkFalg", "vpc"))
 		})
 
 		DescribeTable("topologyAwareRoutingEnabled value",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
CCM's network flag will be judged by seed's provider type, case alicloud it will be set **vpc** to speed up communication with alicloud API server, other will be set **public** by default.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-provider-alicloud/pull/665.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
