### PR TITLE
Fixes Alicloud bastion instance CPU architecture not aligning with the image CPU architecture in certain conditions

### DIFF
--- a/pkg/alicloud/client/client.go
+++ b/pkg/alicloud/client/client.go
@@ -221,6 +221,18 @@ func (c *ecsClient) CheckIfImageExists(imageID string) (bool, error) {
 	return response.TotalCount > 0, nil
 }
 
+// GetImageInfo returns image metadata by imageID
+func (c *ecsClient) GetImageInfo(imageID string) (*ecs.DescribeImagesResponse, error) {
+	request := ecs.CreateDescribeImagesRequest()
+	request.ImageId = imageID
+	request.SetScheme("HTTPS")
+	response, err := c.DescribeImages(request)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
 // GetSecurityGroup return security group metadata by security group name
 func (c *ecsClient) GetSecurityGroup(name string) (*ecs.DescribeSecurityGroupsResponse, error) {
 	request := ecs.CreateDescribeSecurityGroupsRequest()
@@ -245,8 +257,8 @@ func (c *ecsClient) GetInstances(name string) (*ecs.DescribeInstancesResponse, e
 	return c.DescribeInstances(request)
 }
 
-// GetInstanceType return metadata of instance type
-func (c *ecsClient) GetInstanceType(cores int, zoneID string) (*ecs.DescribeAvailableResourceResponse, error) {
+// GetAvailableInstanceType return metadata of instance type
+func (c *ecsClient) GetAvailableInstanceType(cores int, zoneID string) (*ecs.DescribeAvailableResourceResponse, error) {
 	request := ecs.CreateDescribeAvailableResourceRequest()
 	request.SetScheme("HTTPS")
 	request.DestinationResource = "InstanceType"
@@ -255,6 +267,13 @@ func (c *ecsClient) GetInstanceType(cores int, zoneID string) (*ecs.DescribeAvai
 	request.Cores = requests.NewInteger(cores)
 	request.ZoneId = zoneID
 	return c.DescribeAvailableResource(request)
+}
+
+// ListAllInstanceType return metadata of instance type
+func (c *ecsClient) ListAllInstanceType() (*ecs.DescribeInstanceTypesResponse, error) {
+	request := ecs.CreateDescribeInstanceTypesRequest()
+	request.SetScheme("HTTPS")
+	return c.DescribeInstanceTypes(request)
 }
 
 // CreateInstance create a instance

--- a/pkg/alicloud/client/types.go
+++ b/pkg/alicloud/client/types.go
@@ -50,6 +50,7 @@ type ecsClient struct {
 type ECS interface {
 	CheckIfImageExists(imageID string) (bool, error)
 	CheckIfImageOwnedByAliCloud(imageID string) (bool, error)
+	GetImageInfo(imageID string) (*ecs.DescribeImagesResponse, error)
 	ShareImageToAccount(ctx context.Context, regionID, imageID, accountID string) error
 	GetSecurityGroup(name string) (*ecs.DescribeSecurityGroupsResponse, error)
 	GetSecurityGroupWithID(id string) (*ecs.DescribeSecurityGroupsResponse, error)
@@ -58,7 +59,8 @@ type ECS interface {
 	DescribeKeyPairs(request *ecs.DescribeKeyPairsRequest) (*ecs.DescribeKeyPairsResponse, error)
 	DetachECSInstancesFromSSHKeyPair(keyName string) error
 	GetInstances(name string) (*ecs.DescribeInstancesResponse, error)
-	GetInstanceType(core int, zoneID string) (*ecs.DescribeAvailableResourceResponse, error)
+	GetAvailableInstanceType(core int, zoneID string) (*ecs.DescribeAvailableResourceResponse, error)
+	ListAllInstanceType() (*ecs.DescribeInstanceTypesResponse, error)
 	CreateInstances(instanceName, securityGroupID, imageID, vSwitchId, zoneID, instanceTypeID, userData string) (*ecs.RunInstancesResponse, error)
 	DeleteInstances(id string, force bool) error
 	CreateSecurityGroups(vpcId, name string) (*ecs.CreateSecurityGroupResponse, error)

--- a/pkg/mock/provider-alicloud/alicloud/client/mocks.go
+++ b/pkg/mock/provider-alicloud/alicloud/client/mocks.go
@@ -457,19 +457,34 @@ func (mr *MockECSMockRecorder) DetachECSInstancesFromSSHKeyPair(keyName any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachECSInstancesFromSSHKeyPair", reflect.TypeOf((*MockECS)(nil).DetachECSInstancesFromSSHKeyPair), keyName)
 }
 
-// GetInstanceType mocks base method.
-func (m *MockECS) GetInstanceType(core int, zoneID string) (*ecs.DescribeAvailableResourceResponse, error) {
+// GetAvailableInstanceType mocks base method.
+func (m *MockECS) GetAvailableInstanceType(core int, zoneID string) (*ecs.DescribeAvailableResourceResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInstanceType", core, zoneID)
+	ret := m.ctrl.Call(m, "GetAvailableInstanceType", core, zoneID)
 	ret0, _ := ret[0].(*ecs.DescribeAvailableResourceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetInstanceType indicates an expected call of GetInstanceType.
-func (mr *MockECSMockRecorder) GetInstanceType(core, zoneID any) *gomock.Call {
+// GetAvailableInstanceType indicates an expected call of GetAvailableInstanceType.
+func (mr *MockECSMockRecorder) GetAvailableInstanceType(core, zoneID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceType", reflect.TypeOf((*MockECS)(nil).GetInstanceType), core, zoneID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAvailableInstanceType", reflect.TypeOf((*MockECS)(nil).GetAvailableInstanceType), core, zoneID)
+}
+
+// GetImageInfo mocks base method.
+func (m *MockECS) GetImageInfo(imageID string) (*ecs.DescribeImagesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImageInfo", imageID)
+	ret0, _ := ret[0].(*ecs.DescribeImagesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImageInfo indicates an expected call of GetImageInfo.
+func (mr *MockECSMockRecorder) GetImageInfo(imageID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageInfo", reflect.TypeOf((*MockECS)(nil).GetImageInfo), imageID)
 }
 
 // GetInstances mocks base method.
@@ -515,6 +530,21 @@ func (m *MockECS) GetSecurityGroupWithID(id string) (*ecs.DescribeSecurityGroups
 func (mr *MockECSMockRecorder) GetSecurityGroupWithID(id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecurityGroupWithID", reflect.TypeOf((*MockECS)(nil).GetSecurityGroupWithID), id)
+}
+
+// ListAllInstanceType mocks base method.
+func (m *MockECS) ListAllInstanceType() (*ecs.DescribeInstanceTypesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllInstanceType")
+	ret0, _ := ret[0].(*ecs.DescribeInstanceTypesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllInstanceType indicates an expected call of ListAllInstanceType.
+func (mr *MockECSMockRecorder) ListAllInstanceType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllInstanceType", reflect.TypeOf((*MockECS)(nil).ListAllInstanceType))
 }
 
 // ListTagResources mocks base method.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
* Add GetImageInfo method and refactor instance type retrieval in ECS client
* Fixes Alicloud bastion instance CPU architecture not aligning with the image CPU architecture in certain conditions

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixes Alicloud bastion instance CPU architecture not aligning with the image CPU architecture in certain conditions
```

cc @DelinaDeng 
