### PR TITLE
ReadSecretCredentials: Only return credentialsFile when present

### DIFF
--- a/pkg/alicloud/secret.go
+++ b/pkg/alicloud/secret.go
@@ -56,12 +56,8 @@ func ReadSecretCredentials(secret *corev1.Secret, allowDNSKeys bool) (*Credentia
 		return nil, fmt.Errorf("secret %s/%s has no access key secret", secret.Namespace, secret.Name)
 	}
 
-	if !allowDNSKeys {
-		credentialsFile, ok := getSecretDataValue(secret, CredentialsFile, nil)
-		if !ok {
-			return nil, fmt.Errorf("secret %s/%s has no credentials file", secret.Namespace, secret.Name)
-		}
-
+	credentialsFile, ok := getSecretDataValue(secret, CredentialsFile, nil)
+	if ok {
 		return &Credentials{
 			AccessKeyID:     string(accessKeyID),
 			AccessKeySecret: string(accessKeySecret),

--- a/pkg/alicloud/secret_test.go
+++ b/pkg/alicloud/secret_test.go
@@ -36,6 +36,22 @@ var _ = Describe("Alicloud Suite", func() {
 				}))
 			})
 
+			It("should correctly read the credentials if credentials file is missing", func() {
+				creds, err := ReadSecretCredentials(&corev1.Secret{
+					Data: map[string][]byte{
+						AccessKeyID:     []byte(accessKeyID),
+						AccessKeySecret: []byte(accessKeySecret),
+					},
+				}, false)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(creds).To(Equal(&Credentials{
+					AccessKeyID:     accessKeyID,
+					AccessKeySecret: accessKeySecret,
+					CredentialsFile: "",
+				}))
+			})
+
 			It("should fail if DNS keys are used", func() {
 				_, err := ReadSecretCredentials(&corev1.Secret{
 					Data: map[string][]byte{
@@ -63,6 +79,7 @@ var _ = Describe("Alicloud Suite", func() {
 				Expect(creds).To(Equal(&Credentials{
 					AccessKeyID:     accessKeyID,
 					AccessKeySecret: accessKeySecret,
+					CredentialsFile: credentialsFile,
 				}))
 			})
 
@@ -103,17 +120,6 @@ var _ = Describe("Alicloud Suite", func() {
 				Data: map[string][]byte{
 					AccessKeyID:     []byte(accessKeyID),
 					credentialsFile: []byte(credentialsFile),
-				},
-			}, false)
-
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("should fail if credentials file is missing", func() {
-			_, err := ReadSecretCredentials(&corev1.Secret{
-				Data: map[string][]byte{
-					AccessKeyID:     []byte(accessKeyID),
-					AccessKeySecret: []byte(accessKeySecret),
 				},
 			}, false)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform alicloud

**What this PR does / why we need it**:
The `ReadSecretCredentials()` function was changed to only return `CredentialsFile` when present in the specified secret. The field is not required in all cases and could cause failures in `BackupBucket` reconciliation [ref](https://github.com/gardener/gardener-extension-provider-alicloud/blob/678c5e99bc68fef449bd9eaba9865ef619088cf5/pkg/controller/backupbucket/actuator.go#L33)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug was fixed which caused `BackupBucket`s to fail in reconciliation when the referenced secret did not contain a `credentialsFile` field.
```
