### PR TITLE
Cleanup no longer needed CSI chart values

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-secret.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/templates/csi-diskplugin-secret.yaml
@@ -4,7 +4,5 @@ metadata:
   name: csi-diskplugin-alicloud
   namespace: kube-system
 data:
-  accessKeyID: {{ index .Values.credential.accessKeyID }}
-  accessKeySecret: {{ index .Values.credential.accessKeySecret }}
   credentialsFile: {{ index .Values.credential.credentialsFile }}
 type: Opaque

--- a/charts/internal/shoot-system-components/charts/csi-alicloud/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-alicloud/values.yaml
@@ -5,8 +5,6 @@ images:
   csi-liveness-probe: image-repository:image-tag
 
 credential:
-  accessKeyID: keyID
-  accessKeySecret: secret
   credentialsFile: file
 
 enableADController: true

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -454,8 +454,6 @@ func (vp *valuesProvider) getControlPlaneShootChartValues(
 	values := map[string]interface{}{
 		"csi-alicloud": map[string]interface{}{
 			"credential": map[string]interface{}{
-				"accessKeyID":     base64.StdEncoding.EncodeToString([]byte(credentials.AccessKeyID)),
-				"accessKeySecret": base64.StdEncoding.EncodeToString([]byte(credentials.AccessKeySecret)),
 				"credentialsFile": base64.StdEncoding.EncodeToString([]byte(credentials.CredentialsFile)),
 			},
 			"enableADController": vp.enableCSIADController(cpConfig),

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -158,8 +158,6 @@ var _ = Describe("ValuesProvider", func() {
 		controlPlaneShootChartValues = map[string]interface{}{
 			"csi-alicloud": map[string]interface{}{
 				"credential": map[string]interface{}{
-					"accessKeyID":     "Zm9v",
-					"accessKeySecret": "YmFy",
 					"credentialsFile": "YmF6",
 				},
 				"enableADController": true,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/platform alicloud

**What this PR does / why we need it**:
With [#779](https://github.com/gardener/gardener-extension-provider-alicloud/pull/779) the `accessKeyID` and `accessKeySecret` values are no longer used by the CSI components. This PR removes the no longer needed values.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
