### PR TITLE
[GEP-26] CredentialsBinding validation via admission webhook

### DIFF
--- a/charts/gardener-extension-admission-alicloud/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-alicloud/charts/application/templates/rbac.yaml
@@ -16,6 +16,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - security.gardener.cloud
+  resources:
+  - credentialsbindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - secrets

--- a/cmd/gardener-extension-admission-alicloud/app/app.go
+++ b/cmd/gardener-extension-admission-alicloud/app/app.go
@@ -14,6 +14,7 @@ import (
 	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
 	"github.com/gardener/gardener/pkg/apis/core/install"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	securityinstall "github.com/gardener/gardener/pkg/apis/security/install"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -118,6 +119,7 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 			}
 
 			install.Install(mgr.GetScheme())
+			securityinstall.Install(mgr.GetScheme())
 
 			if err := alicloudinstall.AddToScheme(mgr.GetScheme()); err != nil {
 				return fmt.Errorf("could not update manager scheme: %w", err)

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -7,7 +7,7 @@ This document describes the configurable options for Alicloud and provides an ex
 ## Alicloud Provider Credentials
 
 In order for Gardener to create a Kubernetes cluster using Alicloud infrastructure components, a Shoot has to provide credentials with sufficient permissions to the desired Alicloud project.
-Every shoot cluster references a `SecretBinding` which itself references a `Secret`, and this `Secret` contains the provider credentials of the Alicloud project.
+Every shoot cluster references a `SecretBinding` or a `CredentialsBinding` which itself references a `Secret`, and this `Secret` contains the provider credentials of the Alicloud project.
 
 This `Secret` must look as follows:
 
@@ -23,7 +23,7 @@ data:
   accessKeySecret: base64(access-key-secret)
 ```
 
-The `SecretBinding` is configurable in the [Shoot cluster](https://github.com/gardener/gardener/blob/master/example/90-shoot.yaml) with the field `secretBindingName`.
+The `SecretBinding`/`CredentialsBinding` is configurable in the [Shoot cluster](https://github.com/gardener/gardener/blob/master/example/90-shoot.yaml) with the field `secretBindingName`/`credentialsBindingName`.
 
 The required credentials for the Alicloud project are an [AccessKey Pair](https://www.alibabacloud.com/help/doc-detail/29009.htm) associated with a [Resource Access Management (RAM) User](https://www.alibabacloud.com/help/doc-detail/28627.htm).
 A RAM user is a special account that can be used by services and applications to interact with Alicloud Cloud Platform APIs.

--- a/pkg/admission/validator/credentialsbinding.go
+++ b/pkg/admission/validator/credentialsbinding.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/security"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	alicloudvalidation "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/validation"
+)
+
+type credentialsBinding struct {
+	apiReader client.Reader
+}
+
+// NewCredentialsBindingValidator returns a new instance of a credentials binding validator.
+func NewCredentialsBindingValidator(mgr manager.Manager) extensionswebhook.Validator {
+	return &credentialsBinding{
+		apiReader: mgr.GetAPIReader(),
+	}
+}
+
+// Validate checks whether the given CredentialsBinding refers to valid Alicloud credentials.
+func (cb *credentialsBinding) Validate(ctx context.Context, newObj, oldObj client.Object) error {
+	credentialsBinding, ok := newObj.(*security.CredentialsBinding)
+	if !ok {
+		return fmt.Errorf("wrong object type %T", newObj)
+	}
+
+	if oldObj != nil {
+		_, ok := oldObj.(*security.CredentialsBinding)
+		if !ok {
+			return fmt.Errorf("wrong object type %T for old object", oldObj)
+		}
+
+		// The relevant fields of the credentials binding are immutable so we can exit early on update
+		return nil
+	}
+
+	// Explicitly use the client.Reader to prevent controller-runtime to start Informer for Secrets/WorkloadIdentities
+	// under the hood. The latter increases the memory usage of the component.
+	var credentialsKey = client.ObjectKey{Namespace: credentialsBinding.CredentialsRef.Namespace, Name: credentialsBinding.CredentialsRef.Name}
+	switch {
+	case credentialsBinding.CredentialsRef.APIVersion == corev1.SchemeGroupVersion.String() && credentialsBinding.CredentialsRef.Kind == "Secret":
+		secret := &corev1.Secret{}
+		if err := cb.apiReader.Get(ctx, credentialsKey, secret); err != nil {
+			return err
+		}
+
+		return alicloudvalidation.ValidateCloudProviderSecret(secret)
+	default:
+		return fmt.Errorf("unsupported credentials reference: version %q, kind %q", credentialsBinding.CredentialsRef.APIVersion, credentialsBinding.CredentialsRef.Kind)
+	}
+}

--- a/pkg/admission/validator/credentialsbinding_test.go
+++ b/pkg/admission/validator/credentialsbinding_test.go
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/security"
+	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	mockmanager "github.com/gardener/gardener/third_party/mock/controller-runtime/manager"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/admission/validator"
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
+)
+
+var _ = Describe("CredentialsBinding validator", func() {
+	Describe("#Validate", func() {
+		const (
+			namespace = "garden-dev"
+			name      = "my-provider-account"
+		)
+
+		var (
+			credentialsBindingValidator extensionswebhook.Validator
+
+			ctrl      *gomock.Controller
+			mgr       *mockmanager.MockManager
+			apiReader *mockclient.MockReader
+
+			ctx                = context.TODO()
+			credentialsBinding *security.CredentialsBinding
+
+			fakeErr = fmt.Errorf("fake err")
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+
+			mgr = mockmanager.NewMockManager(ctrl)
+
+			apiReader = mockclient.NewMockReader(ctrl)
+			mgr.EXPECT().GetAPIReader().Return(apiReader)
+
+			credentialsBindingValidator = validator.NewCredentialsBindingValidator(mgr)
+
+			credentialsBinding = &security.CredentialsBinding{
+				CredentialsRef: corev1.ObjectReference{
+					Name:       name,
+					Namespace:  namespace,
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+			}
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("should return err when obj is not a CredentialsBinding", func() {
+			err := credentialsBindingValidator.Validate(ctx, &corev1.Secret{}, nil)
+			Expect(err).To(MatchError("wrong object type *v1.Secret"))
+		})
+
+		It("should return err when oldObj is not a CredentialsBinding", func() {
+			err := credentialsBindingValidator.Validate(ctx, &security.CredentialsBinding{}, &corev1.Secret{})
+			Expect(err).To(MatchError("wrong object type *v1.Secret for old object"))
+		})
+
+		It("should return err if the CredentialsBinding references unknown credentials type", func() {
+			credentialsBinding.CredentialsRef.APIVersion = "unknown"
+			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+			Expect(err).To(MatchError(errors.New(`unsupported credentials reference: version "unknown", kind "Secret"`)))
+		})
+
+		It("should return err if it fails to get the corresponding Secret", func() {
+			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
+
+			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+			Expect(err).To(MatchError(fakeErr))
+		})
+
+		It("should return err when the corresponding Secret is not valid", func() {
+			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+					secret := &corev1.Secret{Data: map[string][]byte{
+						"foo": []byte("bar"),
+					}}
+					*obj = *secret
+					return nil
+				})
+
+			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return nil when the corresponding Secret is valid", func() {
+			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+					secret := &corev1.Secret{Data: map[string][]byte{
+						alicloud.AccessKeyID:     []byte(strings.Repeat("a", 16)),
+						alicloud.AccessKeySecret: []byte(strings.Repeat("b", 30)),
+					}}
+					*obj = *secret
+					return nil
+				})
+
+			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return nil when the CredentialsBinding did not change", func() {
+			old := credentialsBinding.DeepCopy()
+
+			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, old)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/pkg/admission/validator/credentialsbinding_test.go
+++ b/pkg/admission/validator/credentialsbinding_test.go
@@ -105,7 +105,7 @@ var _ = Describe("CredentialsBinding validator", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should return nil when the corresponding Secret is valid", func() {
+		It("should succeed when the corresponding Secret is valid", func() {
 			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
 				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
 					secret := &corev1.Secret{Data: map[string][]byte{
@@ -116,15 +116,13 @@ var _ = Describe("CredentialsBinding validator", func() {
 					return nil
 				})
 
-			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)).To(Succeed())
 		})
 
 		It("should return nil when the CredentialsBinding did not change", func() {
 			old := credentialsBinding.DeepCopy()
 
-			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, old)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(credentialsBindingValidator.Validate(ctx, credentialsBinding, old)).To(Succeed())
 		})
 	})
 })

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -27,7 +27,7 @@ const (
 
 var logger = log.Log.WithName("alicloud-validator-webhook")
 
-// New creates a new webhook that validates Shoot and CloudProfile resources.
+// New creates a new webhook that validates Shoot, CloudProfile, SecretBinding and CredentialsBinding resources.
 func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 	logger.Info("Setting up webhook", "name", Name)
 
@@ -37,9 +37,11 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Path:       "/webhooks/validate",
 		Predicates: []predicate.Predicate{extensionspredicate.GardenCoreProviderType(alicloud.Type)},
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
-			NewShootValidator(mgr):              {{Obj: &core.Shoot{}}},
-			NewCloudProfileValidator(mgr):       {{Obj: &core.CloudProfile{}}},
-			NewSecretBindingValidator(mgr):      {{Obj: &core.SecretBinding{}}},
+			NewShootValidator(mgr):         {{Obj: &core.Shoot{}}},
+			NewCloudProfileValidator(mgr):  {{Obj: &core.CloudProfile{}}},
+			NewSecretBindingValidator(mgr): {{Obj: &core.SecretBinding{}}},
+			// TODO(dimityrmirchev): Uncomment this line once this extension uses a g/g version that contains https://github.com/gardener/gardener/pull/10499
+			// Predicates: []predicate.Predicate{predicate.Or(extensionspredicate.GardenCoreProviderType(alicloud.Type), extensionspredicate.GardenSecurityProviderType(alicloud.Type))},
 			NewCredentialsBindingValidator(mgr): {{Obj: &security.CredentialsBinding{}}},
 		},
 		Target: extensionswebhook.TargetSeed,

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -8,6 +8,7 @@ import (
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/security"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -36,9 +37,10 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Path:       "/webhooks/validate",
 		Predicates: []predicate.Predicate{extensionspredicate.GardenCoreProviderType(alicloud.Type)},
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
-			NewShootValidator(mgr):         {{Obj: &core.Shoot{}}},
-			NewCloudProfileValidator(mgr):  {{Obj: &core.CloudProfile{}}},
-			NewSecretBindingValidator(mgr): {{Obj: &core.SecretBinding{}}},
+			NewShootValidator(mgr):              {{Obj: &core.Shoot{}}},
+			NewCloudProfileValidator(mgr):       {{Obj: &core.CloudProfile{}}},
+			NewSecretBindingValidator(mgr):      {{Obj: &core.SecretBinding{}}},
+			NewCredentialsBindingValidator(mgr): {{Obj: &security.CredentialsBinding{}}},
 		},
 		Target: extensionswebhook.TargetSeed,
 		ObjectSelector: &metav1.LabelSelector{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security ipcei
/kind enhancement
/label ipcei/workload-identity
/platform alicloud

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
cc @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The admission webhook now validates `CredentialsBinding`s.
```
