### PR TITLE
Enable support for `NamespacedCloudProfile`s, including custom machine images (versions)

### DIFF
--- a/charts/gardener-extension-admission-alicloud/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-alicloud/charts/application/templates/rbac.yaml
@@ -10,6 +10,7 @@ rules:
   - core.gardener.cloud
   resources:
   - cloudprofiles
+  - namespacedcloudprofiles
   - secretbindings
   verbs:
   - get

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -208,7 +208,8 @@ metadata:
   name: johndoe-alicloud
   namespace: garden-dev
 spec:
-  cloudProfileName: alicloud
+  cloudProfile:
+    name: alicloud
   region: eu-central-1
   secretBindingName: core-alicloud
   provider:
@@ -263,7 +264,8 @@ metadata:
   name: johndoe-alicloud
   namespace: garden-dev
 spec:
-  cloudProfileName: alicloud
+  cloudProfile:
+    name: alicloud
   region: eu-central-1
   secretBindingName: core-alicloud
   provider:

--- a/pkg/admission/cmd/options.go
+++ b/pkg/admission/cmd/options.go
@@ -16,6 +16,6 @@ func GardenWebhookSwitchOptions() *webhookcmd.SwitchOptions {
 	return webhookcmd.NewSwitchOptions(
 		webhookcmd.Switch(validator.Name, validator.New),
 		webhookcmd.Switch(validator.SecretsValidatorName, validator.NewSecretsWebhook),
-		webhookcmd.Switch(mutator.ShootMutatorName, mutator.NewShootsWebhook),
+		webhookcmd.Switch(mutator.Name, mutator.New),
 	)
 }

--- a/pkg/admission/mutator/namespacedcloudprofile.go
+++ b/pkg/admission/mutator/namespacedcloudprofile.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mutator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/v1alpha1"
+)
+
+// NewNamespacedCloudProfileMutator returns a new instance of a NamespacedCloudProfile mutator.
+func NewNamespacedCloudProfileMutator(mgr manager.Manager) extensionswebhook.Mutator {
+	return &namespacedCloudProfile{
+		client:  mgr.GetClient(),
+		decoder: serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
+	}
+}
+
+type namespacedCloudProfile struct {
+	client  client.Client
+	decoder runtime.Decoder
+}
+
+// Mutate mutates the given NamespacedCloudProfile object.
+func (p *namespacedCloudProfile) Mutate(_ context.Context, newObj, _ client.Object) error {
+	profile, ok := newObj.(*gardencorev1beta1.NamespacedCloudProfile)
+	if !ok {
+		return fmt.Errorf("wrong object type %T", newObj)
+	}
+
+	// Ignore NamespacedCloudProfiles being deleted and wait for core mutator to patch the status.
+	if profile.DeletionTimestamp != nil || profile.Generation != profile.Status.ObservedGeneration ||
+		profile.Spec.ProviderConfig == nil || profile.Status.CloudProfileSpec.ProviderConfig == nil {
+		return nil
+	}
+
+	specConfig := &v1alpha1.CloudProfileConfig{}
+	if _, _, err := p.decoder.Decode(profile.Spec.ProviderConfig.Raw, nil, specConfig); err != nil {
+		return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile spec for '%s': %w", profile.Name, err)
+	}
+	statusConfig := &v1alpha1.CloudProfileConfig{}
+	if _, _, err := p.decoder.Decode(profile.Status.CloudProfileSpec.ProviderConfig.Raw, nil, statusConfig); err != nil {
+		return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile status for '%s': %w", profile.Name, err)
+	}
+
+	statusConfig.MachineImages = mergeMachineImages(specConfig.MachineImages, statusConfig.MachineImages)
+
+	modifiedStatusConfig, err := json.Marshal(statusConfig)
+	if err != nil {
+		return err
+	}
+	profile.Status.CloudProfileSpec.ProviderConfig.Raw = modifiedStatusConfig
+
+	return nil
+}
+
+func mergeMachineImages(specMachineImages, statusMachineImages []v1alpha1.MachineImages) []v1alpha1.MachineImages {
+	specImages := utils.CreateMapFromSlice(specMachineImages, func(mi v1alpha1.MachineImages) string { return mi.Name })
+	statusImages := utils.CreateMapFromSlice(statusMachineImages, func(mi v1alpha1.MachineImages) string { return mi.Name })
+	for _, specMachineImage := range specImages {
+		if _, exists := statusImages[specMachineImage.Name]; !exists {
+			statusImages[specMachineImage.Name] = specMachineImage
+		} else {
+			statusImageVersions := utils.CreateMapFromSlice(statusImages[specMachineImage.Name].Versions, func(v v1alpha1.MachineImageVersion) string { return v.Version })
+			specImageVersions := utils.CreateMapFromSlice(specImages[specMachineImage.Name].Versions, func(v v1alpha1.MachineImageVersion) string { return v.Version })
+			for _, version := range specImageVersions {
+				statusImageVersions[version.Version] = version
+			}
+
+			statusImages[specMachineImage.Name] = v1alpha1.MachineImages{
+				Name:     specMachineImage.Name,
+				Versions: slices.Collect(maps.Values(statusImageVersions)),
+			}
+		}
+	}
+	return slices.Collect(maps.Values(statusImages))
+}

