### PR TITLE
1.64 fix flow zone worker

### DIFF
--- a/pkg/apis/alicloud/validation/infrastructure.go
+++ b/pkg/apis/alicloud/validation/infrastructure.go
@@ -129,30 +129,13 @@ func ValidateNetworkZonesConfig(newZones, oldZones []apisalicloud.Zone, fldPath 
 	return allErrs
 }
 
+// check if migrate from worker to workers
 func isZoneMigratWorkerToWorkers(oldZone, newZone apisalicloud.Zone) bool {
 	if oldZone.Worker != "" && oldZone.Workers == "" && newZone.Worker == "" && newZone.Workers != "" {
 		return true
 	}
 	return false
 }
-
-// func getActiveZoneWorkersValue(oldZone, newZone apisalicloud.Zone) (oldValue, newValue string, checkOk bool) {
-// 	checkOk = true
-// 	if oldZone.Workers != "" && newZone.Workers != "" {
-// 		oldValue = oldZone.Workers
-// 		newValue = newZone.Workers
-// 	} else if oldZone.Worker != "" && newZone.Workers != "" {
-// 		oldValue = oldZone.Worker
-// 		newValue = newZone.Workers
-// 	} else if oldZone.Worker != "" && newZone.Worker != "" {
-// 		oldValue = oldZone.Worker
-// 		newValue = newZone.Worker
-// 	} else {
-// 		checkOk = false
-// 	}
-
-// 	return oldValue, newValue, checkOk
-// }
 
 // ValidateNatGatewayConfig validates a NatGatewayConfig object.
 func ValidateNatGatewayConfig(natGateway *apisalicloud.NatGatewayConfig, fldPath *field.Path) field.ErrorList {

--- a/pkg/apis/alicloud/validation/infrastructure_test.go
+++ b/pkg/apis/alicloud/validation/infrastructure_test.go
@@ -197,6 +197,14 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			Expect(ValidateInfrastructureConfigUpdate(infrastructureConfig, infrastructureConfig)).To(BeEmpty())
 		})
 
+		It("should return no errors for migrate zone worker to workers", func() {
+			oldInfrastructureConfig := infrastructureConfig.DeepCopy()
+			tmpvalue := oldInfrastructureConfig.Networks.Zones[0].Worker
+			oldInfrastructureConfig.Networks.Zones[0].Worker = oldInfrastructureConfig.Networks.Zones[0].Workers
+			oldInfrastructureConfig.Networks.Zones[0].Workers = tmpvalue
+			Expect(ValidateInfrastructureConfigUpdate(oldInfrastructureConfig, infrastructureConfig)).To(BeEmpty())
+		})
+
 		It("should forbid changing the VPC section", func() {
 			newInfrastructureConfig := infrastructureConfig.DeepCopy()
 			newCIDR := "1.2.3.4/5"

--- a/pkg/controller/infrastructure/infraflow/reconcile_zone.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile_zone.go
@@ -337,10 +337,14 @@ func (c *FlowContext) ensureVSwitches(ctx context.Context) error {
 	for _, zone := range c.config.Networks.Zones {
 		zoneSuffix := c.getZoneSuffix(zone.Name)
 		workerSuffix := fmt.Sprintf("nodes-%s", zoneSuffix)
+		cidrBlock := zone.Workers
+		if cidrBlock == "" {
+			cidrBlock = zone.Worker
+		}
 		desired = append(desired,
 			&aliclient.VSwitch{
 				Name:      c.namespace + "-" + zone.Name + "-vsw",
-				CidrBlock: zone.Workers,
+				CidrBlock: cidrBlock,
 				VpcId:     vpcId,
 				Tags:      c.commonTagsWithSuffix(workerSuffix),
 				ZoneId:    zone.Name,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
Flow-base now supports zone CIDR named with **worker** ,  and enable migrate from **worker** to **workers**
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Flow-base now supports zone CIDR named with worker ,  and enable migrate from worker to workers 
```
