### PR TITLE
Publish Helm charts as OCI artifacts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,4 +1,25 @@
 gardener-extension-provider-alicloud:
+  templates: 
+    helmcharts:
+    - &provider-alicloud
+      name: provider-alicloud
+      dir: charts/gardener-extension-provider-alicloud
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-provider-alicloud.repository
+        attribute: image.repository
+      - ref: ocm-resource:gardener-extension-provider-alicloud.tag
+        attribute: image.tag
+    - &admission-alicloud
+      name: admission-alicloud
+      dir: charts/gardener-extension-admission-alicloud
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-admission-alicloud.repository
+        attribute: global.image.repository
+      - ref: ocm-resource:gardener-extension-admission-alicloud.tag
+        attribute: global.image.tag
+
   base_definition:
     traits:
       version:
@@ -39,11 +60,19 @@ gardener-extension-provider-alicloud:
         draft_release: ~
         options:
           public_build_logs: true
+        publish:
+          helmcharts:
+          - *provider-alicloud
+          - *admission-alicloud
     pull-request:
       traits:
         pull-request: ~
         options:
           public_build_logs: true
+        publish:
+          helmcharts:
+          - *provider-alicloud
+          - *admission-alicloud
     release:
       steps:
         test-integration:
@@ -76,3 +105,8 @@ gardener-extension-provider-alicloud:
             gardener-extension-admission-alicloud:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/admission-alicloud
               tag_as_latest: true
+          helmcharts:
+          - <<: *provider-alicloud
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
+          - <<: *admission-alicloud
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
We should start publishing Helm charts as OCI artifacts that we can deploy them as `Extension` in the future (see https://github.com/gardener/gardener/issues/9635).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Helm charts of extension and admission controller are published as OCI artifacts now.
```
