### PR TITLE
Inserts Architecture from worker to machineclass 

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -27,6 +27,7 @@ metadata:
     {{- end }}
 {{- if $machineClass.nodeTemplate }}
 nodeTemplate:
+  architecture: {{ $machineClass.nodeTemplate.architecture }}
   capacity:
 {{ toYaml $machineClass.nodeTemplate.capacity | indent 4 }}
   instanceType: {{ $machineClass.nodeTemplate.instanceType }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -5,6 +5,7 @@
 #   imageID: coreos_1745_7_0_64_30G_alibase_20180705.vhd
 #   instanceType: ecs.n1.medium
 #   nodeTemplate:
+#     architecture: amd64
 #     capacity:
 #       cpu: 2
 #       gpu: 0

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -7,6 +7,7 @@ package worker
 import (
 	"context"
 	"fmt"
+	"k8s.io/utils/ptr"
 	"path/filepath"
 	"strconv"
 
@@ -161,11 +162,13 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			})
 
 			if pool.NodeTemplate != nil {
+				arch := ptr.Deref(pool.Architecture, v1beta1constants.ArchitectureAMD64)
 				machineClassSpec["nodeTemplate"] = machinev1alpha1.NodeTemplate{
 					Capacity:     pool.NodeTemplate.Capacity,
 					InstanceType: pool.MachineType,
 					Region:       w.worker.Spec.Region,
 					Zone:         zone,
+					Architecture: ptr.To(arch),
 				}
 			}
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -7,7 +7,6 @@ package worker
 import (
 	"context"
 	"fmt"
-	"k8s.io/utils/ptr"
 	"path/filepath"
 	"strconv"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-provider-alicloud/charts"

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -83,6 +83,9 @@ var _ = Describe("Machines", func() {
 				internetMaxBandwidthOut int
 				spotStrategy            string
 
+				archAMD string
+				archARM string
+
 				machineType           string
 				userData              []byte
 				userDataSecretName    string
@@ -118,9 +121,11 @@ var _ = Describe("Machines", func() {
 				zone1        string
 				zone2        string
 
-				nodeCapacity      corev1.ResourceList
-				nodeTemplateZone1 machinev1alpha1.NodeTemplate
-				nodeTemplateZone2 machinev1alpha1.NodeTemplate
+				nodeCapacity           corev1.ResourceList
+				nodeTemplatePool1Zone1 machinev1alpha1.NodeTemplate
+				nodeTemplatePool1Zone2 machinev1alpha1.NodeTemplate
+				nodeTemplatePool2Zone1 machinev1alpha1.NodeTemplate
+				nodeTemplatePool2Zone2 machinev1alpha1.NodeTemplate
 
 				machineConfiguration *machinev1alpha1.MachineConfiguration
 
@@ -152,6 +157,8 @@ var _ = Describe("Machines", func() {
 				internetMaxBandwidthOut = 5
 				spotStrategy = "NoSpot"
 
+				archAMD = "amd64"
+				archARM = "arm64"
 				machineType = "large"
 				userData = []byte("some-user-data")
 				userDataSecretName = "userdata-secret-name"
@@ -192,20 +199,36 @@ var _ = Describe("Machines", func() {
 					"gpu":    resource.MustParse("1"),
 					"memory": resource.MustParse("128Gi"),
 				}
-				nodeTemplateZone1 = machinev1alpha1.NodeTemplate{
+				nodeTemplatePool1Zone1 = machinev1alpha1.NodeTemplate{
 					Capacity:     nodeCapacity,
 					InstanceType: machineType,
 					Region:       region,
 					Zone:         zone1,
+					Architecture: ptr.To(archAMD),
 				}
 
-				nodeTemplateZone2 = machinev1alpha1.NodeTemplate{
+				nodeTemplatePool1Zone2 = machinev1alpha1.NodeTemplate{
 					Capacity:     nodeCapacity,
 					InstanceType: machineType,
 					Region:       region,
 					Zone:         zone2,
+					Architecture: ptr.To(archAMD),
+				}
+				nodeTemplatePool2Zone1 = machinev1alpha1.NodeTemplate{
+					Capacity:     nodeCapacity,
+					InstanceType: machineType,
+					Region:       region,
+					Zone:         zone1,
+					Architecture: ptr.To(archARM),
 				}
 
+				nodeTemplatePool2Zone2 = machinev1alpha1.NodeTemplate{
+					Capacity:     nodeCapacity,
+					InstanceType: machineType,
+					Region:       region,
+					Zone:         zone2,
+					Architecture: ptr.To(archARM),
+				}
 				machineConfiguration = &machinev1alpha1.MachineConfiguration{}
 
 				shootVersionMajorMinor = "1.2"
@@ -306,6 +329,7 @@ var _ = Describe("Machines", func() {
 								Minimum:        minPool1,
 								Maximum:        maxPool1,
 								MaxSurge:       maxSurgePool1,
+								Architecture:   ptr.To(archAMD),
 								MaxUnavailable: maxUnavailablePool1,
 								MachineType:    machineType,
 								NodeTemplate: &extensionsv1alpha1.NodeTemplate{
@@ -348,6 +372,7 @@ var _ = Describe("Machines", func() {
 								Maximum:        maxPool2,
 								MaxSurge:       maxSurgePool2,
 								MaxUnavailable: maxUnavailablePool2,
+								Architecture:   ptr.To(archARM),
 								MachineType:    machineType,
 								NodeTemplate: &extensionsv1alpha1.NodeTemplate{
 									Capacity: nodeCapacity,
@@ -489,10 +514,10 @@ var _ = Describe("Machines", func() {
 					addNameAndSecretToMachineClass(machineClassPool2Zone1, machineClassWithHashPool2Zone1, w.Spec.SecretRef)
 					addNameAndSecretToMachineClass(machineClassPool2Zone2, machineClassWithHashPool2Zone2, w.Spec.SecretRef)
 
-					addNodeTemplateToMachineClass(machineClassPool1Zone1, nodeTemplateZone1)
-					addNodeTemplateToMachineClass(machineClassPool1Zone2, nodeTemplateZone2)
-					addNodeTemplateToMachineClass(machineClassPool2Zone1, nodeTemplateZone1)
-					addNodeTemplateToMachineClass(machineClassPool2Zone2, nodeTemplateZone2)
+					addNodeTemplateToMachineClass(machineClassPool1Zone1, nodeTemplatePool1Zone1)
+					addNodeTemplateToMachineClass(machineClassPool1Zone2, nodeTemplatePool1Zone2)
+					addNodeTemplateToMachineClass(machineClassPool2Zone1, nodeTemplatePool2Zone1)
+					addNodeTemplateToMachineClass(machineClassPool2Zone2, nodeTemplatePool2Zone2)
 
 					machineClasses = map[string]interface{}{"machineClasses": []map[string]interface{}{
 						machineClassPool1Zone1,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes Part of #https://github.com/gardener/autoscaler/issues/122

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Inserts architecture from worker to the machine class
```
