### PR TITLE
Change metric port

### DIFF
--- a/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/alicloud-ccm-service.yaml
+++ b/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/alicloud-ccm-service.yaml
@@ -7,16 +7,16 @@ metadata:
     app: kubernetes
     role: cloud-controller-manager
   annotations:
-    networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"port":10258,"protocol":"TCP"}]'
+    networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"port":8080,"protocol":"TCP"}]'
     # TODO: This label approach is deprecated and no longer needed in the future. Remove them as soon as gardener/gardener@v1.75 has been released.
     networking.resources.gardener.cloud/from-policy-pod-label-selector: all-scrape-targets
-    networking.resources.gardener.cloud/from-policy-allowed-ports: '[{"port":10258,"protocol":"TCP"}]'
+    networking.resources.gardener.cloud/from-policy-allowed-ports: '[{"port":8080,"protocol":"TCP"}]'
 spec:
   type: ClusterIP
   clusterIP: None
   ports:
     - name: metrics
-      port: 10258
+      port: 8080
       protocol: TCP
   selector:
     app: kubernetes

--- a/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/alicloud-cloud-controller-manager/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 15
         ports:
-        - containerPort: 10258
+        - containerPort: 8080
           name: metrics
           protocol: TCP
         terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug
/platform alicloud

**What this PR does / why we need it**:
Ali changed default metric port in following commit
https://github.com/kubernetes/cloud-provider-alibaba-cloud/commit/4f7d027b7e3c8b01728a948cf2cee1a41f65655f
https://github.com/kubernetes/cloud-provider-alibaba-cloud/commit/c23f391e07aa41dcd52357685c6d2449d8140cbb
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
