### PR TITLE
Add `cloudprovider` mutating webhook to ensure the `cloudprovider` secret has the credentialsFile field present.

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml
@@ -53,16 +53,8 @@ spec:
           value: "false"
         - name: REGION_ID
           value: {{ .Values.regionID }}
-        - name: ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: cloudprovider
-              key: accessKeyID
-        - name: ACCESS_KEY_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: cloudprovider
-              key: accessKeySecret
+        - name: ALIBABA_CLOUD_CREDENTIALS_FILE
+          value: /srv/cloudprovider/credentialsFile
         imagePullPolicy: IfNotPresent
 {{- if .Values.csiPluginController.podResources.diskPlugin }}
         resources:
@@ -89,6 +81,8 @@ spec:
         - mountPath: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig
           name: kubeconfig-csi-controller-ali-plugin
           readOnly: true
+        - name: cloudprovider
+          mountPath: /srv/cloudprovider
       - name: alicloud-csi-attacher
         image: {{ index .Values.images "csi-attacher" }}
         args:
@@ -204,6 +198,9 @@ spec:
         - name: socket-dir
           mountPath: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com
       volumes:
+      - name: cloudprovider
+        secret:
+          secretName: cloudprovider
       - name: socket-dir
         emptyDir: {}
       - name: kubeconfig-csi-controller-ali-plugin

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
@@ -85,16 +85,8 @@ spec:
 {{- end }}
         - name: CSI_ENDPOINT
           value: unix://var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com/csi.sock
-        - name: ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: csi-diskplugin-alicloud
-              key: accessKeyID
-        - name: ACCESS_KEY_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: csi-diskplugin-alicloud
-              key: accessKeySecret
+        - name: ALIBABA_CLOUD_CREDENTIALS_FILE
+          value: /srv/cloudprovider/credentialsFile
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
@@ -124,6 +116,8 @@ spec:
         - mountPath: /dev
           name: host-dev
           mountPropagation: "HostToContainer"
+        - name: cloudprovider
+          mountPath: /srv/cloudprovider
       - name: csi-liveness-probe
         image: {{ index .Values.images "csi-liveness-probe" }}
         args:
@@ -138,6 +132,9 @@ spec:
         - name: plugin-dir
           mountPath: /csi
       volumes:
+      - name: cloudprovider
+        secret:
+          secretName: csi-diskplugin-alicloud
       - name: registration-dir
         hostPath:
           path: /var/lib/kubelet/plugins_registry

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-secret.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-secret.yaml
@@ -6,4 +6,5 @@ metadata:
 data:
   accessKeyID: {{ index .Values.credential.accessKeyID }}
   accessKeySecret: {{ index .Values.credential.accessKeySecret }}
+  credentialsFile: {{ index .Values.credential.credentialsFile }}
 type: Opaque

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/values.yaml
@@ -7,6 +7,7 @@ images:
 credential:
   accessKeyID: keyID
   accessKeySecret: secret
+  credentialsFile: file
 
 enableADController: true
 