--- a/pkg/admission/mutator/namespacedcloudprofile_test.go
+++ b/pkg/admission/mutator/namespacedcloudprofile_test.go
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mutator_test
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/extensions/pkg/util"
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/admission/mutator"
+	api "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/install"
+)
+
+var _ = Describe("NamespacedCloudProfile Mutator", func() {
+	var (
+		fakeClient  client.Client
+		fakeManager manager.Manager
+		namespace   string
+		ctx         = context.Background()
+		decoder     runtime.Decoder
+
+		namespacedCloudProfileMutator extensionswebhook.Mutator
+		namespacedCloudProfile        *v1beta1.NamespacedCloudProfile
+	)
+
+	BeforeEach(func() {
+		scheme := runtime.NewScheme()
+		utilruntime.Must(install.AddToScheme(scheme))
+		utilruntime.Must(v1beta1.AddToScheme(scheme))
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+		fakeManager = &test.FakeManager{
+			Client: fakeClient,
+			Scheme: scheme,
+		}
+		namespace = "garden-dev"
+		decoder = serializer.NewCodecFactory(fakeManager.GetScheme(), serializer.EnableStrict).UniversalDecoder()
+
+		namespacedCloudProfileMutator = mutator.NewNamespacedCloudProfileMutator(fakeManager)
+		namespacedCloudProfile = &v1beta1.NamespacedCloudProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "profile-1",
+				Namespace: namespace,
+			},
+		}
+	})
+
+	Describe("#Mutate", func() {
+		It("should succeed for NamespacedCloudProfile without provider config", func() {
+			Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+		})
+
+		It("should skip if NamespacedCloudProfile is in deletion phase", func() {
+			namespacedCloudProfile.DeletionTimestamp = ptr.To(metav1.Now())
+			expectedProfile := namespacedCloudProfile.DeepCopy()
+
+			Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+			Expect(namespacedCloudProfile).To(DeepEqual(expectedProfile))
+		})
+
+		Describe("merge the provider configurations from a NamespacedCloudProfile and the parent CloudProfile", func() {
+			It("should correctly merge extended machineImages", func() {
+				namespacedCloudProfile.Status.CloudProfileSpec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"alicloud.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[{"version":"1.0","regions":[{"name":"eu1","id":"id-123"}]}]}
+]}`)}
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"alicloud.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[{"version":"1.1","regions":[{"name":"eu2","id":"id-124"}]}]},
+  {"name":"image-2","versions":[{"version":"2.0","regions":[{"name":"eu3","id":"id-125"}]}]}
+]}`)}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				mergedConfig, err := decodeCloudProfileConfig(decoder, namespacedCloudProfile.Status.CloudProfileSpec.ProviderConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mergedConfig.MachineImages).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"Name": Equal("image-1"),
+						"Versions": ContainElements(
+							api.MachineImageVersion{Version: "1.0", Regions: []api.RegionIDMapping{{Name: "eu1", ID: "id-123"}}},
+							api.MachineImageVersion{Version: "1.1", Regions: []api.RegionIDMapping{{Name: "eu2", ID: "id-124"}}},
+						),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Name":     Equal("image-2"),
+						"Versions": ContainElements(api.MachineImageVersion{Version: "2.0", Regions: []api.RegionIDMapping{{Name: "eu3", ID: "id-125"}}}),
+					}),
+				))
+			})
+		})
+	})
+})
+
+func decodeCloudProfileConfig(decoder runtime.Decoder, config *runtime.RawExtension) (*api.CloudProfileConfig, error) {
+	cloudProfileConfig := &api.CloudProfileConfig{}
+	if err := util.Decode(decoder, config.Raw, cloudProfileConfig); err != nil {
+		return nil, err
+	}
+	return cloudProfileConfig, nil
+}

