### PR TITLE
switch to docker-buildx as oci-builder

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -6,7 +6,7 @@ gardener-extension-provider-alicloud:
       version:
         preprocess: 'inject-commit-hash'
       publish:
-        oci-builder: 'kaniko'
+        oci-builder: 'docker-buildx'
         dockerimages:
           gardener-extension-provider-alicloud:
             registry: 'gcr-readwrite'
@@ -68,7 +68,7 @@ gardener-extension-provider-alicloud:
               slack_cfg_name: 'scp_workspace'
         component_descriptor: ~
         publish:
-          oci-builder: 'kaniko'
+          oci-builder: 'docker-buildx'
           dockerimages:
             gardener-extension-provider-alicloud:
               tag_as_latest: true


### PR DESCRIPTION
Support for kaniko is planned to be dropped in pipeline-template. Switch to docker-buildx to unblock upstream removal of kaniko-code. This change should be a drop-in-replacement with no additional required actions.

**How to categorize this PR?**
/area delivery
/kind cleanup
/platform alicloud