### PR TITLE
Rename to `seedprovider` webhook

### DIFF
--- a/cmd/gardener-extension-provider-alicloud/app/app.go
+++ b/cmd/gardener-extension-provider-alicloud/app/app.go
@@ -41,7 +41,7 @@ import (
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/healthcheck"
 	alicloudinfrastructure "github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/infrastructure"
 	alicloudworker "github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/worker"
-	alicloudcontrolplaneexposure "github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/controlplaneexposure"
+	alicloudseedprovider "github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/seedprovider"
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/shoot"
 )
 
@@ -217,7 +217,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			log.Info("Adding controllers to manager")
 			configFileOpts.Completed().ApplyMachineImageOwnerSecretRef(&alicloudinfrastructure.DefaultAddOptions.MachineImageOwnerSecretRef)
 			configFileOpts.Completed().ApplyToBeSharedImageIDs(&alicloudinfrastructure.DefaultAddOptions.ToBeSharedImageIDs)
-			configFileOpts.Completed().ApplyETCDStorage(&alicloudcontrolplaneexposure.DefaultAddOptions.ETCDStorage)
+			configFileOpts.Completed().ApplyETCDStorage(&alicloudseedprovider.DefaultAddOptions.ETCDStorage)
 			configFileOpts.Completed().ApplyService(&shoot.DefaultAddOptions.Service)
 			configFileOpts.Completed().ApplyHealthCheckConfig(&healthcheck.DefaultAddOptions.HealthCheckConfig)
 			configFileOpts.Completed().ApplyCSI(&alicloudcontrolplane.DefaultAddOptions.CSI)

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -33,7 +33,7 @@ import (
 	infrastructurecontroller "github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/infrastructure"
 	workercontroller "github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/worker"
 	controlplanewebhook "github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/controlplane"
-	controlplaneexposurewebhook "github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/controlplaneexposure"
+	seedproviderwebhook "github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/seedprovider"
 	shootwebhook "github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/shoot"
 )
 
@@ -65,7 +65,7 @@ func ControllerSwitchOptions() *controllercmd.SwitchOptions {
 func WebhookSwitchOptions() *webhookcmd.SwitchOptions {
 	return webhookcmd.NewSwitchOptions(
 		webhookcmd.Switch(extensioncontrolplanewebhook.WebhookName, controlplanewebhook.AddToManager),
-		webhookcmd.Switch(extensioncontrolplanewebhook.ExposureWebhookName, controlplaneexposurewebhook.AddToManager),
+		webhookcmd.Switch(extensioncontrolplanewebhook.ExposureWebhookName, seedproviderwebhook.AddToManager),
 		webhookcmd.Switch(extensionshootwebhook.WebhookName, shootwebhook.AddToManager),
 	)
 }

--- a/pkg/webhook/seedprovider/add.go
+++ b/pkg/webhook/seedprovider/add.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package controlplaneexposure
+package seedprovider
 
 import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
@@ -21,13 +21,13 @@ var (
 	DefaultAddOptions = AddOptions{}
 )
 
-// AddOptions are options to apply when adding the Alicloud exposure webhook to the manager.
+// AddOptions are options to apply when adding the Alicloud seedprovider webhook to the manager.
 type AddOptions struct {
 	// ETCDStorage is the etcd storage configuration.
 	ETCDStorage config.ETCDStorage
 }
 
-var logger = log.Log.WithName("alicloud-controlplaneexposure-webhook")
+var logger = log.Log.WithName("alicloud-seedprovider-webhook")
 
 // AddToManagerWithOptions creates a webhook with the given options and adds it to the manager.
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) (*extensionswebhook.Webhook, error) {

--- a/pkg/webhook/seedprovider/ensurer.go
+++ b/pkg/webhook/seedprovider/ensurer.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package controlplaneexposure
+package seedprovider
 
 import (
 	"context"
@@ -17,11 +17,11 @@ import (
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/config"
 )
 
-// NewEnsurer creates a new controlplaneexposure ensurer.
+// NewEnsurer creates a new seedprovider ensurer.
 func NewEnsurer(etcdStorage *config.ETCDStorage, logger logr.Logger) genericmutator.Ensurer {
 	return &ensurer{
 		etcdStorage: etcdStorage,
-		logger:      logger.WithName("alicloud-controlplaneexposure-ensurer"),
+		logger:      logger.WithName("alicloud-seedprovider-ensurer"),
 	}
 }
 

--- a/pkg/webhook/seedprovider/ensurer_test.go
+++ b/pkg/webhook/seedprovider/ensurer_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package controlplaneexposure
+package seedprovider
 
 import (
 	"context"
@@ -27,7 +27,7 @@ const (
 
 func TestController(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Controlplane Exposure Webhook Suite")
+	RunSpecs(t, "Seedprovider Webhook Suite")
 }
 
 var _ = Describe("Ensurer", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup
/platform alicloud

**What this PR does / why we need it**:
Rename packages, loggers and variables according to the new name.

Which issue(s) this PR fixes:
Followup renaming of https://github.com/gardener/gardener/issues/10017.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
