### PR TITLE
Purge unused Machine Controller Manager RBAC resources

### DIFF
--- a/cmd/gardener-extension-provider-alicloud/app/app.go
+++ b/cmd/gardener-extension-provider-alicloud/app/app.go
@@ -264,6 +264,16 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("could not add ready check for webhook server to manager: %w", err)
 			}
 
+			// TODO (georgibaltiev): Remove after the release of version 1.64.0
+			if reconcileOpts.ExtensionClass != "garden" {
+				log.Info("Adding migration runnables")
+				if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+					return purgeMachineControllerManagerRBACResources(ctx, mgr.GetClient(), log)
+				})); err != nil {
+					return fmt.Errorf("error adding migrations: %w", err)
+				}
+			}
+
 			if err := mgr.Start(ctx); err != nil {
 				return fmt.Errorf("error running manager: %w", err)
 			}

--- a/cmd/gardener-extension-provider-alicloud/app/migrations.go
+++ b/cmd/gardener-extension-provider-alicloud/app/migrations.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/go-logr/logr"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var nameRegex = regexp.MustCompile("extensions.gardener.cloud:provider-alicloud:shoot--.*:machine-controller-manager")
+
+// TODO (georgibaltiev): Remove after the release of version 1.64.0
+func purgeMachineControllerManagerRBACResources(ctx context.Context, c client.Client, log logr.Logger) error {
+	log.Info("Starting the deletion of obsolete ClusterRoles and ClusterRoleBindings")
+
+	var (
+		clusterRoleBindingList = &rbacv1.ClusterRoleBindingList{}
+		clusterRoleList        = &rbacv1.ClusterRoleList{}
+	)
+
+	if err := c.List(ctx, clusterRoleBindingList); err != nil {
+		return fmt.Errorf("failed to list ClusterRoleBindings: %w", err)
+	}
+
+	for _, clusterRoleBinding := range clusterRoleBindingList.Items {
+		if nameRegex.Match([]byte(clusterRoleBinding.Name)) {
+			log.Info("Deleting ClusterRoleBinding", "clusterRoleBinding", client.ObjectKeyFromObject(&clusterRoleBinding))
+			if err := kutil.DeleteObject(
+				ctx,
+				c,
+				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleBinding.Name}},
+			); err != nil {
+				return fmt.Errorf("failed to delete ClusterRoleBinding %s: %w", client.ObjectKeyFromObject(&clusterRoleBinding), err)
+			}
+		}
+	}
+
+	if err := c.List(ctx, clusterRoleList); err != nil {
+		return fmt.Errorf("failed to list ClusterRoles: %w", err)
+	}
+
+	for _, clusterRole := range clusterRoleList.Items {
+		if nameRegex.Match([]byte(clusterRole.Name)) {
+			log.Info("Deleting ClusterRole", "clusterRole", client.ObjectKeyFromObject(&clusterRole))
+			if err := kutil.DeleteObject(
+				ctx,
+				c,
+				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: clusterRole.Name}},
+			); err != nil {
+				return fmt.Errorf("failed to delete ClusterRole %s: %w", client.ObjectKeyFromObject(&clusterRole), err)
+			}
+		}
+	}
+
+	log.Info("Successfully deleted the obsolete ClusterRoles and ClusterRoleBindings")
+	return nil
+}


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind cleanup
/platform alicloud

**What this PR does / why we need it**:

After the Machine Controller Manager was moved from the provider extension codebases to the core, the charts that define the component's resources have been deleted, as well as most resources that have been deployed to that point - [PR reference](https://github.com/gardener/gardener-extension-provider-alicloud/pull/706/files).
However, some ClusterRoles and ClusterRoleBindings that were used for the component still remain on certain seeds.
This PR adds a function to purge those, since they are not in use anymore.

The ClusterRoles|ClusterRoleBindings in question are named in the following way:
```
extensions.gardener.cloud:provider-alicloud:<shoot-name>:machine-controller-manager
```

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Obsolete ClusterRoles and ClusterRoleBindings that were leftovers from the machine-controller-manager component are now cleaned up.
```
