### PR TITLE
fix: correctly inject `podNetwork` cidr in cp chart values

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator"
@@ -412,7 +413,7 @@ func (vp *valuesProvider) getControlPlaneChartValues(
 		"alicloud-cloud-controller-manager": map[string]interface{}{
 			"replicas":    extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 			"clusterName": cp.Namespace,
-			"podNetwork":  extensionscontroller.GetPodNetwork(cluster),
+			"podNetwork":  strings.Join(extensionscontroller.GetPodNetwork(cluster), ","),
 			"podLabels": map[string]interface{}{
 				v1beta1constants.LabelPodMaintenanceRestart: "true",
 			},

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -124,7 +124,7 @@ var _ = Describe("ValuesProvider", func() {
 			"alicloud-cloud-controller-manager": map[string]interface{}{
 				"replicas":    1,
 				"clusterName": namespace,
-				"podNetwork":  []string{cidr},
+				"podNetwork":  cidr,
 				"podLabels": map[string]interface{}{
 					"maintenance.gardener.cloud/restart": "true",
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform alicloud

**What this PR does / why we need it**:
Fix wrongly introduced `podNetwork` injection from g/g update in #746.

Else, it gets injected as `[10.251.0.0/16]`, which cannot be parsed: `sync route tables error: sync table [...] error: error parse cluster cidr [10.251.0.0/16]: invalid CIDR address: [10.251.0.0/16]`.

With this fix, it's working now: `sync route tables successfully, tables [...]`.

* [ ] Should also be cherry-picked to `v1.57.x`.

**Special notes for your reviewer**:
/cc @MartinWeindel 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Correctly inject `podNetwork` cidr in control plane chart values.
```
