### PR TITLE
Pass worker pool priority to MachineDeployment during generation

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -155,6 +155,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				Maximum:                      worker.DistributeOverZones(zoneIdx, pool.Maximum, zoneLen),
 				MaxSurge:                     worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxSurge, zoneLen, pool.Maximum),
 				MaxUnavailable:               worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxUnavailable, zoneLen, pool.Minimum),
+				Priority:                     pool.Priority,
 				Labels:                       addTopologyLabel(pool.Labels, zone),
 				Annotations:                  pool.Annotations,
 				Taints:                       pool.Taints,

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -113,6 +113,7 @@ var _ = Describe("Machines", func() {
 				namePool2           string
 				minPool2            int32
 				maxPool2            int32
+				priorityPool2       int32
 				maxSurgePool2       intstr.IntOrString
 				maxUnavailablePool2 intstr.IntOrString
 
@@ -186,6 +187,7 @@ var _ = Describe("Machines", func() {
 				namePool2 = "pool-2"
 				minPool2 = 30
 				maxPool2 = 45
+				priorityPool2 = 100
 				maxSurgePool2 = intstr.FromInt(10)
 				maxUnavailablePool2 = intstr.FromInt(15)
 
@@ -370,6 +372,7 @@ var _ = Describe("Machines", func() {
 								Name:           namePool2,
 								Minimum:        minPool2,
 								Maximum:        maxPool2,
+								Priority:       ptr.To(priorityPool2),
 								MaxSurge:       maxSurgePool2,
 								MaxUnavailable: maxUnavailablePool2,
 								Architecture:   ptr.To(archARM),
@@ -561,6 +564,7 @@ var _ = Describe("Machines", func() {
 							SecretName:           machineClassWithHashPool2Zone1,
 							Minimum:              worker.DistributeOverZones(0, minPool2, 2),
 							Maximum:              worker.DistributeOverZones(0, maxPool2, 2),
+							Priority:             ptr.To(priorityPool2),
 							MaxSurge:             worker.DistributePositiveIntOrPercent(0, maxSurgePool2, 2, maxPool2),
 							MaxUnavailable:       worker.DistributePositiveIntOrPercent(0, maxUnavailablePool2, 2, minPool2),
 							Labels:               labelsZone1,
@@ -572,6 +576,7 @@ var _ = Describe("Machines", func() {
 							SecretName:           machineClassWithHashPool2Zone2,
 							Minimum:              worker.DistributeOverZones(1, minPool2, 2),
 							Maximum:              worker.DistributeOverZones(1, maxPool2, 2),
+							Priority:             ptr.To(priorityPool2),
 							MaxSurge:             worker.DistributePositiveIntOrPercent(1, maxSurgePool2, 2, maxPool2),
 							MaxUnavailable:       worker.DistributePositiveIntOrPercent(1, maxUnavailablePool2, 2, minPool2),
 							Labels:               labelsZone2,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:

This PR adds the passing of the worker pool priorities to the `MachineDeployment`s during generation.
The worker pool priorities were introduced with [`gardener/gardener` #11045](https://github.com/gardener/gardener/pull/11045) and need to be passed in the extensions, so we can remove our [current best-effort approach](https://github.com/gardener/gardener/blob/f92ccada28fda2358f8da4326ba453c673a491b7/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go#L653-L687), which does not work for this extension.

**Which issue(s) this PR fixes**:
Part of [`gardener/gardener` #10683](https://github.com/gardener/gardener/issues/10683)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
