### PR TITLE
Add GetBucketInfo to OSS interface

### DIFF
--- a/pkg/alicloud/client/client.go
+++ b/pkg/alicloud/client/client.go
@@ -174,6 +174,16 @@ func (c *ossClient) CreateBucketIfNotExists(ctx context.Context, bucketName stri
 	return c.SetBucketLifecycle(bucketName, rules)
 }
 
+// GetBucketInfo retrieves bucket details.
+func (c *ossClient) GetBucketInfo(_ context.Context, bucketName string) (*oss.BucketInfo, error) {
+	result, err := c.Client.GetBucketInfo(bucketName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result.BucketInfo, nil
+}
+
 // DeleteBucketIfExists deletes the Alicloud OSS bucket with name <bucketName>. If it does not exist,
 // no error is returned.
 func (c *ossClient) DeleteBucketIfExists(ctx context.Context, bucketName string) error {

--- a/pkg/alicloud/client/client_dns.go
+++ b/pkg/alicloud/client/client_dns.go
@@ -23,8 +23,8 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/alidns"
-	"github.com/gardener/gardener/pkg/utils"
 	"golang.org/x/time/rate"
+	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
@@ -139,7 +139,7 @@ func (d *dnsClient) CreateOrUpdateDomainRecords(ctx context.Context, domainName,
 		}
 	}
 	for value, record := range records {
-		if !utils.ValueExists(value, values) {
+		if !slices.Contains(values, value) {
 			if err := d.deleteDomainRecord(ctx, record.RecordId); err != nil {
 				return err
 			}

--- a/pkg/alicloud/client/types.go
+++ b/pkg/alicloud/client/types.go
@@ -185,6 +185,7 @@ type OSS interface {
 	DeleteObjectsWithPrefix(ctx context.Context, bucketName, prefix string) error
 	CreateBucketIfNotExists(ctx context.Context, bucketName string) error
 	DeleteBucketIfExists(ctx context.Context, bucketName string) error
+	GetBucketInfo(ctx context.Context, bucketName string) (*oss.BucketInfo, error)
 }
 
 // VPCInfo contains info about an existing VPC.

--- a/pkg/mock/provider-alicloud/alicloud/client/mocks.go
+++ b/pkg/mock/provider-alicloud/alicloud/client/mocks.go
@@ -11,6 +11,7 @@ import (
 	ecs "github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	resourcemanager "github.com/aliyun/alibaba-cloud-sdk-go/services/resourcemanager"
 	vpc "github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	oss "github.com/aliyun/aliyun-oss-go-sdk/oss"
 	client "github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud/client"
 	ros "github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud/client/ros"
 	gomock "go.uber.org/mock/gomock"
@@ -1281,6 +1282,21 @@ func (m *MockOSS) DeleteObjectsWithPrefix(arg0 context.Context, arg1, arg2 strin
 func (mr *MockOSSMockRecorder) DeleteObjectsWithPrefix(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObjectsWithPrefix", reflect.TypeOf((*MockOSS)(nil).DeleteObjectsWithPrefix), arg0, arg1, arg2)
+}
+
+// GetBucketInfo mocks base method.
+func (m *MockOSS) GetBucketInfo(arg0 context.Context, arg1 string) (*oss.BucketInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBucketInfo", arg0, arg1)
+	ret0, _ := ret[0].(*oss.BucketInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBucketInfo indicates an expected call of GetBucketInfo.
+func (mr *MockOSSMockRecorder) GetBucketInfo(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketInfo", reflect.TypeOf((*MockOSS)(nil).GetBucketInfo), arg0, arg1)
 }
 
 // MockRAM is a mock of RAM interface.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
The OSS client for creating and deleting buckets on Alicloud OSS is reused by the Gardener Installer. After creating the `ExtranetEndpoint`  is needed which can be retrieved via `GetBucketInfo`.

The replacement of `utils.ValueExists` is needed to allow reuse along with Gardener >= `v1.88.x`, as it was removed and replaced with `slices.Contains`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Add GetBucketInfo to OSS client interface.
```
