### PR TITLE
Fix E2E test panic 

### DIFF
--- a/pkg/controller/infrastructure/infraflow/aliclient/actor.go
+++ b/pkg/controller/infrastructure/infraflow/aliclient/actor.go
@@ -198,13 +198,14 @@ func (c *actor) getSecurityGroup(id string) (*SecurityGroup, error) {
 	if err != nil {
 		return nil, err
 	}
-	rules, err := c.listSecurityGroupRule(sg.SecurityGroupId)
-	if err != nil {
-		return nil, err
+	if sg != nil {
+		rules, err := c.listSecurityGroupRule(sg.SecurityGroupId)
+		if err != nil {
+			return nil, err
+		}
+
+		sg.Rules = append(sg.Rules, rules...)
 	}
-
-	sg.Rules = append(sg.Rules, rules...)
-
 	return sg, nil
 
 }

--- a/pkg/controller/infrastructure/infraflow/reconcile_zone.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile_zone.go
@@ -145,12 +145,15 @@ func (c *FlowContext) getCurrentSnatEntryForZone(ctx context.Context, zoneName s
 	child := c.getZoneChild(zoneName)
 	vswitchId := child.Get(IdentifierZoneVSwitch)
 	ngwId := c.state.Get(IdentifierNatGateway)
+	entryList := []*aliclient.SNATEntry{}
+	if ngwId == nil {
+		return entryList, nil
+	}
 	entries, err := c.actor.FindSNatEntriesByNatGateway(ctx, *ngwId)
 	if err != nil {
 		return nil, err
 	}
 
-	entryList := []*aliclient.SNATEntry{}
 	for _, entry := range entries {
 		if entry.VSwitchId == *vswitchId {
 			entryList = append(entryList, entry)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform alicloud

**What this PR does / why we need it**:
Fix E2E test panic
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
