### PR TITLE
Reverting the creation of bucket with zone redundancy as some region doesn't support it.

### DIFF
--- a/pkg/alicloud/client/client.go
+++ b/pkg/alicloud/client/client.go
@@ -134,7 +134,7 @@ func (c *ossClient) CreateBucketIfNotExists(ctx context.Context, bucketName stri
 		expirationOption = oss.Expires(t)
 	}
 
-	if err := c.CreateBucket(bucketName, oss.StorageClass(oss.StorageStandard), oss.RedundancyType(oss.RedundancyZRS), expirationOption); err != nil {
+	if err := c.CreateBucket(bucketName, oss.StorageClass(oss.StorageStandard), expirationOption); err != nil {
 		if ossErr, ok := err.(oss.ServiceError); !ok {
 			return err
 		} else if ossErr.StatusCode != http.StatusConflict {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind bug
/platform alicloud

**What this PR does / why we need it**:
In this PR: https://github.com/gardener/gardener-extension-provider-alicloud/pull/791, I introduced that AliCloud OSS backup-bucket creation should use the `Zone Redundant Storage (ZRS)` but while testing this PR: https://github.com/gardener/gardener-extension-provider-alicloud/pull/825 with local extension setup, I found that backup-bucket creation failed with this error:
```
Error reconciling backupbucket: oss: service returned error: StatusCode=400, ErrorCode=InvalidArgument, ErrorMessage="The requested ZRS data redundancy type is not supported in this region.
```
Hence, for now I'm reverting this change as I failed to create bucket in `eu-west-1` region with ZRS.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Reverting the fix of creation of OSS backup-bucket with redundancy set to `ZRS` to `LRS` as some region doesn't support the ZRS.
```
