### PR TITLE
export egress cidrs to status

### DIFF
--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -614,10 +614,17 @@ func (a *actuator) reconcile(ctx context.Context, log logr.Logger, infra *extens
 	if err != nil {
 		return err
 	}
+	egressCidrs, err := getEgressCidrs(state)
+	if err != nil {
+		return err
+	}
 
 	patch := client.MergeFrom(infra.DeepCopy())
 	infra.Status.ProviderStatus = &runtime.RawExtension{Object: status}
 	infra.Status.State = &runtime.RawExtension{Raw: stateByte}
+	if egressCidrs != nil {
+		infra.Status.EgressCIDRs = egressCidrs
+	}
 	return a.client.Status().Patch(ctx, infra, patch)
 }
 

--- a/pkg/controller/infrastructure/actuator_flow.go
+++ b/pkg/controller/infrastructure/actuator_flow.go
@@ -125,7 +125,7 @@ func (a *actuator) updateStatusProvider(ctx context.Context, infra *extensionsv1
 
 	patch := client.MergeFrom(infra.DeepCopy())
 	infra.Status.ProviderStatus = &runtime.RawExtension{Object: infrastructureStatus}
-	egressCidrs := GetEgressIpCidrs(state)
+	egressCidrs := getEgressIpCidrs(state)
 	if egressCidrs != nil {
 		infra.Status.EgressCIDRs = egressCidrs
 	}
@@ -133,7 +133,7 @@ func (a *actuator) updateStatusProvider(ctx context.Context, infra *extensionsv1
 
 }
 
-func GetEgressIpCidrs(state *infraflow.PersistentState) []string {
+func getEgressIpCidrs(state *infraflow.PersistentState) []string {
 	if len(state.Data) == 0 {
 		return nil
 	}

--- a/pkg/controller/infrastructure/actuator_flow.go
+++ b/pkg/controller/infrastructure/actuator_flow.go
@@ -125,7 +125,40 @@ func (a *actuator) updateStatusProvider(ctx context.Context, infra *extensionsv1
 
 	patch := client.MergeFrom(infra.DeepCopy())
 	infra.Status.ProviderStatus = &runtime.RawExtension{Object: infrastructureStatus}
+	egressCidrs := GetEgressIpCidrs(state)
+	if egressCidrs != nil {
+		infra.Status.EgressCIDRs = egressCidrs
+	}
 	return a.client.Status().Patch(ctx, infra, patch)
+
+}
+
+func GetEgressIpCidrs(state *infraflow.PersistentState) []string {
+	if len(state.Data) == 0 {
+		return nil
+	}
+
+	cidrs := []string{}
+	prefix := infraflow.ChildIdZones + shared.Separator
+	for k, v := range state.Data {
+		if !shared.IsValidValue(v) {
+			continue
+		}
+		if strings.HasPrefix(k, prefix) {
+			parts := strings.Split(k, shared.Separator)
+			if len(parts) != 3 {
+				continue
+			}
+			if parts[2] == infraflow.ZoneNATGWElasticIPAddress {
+				cidrs = append(cidrs, v+"/32")
+			}
+		}
+	}
+	if len(cidrs) == 0 {
+		return nil
+	}
+
+	return cidrs
 
 }
 

--- a/pkg/controller/infrastructure/tf_migration.go
+++ b/pkg/controller/infrastructure/tf_migration.go
@@ -6,6 +6,7 @@ package infrastructure
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -94,6 +95,9 @@ func getTerraformerRawState(state *runtime.RawExtension) (*terraformer.RawState,
 func getEgressCidrs(terraformState *terraformer.RawState) ([]string, error) {
 	tfState, err := shared.UnmarshalTerraformStateFromTerraformer(terraformState)
 	if err != nil {
+		if strings.Contains(err.Error(), "could not decode terraform state") {
+			return nil, nil
+		}
 		return nil, err
 	}
 	resources := tfState.FindManagedResourcesByType("alicloud_eip")

--- a/pkg/controller/infrastructure/tf_migration.go
+++ b/pkg/controller/infrastructure/tf_migration.go
@@ -6,7 +6,6 @@ package infrastructure
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -95,9 +94,6 @@ func getTerraformerRawState(state *runtime.RawExtension) (*terraformer.RawState,
 func getEgressCidrs(terraformState *terraformer.RawState) ([]string, error) {
 	tfState, err := shared.UnmarshalTerraformStateFromTerraformer(terraformState)
 	if err != nil {
-		if strings.Contains(err.Error(), "could not decode terraform state") {
-			return nil, nil
-		}
 		return nil, err
 	}
 	resources := tfState.FindManagedResourcesByType("alicloud_eip")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
With this PR the CIDR-Ranges used for cluster-egress will be provided in the shoot's infrastructure resource.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The CIDR blocks used for shoot egress will now be provided via the status of the shoot's infrastructure-resource
```
