### PR TITLE
Specify leader-election namespace

### DIFF
--- a/charts/gardener-extension-admission-alicloud/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-alicloud/charts/runtime/templates/deployment.yaml
@@ -72,8 +72,12 @@ spec:
             port: {{ .Values.healthPort }}
             scheme: HTTP
           initialDelaySeconds: 5
-        {{- if .Values.gardener.virtualCluster.enabled }}
         env:
+        - name: LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- if .Values.gardener.virtualCluster.enabled }}
         - name: SOURCE_CLUSTER
           value: enabled
         {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform alicloud

**What this PR does / why we need it**:
This is necessary so that the alicloud admission can start successfully when deployed via the [`configure-admission.sh`](https://github.com/gardener/gardener/blob/master/example/provider-extensions/garden/configure-admission.sh) script which is called when setting up gardener local development with provider extension.

Otherwise the following error can be observed when the admission is started :
```
not running in-cluster, please specify LeaderElectionNamespace
```

This happens because `controller-runtime` is not able to find its leader election namespace from the `/var/run/secrets/kubernetes.io/serviceaccount/namespace` file as it does not exist [ref](https://github.com/kubernetes-sigs/controller-runtime/blob/15c5d6129278bc19c67615032cffbb9fb5e90a2f/pkg/leaderelection/leader_election.go#L133-L148).
The file does not exist because the [`configure-admission.sh`](https://github.com/gardener/gardener/blob/master/example/provider-extensions/garden/configure-admission.sh) script specifies the `kubeconfig` value for the admission's helm charts and `automountServiceAccountToken` is set to false: [ref](https://github.com/gardener/gardener-extension-provider-alicloud/blob/1ffc86cb8726166bec2d6bbdc5e70f2123fe265f/charts/gardener-extension-admission-alicloud/charts/runtime/templates/deployment.yaml#L32-L34).

Similar PRs were open for other extensions, e.g: https://github.com/gardener/gardener-extension-provider-aws/pull/877

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @kon-angelo 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Admission controller will be deployed with the `LEADER_ELECTION_NAMESPACE` environment variable set to the pod namespace
```
