### PR TITLE
chore: Clean up object selector version constraint

### DIFF
--- a/cmd/gardener-extension-provider-alicloud/app/app.go
+++ b/cmd/gardener-extension-provider-alicloud/app/app.go
@@ -119,9 +119,8 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			Namespace: os.Getenv("WEBHOOK_CONFIG_NAMESPACE"),
 		}
 
-		gardenerVersion    = new(string)
 		controllerSwitches = alicloudcmd.ControllerSwitchOptions()
-		webhookSwitches    = alicloudcmd.WebhookSwitchOptions(gardenerVersion)
+		webhookSwitches    = alicloudcmd.WebhookSwitchOptions()
 		webhookOptions     = webhookcmd.NewAddToManagerOptions(
 			alicloud.Name,
 			genericactuator.ShootWebhooksResourceName,
@@ -216,8 +215,6 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			}
 
 			log.Info("Adding controllers to manager")
-			*gardenerVersion = generalOpts.Completed().GardenerVersion
-
 			configFileOpts.Completed().ApplyMachineImageOwnerSecretRef(&alicloudinfrastructure.DefaultAddOptions.MachineImageOwnerSecretRef)
 			configFileOpts.Completed().ApplyToBeSharedImageIDs(&alicloudinfrastructure.DefaultAddOptions.ToBeSharedImageIDs)
 			configFileOpts.Completed().ApplyETCDStorage(&alicloudcontrolplaneexposure.DefaultAddOptions.ETCDStorage)

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -62,9 +62,9 @@ func ControllerSwitchOptions() *controllercmd.SwitchOptions {
 }
 
 // WebhookSwitchOptions are the webhookcmd.SwitchOptions for the provider webhooks.
-func WebhookSwitchOptions(gardenerVersion *string) *webhookcmd.SwitchOptions {
+func WebhookSwitchOptions() *webhookcmd.SwitchOptions {
 	return webhookcmd.NewSwitchOptions(
-		webhookcmd.Switch(extensioncontrolplanewebhook.WebhookName, controlplanewebhook.AddToManager(gardenerVersion)),
+		webhookcmd.Switch(extensioncontrolplanewebhook.WebhookName, controlplanewebhook.AddToManager),
 		webhookcmd.Switch(extensioncontrolplanewebhook.ExposureWebhookName, controlplaneexposurewebhook.AddToManager),
 		webhookcmd.Switch(extensionshootwebhook.WebhookName, shootwebhook.AddToManager),
 	)

--- a/pkg/webhook/controlplane/add.go
+++ b/pkg/webhook/controlplane/add.go
@@ -5,9 +5,6 @@
 package controlplane
 
 import (
-	"fmt"
-
-	"github.com/Masterminds/semver/v3"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
@@ -17,7 +14,6 @@ import (
 	oscutils "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -27,43 +23,22 @@ import (
 
 var (
 	logger = log.Log.WithName("alicloud-controlplane-webhook")
-	// TODO(LucaBernstein): Clean up the gardener version check after November/2024.
-	versionConstraintGreaterEqual198 *semver.Constraints
 )
 
-func init() {
-	var err error
-	versionConstraintGreaterEqual198, err = semver.NewConstraint(">= 1.98")
-	utilruntime.Must(err)
-}
-
 // AddToManager creates a webhook and adds it to the manager.
-func AddToManager(gardenerVersion *string) func(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
-	return func(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
-		var objectSelector *metav1.LabelSelector
-		if gardenerVersion != nil && len(*gardenerVersion) > 0 {
-			version, err := semver.NewVersion(*gardenerVersion)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse gardener version: %v", err)
-			}
-			if versionConstraintGreaterEqual198.Check(version) {
-				objectSelector = &metav1.LabelSelector{MatchLabels: map[string]string{v1beta1constants.LabelExtensionProviderMutatedByControlplaneWebhook: "true"}}
-			}
-		}
-
-		logger.Info("Adding webhook to manager")
-		fciCodec := oscutils.NewFileContentInlineCodec()
-		return controlplane.New(mgr, controlplane.Args{
-			Kind:     controlplane.KindShoot,
-			Provider: alicloud.Type,
-			Types: []extensionswebhook.Type{
-				{Obj: &appsv1.Deployment{}},
-				{Obj: &vpaautoscalingv1.VerticalPodAutoscaler{}},
-				{Obj: &extensionsv1alpha1.OperatingSystemConfig{}},
-			},
-			ObjectSelector: objectSelector,
-			Mutator: genericmutator.NewMutator(mgr, NewEnsurer(logger), oscutils.NewUnitSerializer(),
-				kubelet.NewConfigCodec(fciCodec), fciCodec, logger),
-		})
-	}
+func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	logger.Info("Adding webhook to manager")
+	fciCodec := oscutils.NewFileContentInlineCodec()
+	return controlplane.New(mgr, controlplane.Args{
+		Kind:     controlplane.KindShoot,
+		Provider: alicloud.Type,
+		Types: []extensionswebhook.Type{
+			{Obj: &appsv1.Deployment{}},
+			{Obj: &vpaautoscalingv1.VerticalPodAutoscaler{}},
+			{Obj: &extensionsv1alpha1.OperatingSystemConfig{}},
+		},
+		ObjectSelector: &metav1.LabelSelector{MatchLabels: map[string]string{v1beta1constants.LabelExtensionProviderMutatedByControlplaneWebhook: "true"}},
+		Mutator: genericmutator.NewMutator(mgr, NewEnsurer(logger), oscutils.NewUnitSerializer(),
+			kubelet.NewConfigCodec(fciCodec), fciCodec, logger),
+	})
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/platform alicloud

**What this PR does / why we need it**:
Remove gardener version constraint for controlplane webhook object selector.

**Which issue(s) this PR fixes**:
Followup cleanup to https://github.com/gardener/gardener/issues/9864.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
