### PR TITLE
change set network vpc condition

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -406,7 +406,7 @@ func (vp *valuesProvider) getControlPlaneChartValues(
 	}
 
 	ccmNetworkFalg := "public"
-	if cluster.Seed != nil && cluster.Seed.Spec.Provider.Type == alicloud.Type {
+	if cluster.Seed != nil && cluster.Seed.Spec.Provider.Type == alicloud.Type && cluster.Shoot != nil && cluster.Seed.Spec.Provider.Region == cluster.Shoot.Spec.Region {
 		ccmNetworkFalg = "vpc"
 	}
 	values := map[string]interface{}{

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -255,8 +255,14 @@ var _ = Describe("ValuesProvider", func() {
 			cluster.Seed = &gardencorev1beta1.Seed{
 				Spec: gardencorev1beta1.SeedSpec{
 					Provider: gardencorev1beta1.SeedProvider{
-						Type: "alicloud",
+						Type:   "alicloud",
+						Region: "region",
 					},
+				},
+			}
+			cluster.Shoot = &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Region: "region",
 				},
 			}
 			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, fakeSecretsManager, checksums, false)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
CCM's network flag will be judged by seed's provider type and the regions of seed and shoot, case provider type is alicloud and the regions are same  it will be set vpc to speed up communication with alicloud API server, other will be set public by default.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
