### PR TITLE
[GEP-26] Update seed backup docs to use credentialsRef field

### DIFF
--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -78,7 +78,7 @@ spec:
 
 ## Enable customized machine images for the Alicloud extension
 
-Customized machine images can be created for an Alicloud account and shared with other Alicloud accounts. 
+Customized machine images can be created for an Alicloud account and shared with other Alicloud accounts.
 The same customized machine image has different image ID in different regions on Alicloud.
 If you need to enable `encrypted system disk`, you must provide customized machine images.
 Administrators/Operators need to explicitly declare them per imageID per region as below:
@@ -182,7 +182,9 @@ spec:
     region: cn-shanghai
   backup:
     provider: alicloud
-    secretRef:
+    credentialsRef:
+      apiVersion: v1
+      kind: Secret
       name: backup-credentials
       namespace: garden
   ...
@@ -191,5 +193,5 @@ An example of the referenced secret containing the credentials for the Alicloud 
 
 #### Permissions for Alicloud Object Storage Service
 
-Please make sure the RAM user associated with the provided AccessKey pair has the following permission. 
+Please make sure the RAM user associated with the provided AccessKey pair has the following permission.
 - AliyunOSSFullAccess


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei documentation
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
Update seed backup docs to use credentialsRef field

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Part of https://github.com/gardener/gardener/issues/9586 
x-ref: https://github.com/gardener/gardener/pull/12347#discussion_r2160947091

cc @dimityrmirchev 


**Release note**:
```other operator
NONE
```