--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -16,6 +16,7 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -223,19 +224,25 @@ func (s *shootMutator) setDefaultForEncryptedDisk(ctx context.Context, shoot *co
 }
 
 func (s *shootMutator) isCustomizedImage(ctx context.Context, shoot *corev1beta1.Shoot, imageName string, imageVersion *string) (bool, error) {
-	cloudProfile := ptr.Deref(shoot.Spec.CloudProfileName, "")
+	cloudProfile, err := gardener.GetCloudProfile(ctx, s.client, shoot)
+	if err != nil {
+		return false, err
+	}
+	if cloudProfile == nil {
+		return false, fmt.Errorf("cloudprofile could not be found")
+	}
 	region := shoot.Spec.Region
-	logger.Info("Checking in cloudProfie", "CloudProfile", cloudProfile, "Region", region)
+	logger.Info("Checking in cloudProfile", "CloudProfile", client.ObjectKeyFromObject(cloudProfile), "Region", region)
 	imageId, err := s.getImageId(ctx, imageName, imageVersion, region, cloudProfile)
 	if err != nil || imageId == "" {
 		return false, err
 	}
 	logger.Info("Got ImageID", "ImageID", imageId)
-	isOwnedByAli, err := s.isOwnedbyAliCloud(ctx, shoot, imageId, region)
+	isOwnedByAli, err := s.isOwnedByAliCloud(ctx, shoot, imageId, region)
 	return !isOwnedByAli, err
 }
 
