### PR TITLE
Remove `source-` prefix from `BackupEntry` when performing deletion

### DIFF
--- a/pkg/controller/backupentry/actuator.go
+++ b/pkg/controller/backupentry/actuator.go
@@ -17,9 +17,11 @@ package backupentry
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/backupentry/genericactuator"
 	"github.com/gardener/gardener/extensions/pkg/util"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,6 +52,6 @@ func (a *actuator) Delete(ctx context.Context, _ logr.Logger, be *extensionsv1al
 	if err != nil {
 		return util.DetermineError(err, helper.KnownCodes)
 	}
-
-	return util.DetermineError(cli.DeleteObjectsWithPrefix(ctx, be.Spec.BucketName, fmt.Sprintf("%s/", be.Name)), helper.KnownCodes)
+	entryName := strings.TrimPrefix(be.Name, v1beta1constants.BackupSourcePrefix+"-")
+	return util.DetermineError(cli.DeleteObjectsWithPrefix(ctx, be.Spec.BucketName, fmt.Sprintf("%s/", entryName)), helper.KnownCodes)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug
/platform alicloud

**What this PR does / why we need it**:
This PR removes the `source-` prefix of the given `BackupEntry` when performing entry deletion

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8730

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
`source-` prefix of `BackupEntry` name is being ignored when performing entry deletion
```
