### PR TITLE
Csi plugin update

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-plugin-rbac.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/auth/csi-plugin-rbac.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "list", "update"]
+  verbs: ["get", "list", "update", "patch"]
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get", "list"]

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
@@ -36,8 +36,6 @@ spec:
       initContainers:
       - name: init
         image: {{ index .Values.images "csi-plugin-alicloud-init" }}
-        # args:
-        #   - --driver=disk
         securityContext:
           privileged: true
           allowPrivilegeEscalation: true

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
@@ -33,6 +33,21 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: init
+        image: {{ index .Values.images "csi-plugin-alicloud-init" }}
+        # args:
+        #   - --driver=disk
+        securityContext:
+          privileged: true
+          allowPrivilegeEscalation: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 1024Mi
       containers:
       - name: driver-registrar
         image: {{ index .Values.images "csi-node-driver-registrar" }}

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/values.yaml
@@ -1,6 +1,7 @@
 images:
   csi-driver-registrar: image-repository:image-tag
   csi-plugin-alicloud: image-repository:image-tag
+  csi-plugin-alicloud-init: image-repository:image-tag
   csi-liveness-probe: image-repository:image-tag
 
 credential:

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -115,7 +115,11 @@ images:
 - name: csi-plugin-alicloud
   sourceRepository: https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver
   repository: registry.eu-central-1.aliyuncs.com/acs/csi-plugin
-  tag: v1.26.1-70dbbcd-aliyun
+  tag: v1.30.1-242df8a-aliyun
+- name: csi-plugin-alicloud-init
+  sourceRepository: https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver
+  repository: registry.eu-central-1.aliyuncs.com/acs/csi-plugin
+  tag: v1.30.1-242df8a-aliyun-init
 - name: csi-liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: registry.k8s.io/sig-storage/livenessprobe

--- a/pkg/alicloud/types.go
+++ b/pkg/alicloud/types.go
@@ -38,6 +38,9 @@ const (
 	// CSIPluginImageName is the name of the CSI plugin image.
 	CSIPluginImageName = "csi-plugin-alicloud"
 
+	// CSIPluginInitImageName is the name of the CSI plugin init image.
+	CSIPluginInitImageName = "csi-plugin-alicloud-init"
+
 	// CSISnapshotValidationWebhookImageName is the name of the csi-snapshot-validation-webhook image.
 	CSISnapshotValidationWebhookImageName = "csi-snapshot-validation-webhook"
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -157,6 +157,7 @@ var controlPlaneShootChart = &chart.Chart{
 			Images: []string{
 				alicloud.CSINodeDriverRegistrarImageName,
 				alicloud.CSIPluginImageName,
+				alicloud.CSIPluginInitImageName,
 				alicloud.CSILivenessProbeImageName,
 			},
 			Objects: []*chart.Object{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
Update csi-plugin-alicloud to v1.30.1-242df8a-aliyun.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
An new init container is added to csi-diskplugin-ds.yaml
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update csi-plugin-alicloud to v1.30.1-242df8a-aliyun
```