-func (s *shootMutator) isOwnedbyAliCloud(ctx context.Context, shoot *corev1beta1.Shoot, imageId string, region string) (bool, error) {
+func (s *shootMutator) isOwnedByAliCloud(ctx context.Context, shoot *corev1beta1.Shoot, imageId string, region string) (bool, error) {
 	if shoot.Spec.SecretBindingName == nil && shoot.Spec.CredentialsBindingName == nil {
 		return false, fmt.Errorf("secretBindingName and credentialsBindingName cannot be both nil")
 	}
@@ -281,15 +288,8 @@ func (s *shootMutator) isOwnedbyAliCloud(ctx context.Context, shoot *corev1beta1
 	return false, nil
 }
 
-func (s *shootMutator) getImageId(ctx context.Context, imageName string, imageVersion *string, imageRegion string, cloudProfileName string) (string, error) {
-	var (
-		cloudProfile    = &corev1beta1.CloudProfile{}
-		cloudProfileKey = client.ObjectKey{Name: cloudProfileName}
-	)
-	if err := kutil.LookupObject(ctx, s.client, s.apiReader, cloudProfileKey, cloudProfile); err != nil {
-		return "", err
-	}
-	cloudProfileConfig, err := s.getCloudProfileConfig(cloudProfile)
+func (s *shootMutator) getImageId(ctx context.Context, imageName string, imageVersion *string, imageRegion string, cloudProfileSpec *corev1beta1.CloudProfile) (string, error) {
+	cloudProfileConfig, err := s.getCloudProfileConfig(cloudProfileSpec)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -35,8 +35,6 @@ import (
 )
 
 const (
-	// ShootMutatorName is the shoots mutator webhook name.
-	ShootMutatorName = "shoots.mutator"
 	// MutatorPath is the mutator webhook path.
 	MutatorPath = "/webhooks/mutate"
 
@@ -288,7 +286,7 @@ func (s *shootMutator) isOwnedByAliCloud(ctx context.Context, shoot *corev1beta1
 	return false, nil
 }
 
-func (s *shootMutator) getImageId(ctx context.Context, imageName string, imageVersion *string, imageRegion string, cloudProfileSpec *corev1beta1.CloudProfile) (string, error) {
+func (s *shootMutator) getImageId(_ context.Context, imageName string, imageVersion *string, imageRegion string, cloudProfileSpec *corev1beta1.CloudProfile) (string, error) {
 	cloudProfileConfig, err := s.getCloudProfileConfig(cloudProfileSpec)
 	if err != nil {
 		return "", err

--- a/pkg/admission/mutator/webhook.go
+++ b/pkg/admission/mutator/webhook.go
@@ -8,22 +8,29 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
 )
 
+const (
+	// Name is the name of the mutator webhook.
+	Name = "shoots.mutator"
+)
+
 var logger = log.Log.WithName("alicloud-mutator-webhook")
 
-// NewShootsWebhook creates a new mutation webhook for shoots.
-func NewShootsWebhook(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+// New creates a new webhook that mutates Shoot and NamespacedCloudProfile resources.
+func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 	return extensionswebhook.New(mgr, extensionswebhook.Args{
 		Provider: alicloud.Type,
-		Name:     ShootMutatorName,
-		Path:     MutatorPath + "/shoots",
+		Name:     Name,
+		Path:     MutatorPath,
 		Mutators: map[extensionswebhook.Mutator][]extensionswebhook.Type{
-			NewShootMutator(mgr): {{Obj: &corev1beta1.Shoot{}}},
+			NewShootMutator(mgr):                  {{Obj: &corev1beta1.Shoot{}}},
+			NewNamespacedCloudProfileMutator(mgr): {{Obj: &corev1beta1.NamespacedCloudProfile{}, Subresource: ptr.To("status")}},
 		},
 		Target: extensionswebhook.TargetSeed,
 		ObjectSelector: &metav1.LabelSelector{

--- a/pkg/admission/validator/namespacedcloudprofile.go
+++ b/pkg/admission/validator/namespacedcloudprofile.go
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/extensions/pkg/util"
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	api "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/validation"
+)
+
+// NewNamespacedCloudProfileValidator returns a new instance of a namespaced cloud profile validator.
+func NewNamespacedCloudProfileValidator(mgr manager.Manager) extensionswebhook.Validator {
+	return &namespacedCloudProfile{
+		client:  mgr.GetClient(),
+		decoder: serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
+	}
+}
+
+type namespacedCloudProfile struct {
+	client  client.Client
+	decoder runtime.Decoder
+}
+
+// Validate validates the given NamespacedCloudProfile objects.
+func (p *namespacedCloudProfile) Validate(ctx context.Context, newObj, _ client.Object) error {
+	profile, ok := newObj.(*core.NamespacedCloudProfile)
+	if !ok {
+		return fmt.Errorf("wrong object type %T", newObj)
+	}
+
+	if profile.DeletionTimestamp != nil {
+		return nil
+	}
+
+	cpConfig := &api.CloudProfileConfig{}
+	if profile.Spec.ProviderConfig != nil {
+		var err error
+		cpConfig, err = decodeCloudProfileConfig(p.decoder, profile.Spec.ProviderConfig)
+		if err != nil {
+			return err
+		}
+	}
+
+	parentCloudProfile := profile.Spec.Parent
+	if parentCloudProfile.Kind != constants.CloudProfileReferenceKindCloudProfile {
+		return fmt.Errorf("parent reference must be of kind CloudProfile (unsupported kind: %s)", parentCloudProfile.Kind)
+	}
+	parentProfile := &gardencorev1beta1.CloudProfile{}
+	if err := p.client.Get(ctx, client.ObjectKey{Name: parentCloudProfile.Name}, parentProfile); err != nil {
+		return err
+	}
+
+	return p.validateNamespacedCloudProfileProviderConfig(cpConfig, profile.Spec, parentProfile.Spec).ToAggregate()
+}
+
+// validateNamespacedCloudProfileProviderConfig validates the CloudProfileConfig passed with a NamespacedCloudProfile.
+func (p *namespacedCloudProfile) validateNamespacedCloudProfileProviderConfig(providerConfig *api.CloudProfileConfig, profileSpec core.NamespacedCloudProfileSpec, parentSpec gardencorev1beta1.CloudProfileSpec) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, p.validateMachineImages(providerConfig, profileSpec.MachineImages, parentSpec)...)
+
+	return allErrs
+}
+
+func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.CloudProfileConfig, machineImages []core.MachineImage, parentSpec gardencorev1beta1.CloudProfileSpec) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	machineImagesPath := field.NewPath("spec.providerConfig.machineImages")
+	for i, machineImage := range providerConfig.MachineImages {
+		idxPath := machineImagesPath.Index(i)
+		allErrs = append(allErrs, validation.ValidateMachineImage(idxPath, machineImage)...)
+	}
+
+	profileImages := util.NewCoreImagesContext(machineImages)
+	parentImages := util.NewV1beta1ImagesContext(parentSpec.MachineImages)
+	providerImages := newProviderImagesContext(providerConfig.MachineImages)
+
+	for _, machineImage := range profileImages.Images {
+		// Check that for each new image version defined in the NamespacedCloudProfile, the image is also defined in the providerConfig.
+		_, existsInParent := parentImages.GetImage(machineImage.Name)
+		if _, existsInProvider := providerImages.GetImage(machineImage.Name); !existsInParent && !existsInProvider {
+			allErrs = append(allErrs, field.Required(
+				field.NewPath("spec.providerConfig.machineImages"),
+				fmt.Sprintf("machine image %s is not defined in the NamespacedCloudProfile providerConfig", machineImage.Name),
+			))
+			continue
+		}
+		for _, version := range machineImage.Versions {
+			_, existsInParent := parentImages.GetImageVersion(machineImage.Name, version.Version)
+			_, exists := providerImages.GetImageVersion(machineImage.Name, version.Version)
+			if !existsInParent && !exists {
+				allErrs = append(allErrs, field.Required(
+					field.NewPath("spec.providerConfig.machineImages"),
+					fmt.Sprintf("machine image version %s@%s is not defined in the NamespacedCloudProfile providerConfig", machineImage.Name, version.Version),
+				))
+			}
+		}
+	}
+	for imageIdx, machineImage := range providerConfig.MachineImages {
+		// Check that the machine image version is not already defined in the parent CloudProfile.
+		if _, exists := parentImages.GetImage(machineImage.Name); exists {
+			for versionIdx, version := range machineImage.Versions {
+				if _, exists := parentImages.GetImageVersion(machineImage.Name, version.Version); exists {
+					allErrs = append(allErrs, field.Forbidden(
+						field.NewPath("spec.providerConfig.machineImages").Index(imageIdx).Child("versions").Index(versionIdx),
+						fmt.Sprintf("machine image version %s@%s is already defined in the parent CloudProfile", machineImage.Name, version.Version),
+					))
+				}
+			}
+		}
+		// Check that the machine image version is defined in the NamespacedCloudProfile.
+		if _, exists := profileImages.GetImage(machineImage.Name); !exists {
+			allErrs = append(allErrs, field.Required(
+				field.NewPath("spec.providerConfig.machineImages").Index(imageIdx),
+				fmt.Sprintf("machine image %s is not defined in the NamespacedCloudProfile .spec.machineImages", machineImage.Name),
+			))
+			continue
+		}
+		for versionIdx, version := range machineImage.Versions {
+			if _, exists := profileImages.GetImageVersion(machineImage.Name, version.Version); !exists {
+				allErrs = append(allErrs, field.Invalid(
+					field.NewPath("spec.providerConfig.machineImages").Index(imageIdx).Child("versions").Index(versionIdx),
+					fmt.Sprintf("%s@%s", machineImage.Name, version.Version),
+					"machine image version is not defined in the NamespacedCloudProfile",
+				))
+			}
+		}
+	}
+
+	return allErrs
+}
+
+func newProviderImagesContext(providerImages []api.MachineImages) *util.ImagesContext[api.MachineImages, api.MachineImageVersion] {
+	return util.NewImagesContext(
+		utils.CreateMapFromSlice(providerImages, func(mi api.MachineImages) string { return mi.Name }),
+		func(mi api.MachineImages) map[string]api.MachineImageVersion {
+			return utils.CreateMapFromSlice(mi.Versions, func(v api.MachineImageVersion) string { return v.Version })
+		},
+	)
+}

--- a/pkg/admission/validator/namespacedcloudprofile_test.go
+++ b/pkg/admission/validator/namespacedcloudprofile_test.go
@@ -1,0 +1,255 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator_test
+
+import (
+	"context"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/admission/validator"
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/install"
+)
+
+var _ = Describe("NamespacedCloudProfile Validator", func() {
+	var (
+		fakeClient  client.Client
+		fakeManager manager.Manager
+		namespace   string
+		ctx         = context.Background()
+
+		namespacedCloudProfileValidator extensionswebhook.Validator
+		namespacedCloudProfile          *core.NamespacedCloudProfile
+		cloudProfile                    *v1beta1.CloudProfile
+	)
+
+	BeforeEach(func() {
+		scheme := runtime.NewScheme()
+		utilruntime.Must(install.AddToScheme(scheme))
+		utilruntime.Must(v1beta1.AddToScheme(scheme))
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+		fakeManager = &test.FakeManager{
+			Client: fakeClient,
+			Scheme: scheme,
+		}
+		namespace = "garden-dev"
+
+		namespacedCloudProfileValidator = validator.NewNamespacedCloudProfileValidator(fakeManager)
+		namespacedCloudProfile = &core.NamespacedCloudProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "profile-1",
+				Namespace: namespace,
+			},
+			Spec: core.NamespacedCloudProfileSpec{
+				Parent: core.CloudProfileReference{
+					Name: "cloud-profile",
+					Kind: "CloudProfile",
+				},
+			},
+		}
+		cloudProfile = &v1beta1.CloudProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cloud-profile",
+			},
+		}
+	})
+
+	Describe("#Validate", func() {
+		It("should succeed for NamespacedCloudProfile without provider config", func() {
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+		})
+
+		It("should succeed if NamespacedCloudProfile is in deletion phase", func() {
+			namespacedCloudProfile.DeletionTimestamp = ptr.To(metav1.Now())
+
+			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+		})
+
+		It("should succeed if the NamespacedCloudProfile correctly defines new machine images and types", func() {
+			cloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"alicloud.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[{"name":"image-1","versions":[{"version":"1.0","regions":[{"name":"eu1","id":"id-123"}]}]}]
+}`)}
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"alicloud.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[{"version":"1.1","regions":[{"name":"eu1","id":"id-123"}]}]},
+  {"name":"image-2","versions":[{"version":"2.0","regions":[{"name":"eu1","id":"id-123"}]}]}
+]
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name:     "image-1",
+					Versions: []core.MachineImageVersion{{ExpirableVersion: core.ExpirableVersion{Version: "1.1"}, Architectures: []string{"amd64"}}},
+				},
+				{
+					Name:     "image-2",
+					Versions: []core.MachineImageVersion{{ExpirableVersion: core.ExpirableVersion{Version: "2.0"}, Architectures: []string{"amd64"}}},
+				},
+			}
+			namespacedCloudProfile.Spec.MachineTypes = []core.MachineType{
+				{Name: "type-2"},
+			}
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+		})
+
+		It("should fail for NamespacedCloudProfile with invalid parent kind", func() {
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"alicloud.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig"
+}`)}
+			namespacedCloudProfile.Spec.Parent = core.CloudProfileReference{
+				Name: "cloud-profile",
+				Kind: "NamespacedCloudProfile",
+			}
+
+			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(MatchError(ContainSubstring("parent reference must be of kind CloudProfile")))
+		})
+
+		It("should fail for NamespacedCloudProfile trying to override an already existing machine image version", func() {
+			cloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+				{Name: "image-1", Versions: []v1beta1.MachineImageVersion{{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0"}}}},
+			}
+			cloudProfile.Spec.MachineTypes = []v1beta1.MachineType{{Name: "type-1"}}
+
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"alicloud.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[{"version":"1.0","regions":[{"name":"eu1","id":"id-123"}]}]}
+]
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name: "image-1",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.0"}, Architectures: []string{"amd64"}},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+			err := namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)
+			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeForbidden),
+				"Field":  Equal("spec.providerConfig.machineImages[0].versions[0]"),
+				"Detail": Equal("machine image version image-1@1.0 is already defined in the parent CloudProfile"),
+			}))))
+		})
+
+		It("should fail for NamespacedCloudProfile specifying provider config without the according version in the spec.machineImages", func() {
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"alicloud.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[{"version":"1.1","regions":[{"name":"eu1","id":"id-123"}]}]}
+]
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name: "image-1",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.2"}},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+			err := namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)
+			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.providerConfig.machineImages"),
+				"Detail": Equal("machine image version image-1@1.2 is not defined in the NamespacedCloudProfile providerConfig"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal("spec.providerConfig.machineImages[0].versions[0]"),
+				"BadValue": Equal("image-1@1.1"),
+				"Detail":   Equal("machine image version is not defined in the NamespacedCloudProfile"),
+			}))))
+		})
+
+		It("should fail for NamespacedCloudProfile specifying new spec.machineImages without the according version entry in the provider config", func() {
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"alicloud.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[
+	{"version":"1.1-regions","regions":[
+      {"name":"image-region-1","id":"id-img-reg-1"},
+      {"name":"image-region-2","id":"id-img-reg-2"}
+    ]},
+    {"version":"1.1-fallback","regions":[
+      {"name":"image-region-2","id":"id-img-reg-2"}
+    ]}
+  ]}
+]
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name: "image-1",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.1-regions"}, Architectures: []string{"amd64", "arm64"}},
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.1-fallback"}, Architectures: []string{"arm64"}},
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.1-missing"}, Architectures: []string{"arm64"}},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+			err := namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)
+			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.providerConfig.machineImages"),
+				"Detail": Equal("machine image version image-1@1.1-missing is not defined in the NamespacedCloudProfile providerConfig"),
+			}))))
+		})
+
+		It("should fail for NamespacedCloudProfile specifying new spec.machineImages without the according version in the provider config", func() {
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"alicloud.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig"
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name: "image-3",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{Version: "3.0"}},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+			err := namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)
+			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.providerConfig.machineImages"),
+				"Detail": Equal("machine image image-3 is not defined in the NamespacedCloudProfile providerConfig"),
+			}))))
+		})
+	})
+})

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -34,10 +34,11 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Name:     Name,
 		Path:     "/webhooks/validate",
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
-			NewShootValidator(mgr):              {{Obj: &core.Shoot{}}},
-			NewCloudProfileValidator(mgr):       {{Obj: &core.CloudProfile{}}},
-			NewSecretBindingValidator(mgr):      {{Obj: &core.SecretBinding{}}},
-			NewCredentialsBindingValidator(mgr): {{Obj: &security.CredentialsBinding{}}},
+			NewShootValidator(mgr):                  {{Obj: &core.Shoot{}}},
+			NewCloudProfileValidator(mgr):           {{Obj: &core.CloudProfile{}}},
+			NewNamespacedCloudProfileValidator(mgr): {{Obj: &core.NamespacedCloudProfile{}}},
+			NewSecretBindingValidator(mgr):          {{Obj: &core.SecretBinding{}}},
+			NewCredentialsBindingValidator(mgr):     {{Obj: &security.CredentialsBinding{}}},
 		},
 		Target: extensionswebhook.TargetSeed,
 		ObjectSelector: &metav1.LabelSelector{

--- a/pkg/apis/alicloud/helper/scheme.go
+++ b/pkg/apis/alicloud/helper/scheme.go
@@ -66,9 +66,13 @@ func InfrastructureStatusFromRaw(raw *runtime.RawExtension) (*api.Infrastructure
 func CloudProfileConfigFromCluster(cluster *controller.Cluster) (*api.CloudProfileConfig, error) {
 	var cloudProfileConfig *api.CloudProfileConfig
 	if cluster != nil && cluster.CloudProfile != nil && cluster.CloudProfile.Spec.ProviderConfig != nil && cluster.CloudProfile.Spec.ProviderConfig.Raw != nil {
+		cloudProfileSpecifier := fmt.Sprintf("CloudProfile %q", client.ObjectKeyFromObject(cluster.CloudProfile))
+		if cluster.Shoot != nil && cluster.Shoot.Spec.CloudProfile != nil {
+			cloudProfileSpecifier = fmt.Sprintf("%s '%s/%s'", cluster.Shoot.Spec.CloudProfile.Kind, cluster.Shoot.Namespace, cluster.Shoot.Spec.CloudProfile.Name)
+		}
 		cloudProfileConfig = &api.CloudProfileConfig{}
 		if _, _, err := decoder.Decode(cluster.CloudProfile.Spec.ProviderConfig.Raw, nil, cloudProfileConfig); err != nil {
-			return nil, fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", client.ObjectKeyFromObject(cluster.CloudProfile), err)
+			return nil, fmt.Errorf("could not decode providerConfig of %s: %w", cloudProfileSpecifier, err)
 		}
 	}
 	return cloudProfileConfig, nil

--- a/pkg/apis/alicloud/validation/cloudprofile.go
+++ b/pkg/apis/alicloud/validation/cloudprofile.go
@@ -22,32 +22,40 @@ func ValidateCloudProfileConfig(cloudProfile *apisalicloud.CloudProfileConfig, f
 	}
 	for i, machineImage := range cloudProfile.MachineImages {
 		idxPath := machineImagesPath.Index(i)
+		allErrs = append(allErrs, ValidateMachineImage(idxPath, machineImage)...)
+	}
 
-		if len(machineImage.Name) == 0 {
-			allErrs = append(allErrs, field.Required(idxPath.Child("name"), "must provide a name"))
+	return allErrs
+}
+
+// ValidateMachineImage validates a CloudProfileConfig MachineImages entry.
+func ValidateMachineImage(validationPath *field.Path, machineImage apisalicloud.MachineImages) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(machineImage.Name) == 0 {
+		allErrs = append(allErrs, field.Required(validationPath.Child("name"), "must provide a name"))
+	}
+
+	if len(machineImage.Versions) == 0 {
+		allErrs = append(allErrs, field.Required(validationPath.Child("versions"), fmt.Sprintf("must provide at least one version for machine image %q", machineImage.Name)))
+	}
+	for j, version := range machineImage.Versions {
+		jdxPath := validationPath.Child("versions").Index(j)
+
+		if len(version.Version) == 0 {
+			allErrs = append(allErrs, field.Required(jdxPath.Child("version"), "must provide a version"))
 		}
 
-		if len(machineImage.Versions) == 0 {
-			allErrs = append(allErrs, field.Required(idxPath.Child("versions"), fmt.Sprintf("must provide at least one version for machine image %q", machineImage.Name)))
+		if len(version.Regions) == 0 {
+			allErrs = append(allErrs, field.Required(jdxPath.Child("regions"), fmt.Sprintf("must provide at least one region for machine image %q and version %q", machineImage.Name, version.Version)))
 		}
-		for j, version := range machineImage.Versions {
-			jdxPath := idxPath.Child("versions").Index(j)
-
-			if len(version.Version) == 0 {
-				allErrs = append(allErrs, field.Required(jdxPath.Child("version"), "must provide a version"))
+		for k, region := range version.Regions {
+			kdxPath := jdxPath.Child("regions").Index(k)
+			if len(region.Name) == 0 {
+				allErrs = append(allErrs, field.Required(kdxPath.Child("name"), "must provide a name"))
 			}
-
-			if len(version.Regions) == 0 {
-				allErrs = append(allErrs, field.Required(jdxPath.Child("regions"), fmt.Sprintf("must provide at least one region for machine image %q and version %q", machineImage.Name, version.Version)))
-			}
-			for k, region := range version.Regions {
-				kdxPath := jdxPath.Child("regions").Index(k)
-				if len(region.Name) == 0 {
-					allErrs = append(allErrs, field.Required(kdxPath.Child("name"), "must provide a name"))
-				}
-				if len(region.ID) == 0 {
-					allErrs = append(allErrs, field.Required(kdxPath.Child("id"), "must provide an id"))
-				}
+			if len(region.ID) == 0 {
+				allErrs = append(allErrs, field.Required(kdxPath.Child("id"), "must provide an id"))
 			}
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
Make the provider extension aware of the `CloudProfile` field and the option to provide `NamespacedCloudProfile` references in the `shoot.Spec.CloudProfile`.

See also [GEP-25](https://github.com/gardener/gardener/issues/9504) and [this PR](https://github.com/gardener/gardener/pull/10093).

* Shoot cloudProfile reference as complement to cloudProfileName
* Add NamespacedCloudProfile validation (`providerConfig`).
* Switch from CloudProfile to CloudProfileSpec as a generic foundation for `CloudProfile`s and `NamespacedCloudProfile`s.
* Improve log message for possibly artificially crafted CloudProfile from NamespacedCloudProfile in Cluster resource.

**Which issue(s) this PR fixes**:
Related to https://github.com/gardener/gardener/issues/9504.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Enable support for the field `shoot.Spec.CloudProfile` alongside `cloudProfileName` and enable the future use of `NamespacedCloudProfile`s.
```

```other operator
Add `NamespacedCloudProfile` admission mutation and validation to support custom machine images and types.
```
