### PR TITLE
[release-v1.61] Automated cherry pick of #787: ReadSecretCredentials: Only return credentialsFile when present

### DIFF
--- a/pkg/alicloud/secret.go
+++ b/pkg/alicloud/secret.go
@@ -56,12 +56,8 @@ func ReadSecretCredentials(secret *corev1.Secret, allowDNSKeys bool) (*Credentia
 		return nil, fmt.Errorf("secret %s/%s has no access key secret", secret.Namespace, secret.Name)
 	}
 
-	if !allowDNSKeys {
-		credentialsFile, ok := getSecretDataValue(secret, CredentialsFile, nil)
-		if !ok {
-			return nil, fmt.Errorf("secret %s/%s has no credentials file", secret.Namespace, secret.Name)
-		}
-
+	credentialsFile, ok := getSecretDataValue(secret, CredentialsFile, nil)
+	if ok {
 		return &Credentials{
 			AccessKeyID:     string(accessKeyID),
 			AccessKeySecret: string(accessKeySecret),

--- a/pkg/alicloud/secret_test.go
+++ b/pkg/alicloud/secret_test.go
@@ -36,6 +36,22 @@ var _ = Describe("Alicloud Suite", func() {
 				}))
 			})
 
+			It("should correctly read the credentials if credentials file is missing", func() {
+				creds, err := ReadSecretCredentials(&corev1.Secret{
+					Data: map[string][]byte{
+						AccessKeyID:     []byte(accessKeyID),
+						AccessKeySecret: []byte(accessKeySecret),
+					},
+				}, false)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(creds).To(Equal(&Credentials{
+					AccessKeyID:     accessKeyID,
+					AccessKeySecret: accessKeySecret,
+					CredentialsFile: "",
+				}))
+			})
+
 			It("should fail if DNS keys are used", func() {
 				_, err := ReadSecretCredentials(&corev1.Secret{
 					Data: map[string][]byte{
@@ -63,6 +79,7 @@ var _ = Describe("Alicloud Suite", func() {
 				Expect(creds).To(Equal(&Credentials{
 					AccessKeyID:     accessKeyID,
 					AccessKeySecret: accessKeySecret,
+					CredentialsFile: credentialsFile,
 				}))
 			})
 
@@ -103,17 +120,6 @@ var _ = Describe("Alicloud Suite", func() {
 				Data: map[string][]byte{
 					AccessKeyID:     []byte(accessKeyID),
 					credentialsFile: []byte(credentialsFile),
-				},
-			}, false)
-
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("should fail if credentials file is missing", func() {
-			_, err := ReadSecretCredentials(&corev1.Secret{
-				Data: map[string][]byte{
-					AccessKeyID:     []byte(accessKeyID),
-					AccessKeySecret: []byte(accessKeySecret),
 				},
 			}, false)
 


### PR DESCRIPTION
/area quality
/kind bug

Cherry pick of #787 on release-v1.61.

#787: ReadSecretCredentials: Only return credentialsFile when present

**Release Notes:**
```bugfix operator
A bug was fixed which caused `BackupBucket`s to fail in reconciliation when the referenced secret did not contain a `credentialsFile` field.
```