--- a/pkg/alicloud/secret.go
+++ b/pkg/alicloud/secret.go
@@ -18,6 +18,7 @@ import (
 type Credentials struct {
 	AccessKeyID     string
 	AccessKeySecret string
+	CredentialsFile string
 }
 
 const (
@@ -25,6 +26,8 @@ const (
 	AccessKeyID = "accessKeyID"
 	// AccessKeySecret is the data field in a secret where the access key secret is stored at.
 	AccessKeySecret = "accessKeySecret"
+	// CredentialsFile is a constant for the key in cloud provider secret that holds the Alibaba Cloud credentials file.
+	CredentialsFile = "credentialsFile"
 
 	// dnsAccessKeyID is the data field in a DNS secret where the access key id is stored at.
 	dnsAccessKeyID = "ACCESS_KEY_ID"

--- a/pkg/alicloud/secret.go
+++ b/pkg/alicloud/secret.go
@@ -56,15 +56,22 @@ func ReadSecretCredentials(secret *corev1.Secret, allowDNSKeys bool) (*Credentia
 		return nil, fmt.Errorf("secret %s/%s has no access key secret", secret.Namespace, secret.Name)
 	}
 
-	credentialsFile, ok := getSecretDataValue(secret, CredentialsFile, nil)
-	if !ok {
-		return nil, fmt.Errorf("secret %s/%s has no credentials file", secret.Namespace, secret.Name)
+	if !allowDNSKeys {
+		credentialsFile, ok := getSecretDataValue(secret, CredentialsFile, nil)
+		if !ok {
+			return nil, fmt.Errorf("secret %s/%s has no credentials file", secret.Namespace, secret.Name)
+		}
+
+		return &Credentials{
+			AccessKeyID:     string(accessKeyID),
+			AccessKeySecret: string(accessKeySecret),
+			CredentialsFile: string(credentialsFile),
+		}, nil
 	}
 
 	return &Credentials{
 		AccessKeyID:     string(accessKeyID),
 		AccessKeySecret: string(accessKeySecret),
-		CredentialsFile: string(credentialsFile),
 	}, nil
 }
 

--- a/pkg/alicloud/secret_test.go
+++ b/pkg/alicloud/secret_test.go
@@ -13,6 +13,7 @@ import (
 const (
 	accessKeyID     = "accessKeyID"
 	accessKeySecret = "accessKeySecret"
+	credentialsFile = "credentialsFile"
 )
 
 var _ = Describe("Alicloud Suite", func() {
@@ -23,6 +24,7 @@ var _ = Describe("Alicloud Suite", func() {
 					Data: map[string][]byte{
 						AccessKeyID:     []byte(accessKeyID),
 						AccessKeySecret: []byte(accessKeySecret),
+						CredentialsFile: []byte(credentialsFile),
 					},
 				}, false)
 
@@ -30,6 +32,7 @@ var _ = Describe("Alicloud Suite", func() {
 				Expect(creds).To(Equal(&Credentials{
 					AccessKeyID:     accessKeyID,
 					AccessKeySecret: accessKeySecret,
+					CredentialsFile: credentialsFile,
 				}))
 			})
 
@@ -38,6 +41,7 @@ var _ = Describe("Alicloud Suite", func() {
 					Data: map[string][]byte{
 						dnsAccessKeyID:     []byte(accessKeyID),
 						dnsAccessKeySecret: []byte(accessKeySecret),
+						CredentialsFile:    []byte(credentialsFile),
 					},
 				}, false)
 
@@ -51,6 +55,7 @@ var _ = Describe("Alicloud Suite", func() {
 					Data: map[string][]byte{
 						AccessKeyID:     []byte(accessKeyID),
 						AccessKeySecret: []byte(accessKeySecret),
+						CredentialsFile: []byte(credentialsFile),
 					},
 				}, true)
 
@@ -73,6 +78,7 @@ var _ = Describe("Alicloud Suite", func() {
 				Expect(creds).To(Equal(&Credentials{
 					AccessKeyID:     accessKeyID,
 					AccessKeySecret: accessKeySecret,
+					CredentialsFile: "",
 				}))
 			})
 		})
@@ -95,7 +101,19 @@ var _ = Describe("Alicloud Suite", func() {
 		It("should fail if access key secret is missing", func() {
 			_, err := ReadSecretCredentials(&corev1.Secret{
 				Data: map[string][]byte{
-					AccessKeyID: []byte(accessKeyID),
+					AccessKeyID:     []byte(accessKeyID),
+					credentialsFile: []byte(credentialsFile),
+				},
+			}, false)
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail if credentials file is missing", func() {
+			_, err := ReadSecretCredentials(&corev1.Secret{
+				Data: map[string][]byte{
+					AccessKeyID:     []byte(accessKeyID),
+					AccessKeySecret: []byte(accessKeySecret),
 				},
 			}, false)
 

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -17,6 +17,7 @@ import (
 	extensionsheartbeatcontroller "github.com/gardener/gardener/extensions/pkg/controller/heartbeat"
 	extensionsinfrastructurecontroller "github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
 	extensionsworkercontroller "github.com/gardener/gardener/extensions/pkg/controller/worker"
+	extensionscloudproviderwebhook "github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
 	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
 	extensioncontrolplanewebhook "github.com/gardener/gardener/extensions/pkg/webhook/controlplane"
 	extensionshootwebhook "github.com/gardener/gardener/extensions/pkg/webhook/shoot"
@@ -32,6 +33,7 @@ import (
 	healthcheckcontroller "github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/healthcheck"
 	infrastructurecontroller "github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/infrastructure"
 	workercontroller "github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/worker"
+	cloudproviderwebhook "github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/cloudprovider"
 	controlplanewebhook "github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/controlplane"
 	seedproviderwebhook "github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/seedprovider"
 	shootwebhook "github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/shoot"
@@ -67,6 +69,7 @@ func WebhookSwitchOptions() *webhookcmd.SwitchOptions {
 		webhookcmd.Switch(extensioncontrolplanewebhook.WebhookName, controlplanewebhook.AddToManager),
 		webhookcmd.Switch(extensioncontrolplanewebhook.SeedProviderWebhookName, seedproviderwebhook.AddToManager),
 		webhookcmd.Switch(extensionshootwebhook.WebhookName, shootwebhook.AddToManager),
+		webhookcmd.Switch(extensionscloudproviderwebhook.WebhookName, cloudproviderwebhook.AddToManager),
 	)
 }
 

--- a/pkg/controller/bastion/configvalidator_test.go
+++ b/pkg/controller/bastion/configvalidator_test.go
@@ -35,6 +35,7 @@ const (
 	namespace       = "shoot--foobar--alicloud"
 	accessKeyID     = "accessKeyID"
 	accessKeySecret = "accessKeySecret"
+	credentialsFile = "credentialsFile"
 	region          = "region"
 	id              = "id"
 )
@@ -90,6 +91,7 @@ var _ = Describe("ConfigValidator", func() {
 			Data: map[string][]byte{
 				alicloud.AccessKeyID:     []byte(accessKeyID),
 				alicloud.AccessKeySecret: []byte(accessKeySecret),
+				alicloud.CredentialsFile: []byte(credentialsFile),
 			},
 		}
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -473,6 +473,7 @@ func (vp *valuesProvider) getControlPlaneShootChartValues(
 			"credential": map[string]interface{}{
 				"accessKeyID":     base64.StdEncoding.EncodeToString([]byte(credentials.AccessKeyID)),
 				"accessKeySecret": base64.StdEncoding.EncodeToString([]byte(credentials.AccessKeySecret)),
+				"credentialsFile": base64.StdEncoding.EncodeToString([]byte(credentials.CredentialsFile)),
 			},
 			"enableADController": vp.enableCSIADController(cpConfig),
 			"webhookConfig": map[string]interface{}{

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -109,6 +109,7 @@ var _ = Describe("ValuesProvider", func() {
 			Data: map[string][]byte{
 				alicloud.AccessKeyID:     []byte("foo"),
 				alicloud.AccessKeySecret: []byte("bar"),
+				alicloud.CredentialsFile: []byte("baz"),
 			},
 		}
 
@@ -163,6 +164,7 @@ var _ = Describe("ValuesProvider", func() {
 				"credential": map[string]interface{}{
 					"accessKeyID":     "Zm9v",
 					"accessKeySecret": "YmFy",
+					"credentialsFile": "YmF6",
 				},
 				"enableADController": true,
 				"webhookConfig": map[string]interface{}{

--- a/pkg/controller/dnsrecord/actuator_test.go
+++ b/pkg/controller/dnsrecord/actuator_test.go
@@ -37,6 +37,7 @@ const (
 
 	accessKeyID     = "accessKeyID"
 	accessKeySecret = "accessKeySecret"
+	credentialsFile = "credentialsFile"
 )
 
 var _ = Describe("Actuator", func() {
@@ -101,6 +102,7 @@ var _ = Describe("Actuator", func() {
 			Data: map[string][]byte{
 				alicloud.AccessKeyID:     []byte(accessKeyID),
 				alicloud.AccessKeySecret: []byte(accessKeySecret),
+				alicloud.CredentialsFile: []byte(credentialsFile),
 			},
 		}
 

--- a/pkg/controller/infrastructure/actuator_test.go
+++ b/pkg/controller/infrastructure/actuator_test.go
@@ -96,6 +96,7 @@ var _ = Describe("Actuator", func() {
 			owner           *metav1.OwnerReference
 			accessKeyID     string
 			accessKeySecret string
+			credentialsFile string
 			cluster         controller.Cluster
 
 			initializerValues InitializerValues
@@ -174,8 +175,11 @@ var _ = Describe("Actuator", func() {
 					},
 				}
 				owner = metav1.NewControllerRef(&infra, extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.InfrastructureResource))
+
 				accessKeyID = "accessKeyID"
 				accessKeySecret = "accessKeySecret"
+				credentialsFile = "credentialsFile"
+
 				podCIDR = "100.96.0.0/11"
 				cluster = controller.Cluster{
 					Shoot: &gardencorev1beta1.Shoot{
@@ -261,6 +265,7 @@ var _ = Describe("Actuator", func() {
 							Data: map[string][]byte{
 								alicloud.AccessKeyID:     []byte(accessKeyID),
 								alicloud.AccessKeySecret: []byte(accessKeySecret),
+								alicloud.CredentialsFile: []byte(credentialsFile),
 							},
 						}),
 
@@ -303,6 +308,7 @@ var _ = Describe("Actuator", func() {
 							Data: map[string][]byte{
 								alicloud.AccessKeyID:     []byte(accessKeyID),
 								alicloud.AccessKeySecret: []byte(accessKeySecret),
+								alicloud.CredentialsFile: []byte(credentialsFile),
 							},
 						}),
 					alicloudClientFactory.EXPECT().NewECSClient(region, accessKeyID, accessKeySecret).Return(shootECSClient, nil),
@@ -355,6 +361,7 @@ var _ = Describe("Actuator", func() {
 							Data: map[string][]byte{
 								alicloud.AccessKeyID:     []byte(accessKeyID),
 								alicloud.AccessKeySecret: []byte(accessKeySecret),
+								alicloud.CredentialsFile: []byte(credentialsFile),
 							},
 						}),
 
@@ -396,6 +403,7 @@ var _ = Describe("Actuator", func() {
 							Data: map[string][]byte{
 								alicloud.AccessKeyID:     []byte(accessKeyID),
 								alicloud.AccessKeySecret: []byte(accessKeySecret),
+								alicloud.CredentialsFile: []byte(credentialsFile),
 							},
 						}),
 					alicloudClientFactory.EXPECT().NewECSClient(region, accessKeyID, accessKeySecret).Return(shootECSClient, nil),

--- a/pkg/controller/infrastructure/configvalidator_test.go
+++ b/pkg/controller/infrastructure/configvalidator_test.go
@@ -43,6 +43,7 @@ const (
 
 	accessKeyID     = "accessKeyID"
 	secretAccessKey = "secretAccessKey"
+	credentialsFile = "credentialsFile"
 )
 
 var _ = Describe("ConfigValidator", func() {
@@ -105,6 +106,7 @@ var _ = Describe("ConfigValidator", func() {
 			Data: map[string][]byte{
 				alicloud.AccessKeyID:     []byte(accessKeyID),
 				alicloud.AccessKeySecret: []byte(secretAccessKey),
+				alicloud.CredentialsFile: []byte(credentialsFile),
 			},
 		}
 

--- a/pkg/webhook/cloudprovider/add.go
+++ b/pkg/webhook/cloudprovider/add.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudprovider
+
+import (
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
+)
+
+var logger = log.Log.WithName("alicloud-cloudprovider-webhook")
+
+// AddToManager creates the cloudprovider webhook and adds it to the manager.
+func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	logger.Info("adding webhook to manager")
+	return cloudprovider.New(mgr, cloudprovider.Args{
+		Provider: alicloud.Type,
+		Mutator:  cloudprovider.NewMutator(mgr, logger, NewEnsurer(logger)),
+	})
+}

--- a/pkg/webhook/cloudprovider/ensurer.go
+++ b/pkg/webhook/cloudprovider/ensurer.go
@@ -39,7 +39,7 @@ type ensurer struct {
 
 // EnsureCloudProviderSecret ensures that cloudprovider secret contains
 // the shared credentials file.
-func (e *ensurer) EnsureCloudProviderSecret(ctx context.Context, _ gcontext.GardenContext, new, _ *corev1.Secret) error {
+func (e *ensurer) EnsureCloudProviderSecret(_ context.Context, _ gcontext.GardenContext, new, _ *corev1.Secret) error {
 	if _, ok := new.Data[alicloud.AccessKeyID]; !ok {
 		return fmt.Errorf("could not mutate cloudprovider secret as %q field is missing", alicloud.AccessKeyID)
 	}

--- a/pkg/webhook/cloudprovider/ensurer.go
+++ b/pkg/webhook/cloudprovider/ensurer.go
@@ -39,19 +39,19 @@ type ensurer struct {
 
 // EnsureCloudProviderSecret ensures that cloudprovider secret contains
 // the shared credentials file.
-func (e *ensurer) EnsureCloudProviderSecret(_ context.Context, _ gcontext.GardenContext, new, _ *corev1.Secret) error {
-	if _, ok := new.Data[alicloud.AccessKeyID]; !ok {
+func (e *ensurer) EnsureCloudProviderSecret(_ context.Context, _ gcontext.GardenContext, newSecret, _ *corev1.Secret) error {
+	if _, ok := newSecret.Data[alicloud.AccessKeyID]; !ok {
 		return fmt.Errorf("could not mutate cloudprovider secret as %q field is missing", alicloud.AccessKeyID)
 	}
-	if _, ok := new.Data[alicloud.AccessKeySecret]; !ok {
+	if _, ok := newSecret.Data[alicloud.AccessKeySecret]; !ok {
 		return fmt.Errorf("could not mutate cloudprovider secret as %q field is missing", alicloud.AccessKeySecret)
 	}
 
-	e.logger.V(5).Info("mutate cloudprovider secret", "namespace", new.Namespace, "name", new.Name)
-	new.Data[alicloud.CredentialsFile] = []byte("[default]\n" +
+	e.logger.V(5).Info("mutate cloudprovider secret", "namespace", newSecret.Namespace, "name", newSecret.Name)
+	newSecret.Data[alicloud.CredentialsFile] = []byte("[default]\n" +
 		"type = access_key\n" +
-		fmt.Sprintf("access_key_id = %s\n", string(new.Data[alicloud.AccessKeyID])) +
-		fmt.Sprintf("access_key_secret = %s", string(new.Data[alicloud.AccessKeySecret])),
+		fmt.Sprintf("access_key_id = %s\n", string(newSecret.Data[alicloud.AccessKeyID])) +
+		fmt.Sprintf("access_key_secret = %s", string(newSecret.Data[alicloud.AccessKeySecret])),
 	)
 
 	return nil

--- a/pkg/webhook/cloudprovider/ensurer.go
+++ b/pkg/webhook/cloudprovider/ensurer.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprovider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
+	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
+)
+
+// NewEnsurer creates cloudprovider ensurer.
+func NewEnsurer(logger logr.Logger) cloudprovider.Ensurer {
+	return &ensurer{
+		logger: logger,
+	}
+}
+
+type ensurer struct {
+	logger logr.Logger
+}
+
+// EnsureCloudProviderSecret ensures that cloudprovider secret contains
+// the shared credentials file.
+func (e *ensurer) EnsureCloudProviderSecret(ctx context.Context, _ gcontext.GardenContext, new, _ *corev1.Secret) error {
+	if _, ok := new.Data[alicloud.AccessKeyID]; !ok {
+		return fmt.Errorf("could not mutate cloudprovider secret as %q field is missing", alicloud.AccessKeyID)
+	}
+	if _, ok := new.Data[alicloud.AccessKeySecret]; !ok {
+		return fmt.Errorf("could not mutate cloudprovider secret as %q field is missing", alicloud.AccessKeySecret)
+	}
+
+	e.logger.V(5).Info("mutate cloudprovider secret", "namespace", new.Namespace, "name", new.Name)
+	new.Data[alicloud.CredentialsFile] = []byte("[default]\n" +
+		"type = access_key\n" +
+		fmt.Sprintf("access_key_id = %s\n", string(new.Data[alicloud.AccessKeyID])) +
+		fmt.Sprintf("access_key_secret = %s", string(new.Data[alicloud.AccessKeySecret])),
+	)
+
+	return nil
+}

--- a/pkg/webhook/cloudprovider/ensurer_test.go
+++ b/pkg/webhook/cloudprovider/ensurer_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprovider_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
+	. "github.com/gardener/gardener-extension-provider-alicloud/pkg/webhook/cloudprovider"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CloudProvider Webhook Suite")
+}
+
+var _ = Describe("Ensurer", func() {
+	var (
+		logger = log.Log.WithName("alicloud-cloudprovider-webhook-test")
+		ctx    = context.TODO()
+
+		ensurer cloudprovider.Ensurer
+
+		secret *corev1.Secret
+	)
+
+	BeforeEach(func() {
+		secret = &corev1.Secret{
+			Data: map[string][]byte{
+				alicloud.AccessKeyID:     []byte("access-key-id"),
+				alicloud.AccessKeySecret: []byte("access-key-secret"),
+			},
+		}
+
+		ensurer = NewEnsurer(logger)
+	})
+
+	Describe("#EnsureCloudProviderSecret", func() {
+		It("should fail as no accessKeyID is present", func() {
+			delete(secret.Data, alicloud.AccessKeyID)
+			err := ensurer.EnsureCloudProviderSecret(ctx, nil, secret, nil)
+			Expect(err).To(MatchError(ContainSubstring("could not mutate cloudprovider secret as %q field is missing", alicloud.AccessKeyID)))
+		})
+		It("should fail as no secretAccessKey is present", func() {
+			delete(secret.Data, alicloud.AccessKeySecret)
+			err := ensurer.EnsureCloudProviderSecret(ctx, nil, secret, nil)
+			Expect(err).To(MatchError(ContainSubstring("could not mutate cloudprovider secret as %q field is missing", alicloud.AccessKeySecret)))
+		})
+		It("should replace esixting credentials file", func() {
+			secret.Data[alicloud.CredentialsFile] = []byte("shared-credentials-file")
+
+			err := ensurer.EnsureCloudProviderSecret(ctx, nil, secret, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret.Data).To(Equal(map[string][]byte{
+				alicloud.AccessKeyID:     []byte("access-key-id"),
+				alicloud.AccessKeySecret: []byte("access-key-secret"),
+				alicloud.CredentialsFile: []byte(`[default]
+enable = true
+type = access_key
+access_key_id = access-key-id
+access_key_secret = access-key-secret`),
+			}))
+		})
+		It("should add credentials file", func() {
+			err := ensurer.EnsureCloudProviderSecret(ctx, nil, secret, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret.Data).To(Equal(map[string][]byte{
+				alicloud.AccessKeyID:     []byte("access-key-id"),
+				alicloud.AccessKeySecret: []byte("access-key-secret"),
+				alicloud.CredentialsFile: []byte(`[default]
+enable = true
+type = access_key
+access_key_id = access-key-id
+access_key_secret = access-key-secret`),
+			}))
+		})
+	})
+})

--- a/pkg/webhook/cloudprovider/ensurer_test.go
+++ b/pkg/webhook/cloudprovider/ensurer_test.go
@@ -74,7 +74,6 @@ var _ = Describe("Ensurer", func() {
 				alicloud.AccessKeyID:     []byte("access-key-id"),
 				alicloud.AccessKeySecret: []byte("access-key-secret"),
 				alicloud.CredentialsFile: []byte(`[default]
-enable = true
 type = access_key
 access_key_id = access-key-id
 access_key_secret = access-key-secret`),
@@ -88,7 +87,6 @@ access_key_secret = access-key-secret`),
 				alicloud.AccessKeyID:     []byte("access-key-id"),
 				alicloud.AccessKeySecret: []byte("access-key-secret"),
 				alicloud.CredentialsFile: []byte(`[default]
-enable = true
 type = access_key
 access_key_id = access-key-id
 access_key_secret = access-key-secret`),

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -177,6 +177,11 @@ var _ = BeforeSuite(func() {
 		Data: map[string][]byte{
 			alicloud.AccessKeyID:     []byte(*accessKeyID),
 			alicloud.AccessKeySecret: []byte(*accessKeySecret),
+			alicloud.CredentialsFile: []byte("[default]\n" +
+				"type = access_key\n" +
+				fmt.Sprintf("access_key_id = %s\n", *accessKeyID) +
+				fmt.Sprintf("access_key_secret = %s", *accessKeySecret),
+			),
 		},
 	}
 

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -275,6 +275,7 @@ var _ = Describe("Infrastructure tests", func() {
 				Data: map[string][]byte{
 					alicloud.AccessKeyID:     []byte("invalid"),
 					alicloud.AccessKeySecret: []byte("fake"),
+					alicloud.CredentialsFile: []byte("foo"),
 				},
 			}
 			Expect(c.Create(ctx, secret)).To(Succeed())
@@ -360,6 +361,7 @@ var _ = Describe("Infrastructure tests", func() {
 				Data: map[string][]byte{
 					alicloud.AccessKeyID:     []byte("invalid"),
 					alicloud.AccessKeySecret: []byte("fake"),
+					alicloud.CredentialsFile: []byte("foo"),
 				},
 			}
 			Expect(c.Create(ctx, secret)).To(Succeed())
@@ -449,6 +451,11 @@ func runTest(ctx context.Context, logger logr.Logger, c client.Client, providerC
 		Data: map[string][]byte{
 			alicloud.AccessKeyID:     []byte(*accessKeyID),
 			alicloud.AccessKeySecret: []byte(*accessKeySecret),
+			alicloud.CredentialsFile: []byte("[default]\n" +
+				"type = access_key\n" +
+				fmt.Sprintf("access_key_id = %s\n", *accessKeyID) +
+				fmt.Sprintf("access_key_secret = %s", *accessKeySecret),
+			),
 		},
 	}
 	if err := c.Create(ctx, secret); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area compliance
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
This PR adds a new mutating webhook which creates a new field `credentialsFile` for the `cloudprovider` secret, if the field does not already exist. The field is used for authentication purposes in `csi-plugin-controller` deployment and `csi-diskplugin` daemonset, replacing the old authentication method which used environment variables.
This PR is in sync with Kubernetes' STIG. See [DISA STIG](https://cyber.trackr.live/stig/Kubernetes/2/2) rule 242415 for more details.

**Which issue(s) this PR fixes**:
Fixes #625 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added `cloudprovider` webhook part of `gardener-extension-provider-alicloud` which ensures that the `cloudprovider` secret has the `credentialsFile` field present. The format of this field can be found in [this documentation](https://www.alibabacloud.com/help/en/sdk/developer-reference/credentials-settings).
```
```other operator
The `csi-plugin-controller` deployment and `csi-diskplugin` daemonset now use an Alibaba cloud credentials file for authentication.
```
