### PR TITLE
OSS backup bucket creation moved to use redundancy set to `ZRS`.

### DIFF
--- a/pkg/alicloud/client/client.go
+++ b/pkg/alicloud/client/client.go
@@ -135,7 +135,7 @@ func (c *ossClient) CreateBucketIfNotExists(ctx context.Context, bucketName stri
 		expirationOption = oss.Expires(t)
 	}
 
-	if err := c.CreateBucket(bucketName, oss.StorageClass(oss.StorageStandard), expirationOption); err != nil {
+	if err := c.CreateBucket(bucketName, oss.StorageClass(oss.StorageStandard), oss.RedundancyType(oss.RedundancyZRS), expirationOption); err != nil {
 		if ossErr, ok := err.(oss.ServiceError); !ok {
 			return err
 		} else if ossErr.StatusCode != http.StatusConflict {


### PR DESCRIPTION
**How to categorize this PR?**
/area disaster-recovery
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
This PR updates the AliCloud OSS backup-bucket creation to use the `Zone Redundant Storage (ZRS)` as currently backup-bucket is being created with default settings, which default to `Locally Redundant Storage (LRS)`.

**Which issue(s) this PR fixes**:
Fixes #790 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```user operator
Fixes an issue where the OSS backup-bucket was being created with redundancy set to `LRS`. From now on, the OSS backup bucket will be created with redundancy set to `ZRS`.
```
