### PR TITLE
[GEP-26] Enable validation of `seed.spec.backup.credentialsRef` and `backupBucket.spec.credentialsRef`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ IGNORE_OPERATION_ANNOTATION := true
 WEBHOOK_CONFIG_PORT	:= 8443
 WEBHOOK_CONFIG_MODE	:= url
 WEBHOOK_CONFIG_URL	:= host.docker.internal:$(WEBHOOK_CONFIG_PORT)
-EXTENSION_NAMESPACE	:=
+EXTENSION_NAMESPACE	:= garden
+GARDEN_KUBECONFIG	?=
 
 WEBHOOK_PARAM := --webhook-config-url=$(WEBHOOK_CONFIG_URL)
 ifeq ($(WEBHOOK_CONFIG_MODE), service)
@@ -50,7 +51,10 @@ include $(GARDENER_HACK_DIR)/tools.mk
 
 .PHONY: start
 start:
-	@LEADER_ELECTION_NAMESPACE=garden go run \
+	@LEADER_ELECTION_NAMESPACE=$(EXTENSION_NAMESPACE) \
+		GARDEN_KUBECONFIG=$(GARDEN_KUBECONFIG) \
+		GARDENER_SHOOT_CLIENT="external" \
+		go run \
 		-ldflags $(LD_FLAGS) \
 		./cmd/$(EXTENSION_PREFIX)-$(NAME) \
 		--config-file=./example/00-componentconfig.yaml \
@@ -64,7 +68,7 @@ start:
 
 .PHONY: start-admission
 start-admission:
-	@LEADER_ELECTION_NAMESPACE=garden go run \
+	@LEADER_ELECTION_NAMESPACE=$(EXTENSION_NAMESPACE) go run \
 		-ldflags $(LD_FLAGS) \
 		./cmd/$(EXTENSION_PREFIX)-$(ADMISSION_NAME) \
 		--webhook-config-server-host=0.0.0.0 \

--- a/pkg/admission/mutator/namespacedcloudprofile.go
+++ b/pkg/admission/mutator/namespacedcloudprofile.go
@@ -25,13 +25,11 @@ import (
 // NewNamespacedCloudProfileMutator returns a new instance of a NamespacedCloudProfile mutator.
 func NewNamespacedCloudProfileMutator(mgr manager.Manager) extensionswebhook.Mutator {
 	return &namespacedCloudProfile{
-		client:  mgr.GetClient(),
 		decoder: serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
 	}
 }
 
 type namespacedCloudProfile struct {
-	client  client.Client
 	decoder runtime.Decoder
 }
 

--- a/pkg/admission/mutator/namespacedcloudprofile_test.go
+++ b/pkg/admission/mutator/namespacedcloudprofile_test.go
@@ -20,8 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/admission/mutator"
@@ -31,7 +29,6 @@ import (
 
 var _ = Describe("NamespacedCloudProfile Mutator", func() {
 	var (
-		fakeClient  client.Client
 		fakeManager manager.Manager
 		namespace   string
 		ctx         = context.Background()
@@ -45,9 +42,7 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 		scheme := runtime.NewScheme()
 		utilruntime.Must(install.AddToScheme(scheme))
 		utilruntime.Must(v1beta1.AddToScheme(scheme))
-		fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 		fakeManager = &test.FakeManager{
-			Client: fakeClient,
 			Scheme: scheme,
 		}
 		namespace = "garden-dev"

--- a/pkg/admission/validator/backupbucket.go
+++ b/pkg/admission/validator/backupbucket.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	alicloudvalidation "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/validation"
+)
+
+// backupBucketValidator validates create and update operations on BackupBucket resources,
+type backupBucketValidator struct {
+	decoder        runtime.Decoder
+	lenientDecoder runtime.Decoder
+}
+
+// NewBackupBucketValidator returns a new instance of backupBucket validator.
+func NewBackupBucketValidator(mgr manager.Manager) extensionswebhook.Validator {
+	return &backupBucketValidator{
+		decoder:        serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
+		lenientDecoder: serializer.NewCodecFactory(mgr.GetScheme()).UniversalDecoder(),
+	}
+}
+
+// Validate validates the BackupBucket resource during create or update operations.
+func (s *backupBucketValidator) Validate(_ context.Context, newObj, oldObj client.Object) error {
+	newBackupBucket, ok := newObj.(*gardencorev1beta1.BackupBucket)
+	if !ok {
+		return fmt.Errorf("wrong object type %T for new object", newObj)
+	}
+
+	if oldObj != nil {
+		oldBackupBucket, ok := oldObj.(*gardencorev1beta1.BackupBucket)
+		if !ok {
+			return fmt.Errorf("wrong object type %T for old object", oldObj)
+		}
+		return s.validateUpdate(oldBackupBucket, newBackupBucket).ToAggregate()
+	}
+
+	return s.validateCreate(newBackupBucket).ToAggregate()
+}
+
+// validateCreate validates the BackupBucket object upon creation.
+func (b *backupBucketValidator) validateCreate(backupBucket *gardencorev1beta1.BackupBucket) field.ErrorList {
+	var (
+		allErrs            = field.ErrorList{}
+		providerConfigPath = field.NewPath("spec", "providerConfig")
+	)
+
+	config, err := DecodeBackupBucketConfig(b.decoder, backupBucket.Spec.ProviderConfig)
+	if err != nil {
+		return append(allErrs, field.InternalError(providerConfigPath, fmt.Errorf("failed to decode provider config: %w", err)))
+	}
+
+	allErrs = append(allErrs, alicloudvalidation.ValidateBackupBucketConfig(config, providerConfigPath)...)
+	allErrs = append(allErrs, alicloudvalidation.ValidateBackupBucketCredentialsRef(backupBucket.Spec.CredentialsRef, field.NewPath("spec", "credentialsRef"))...)
+
+	return allErrs
+}
+
+// validateUpdate validates updates to the BackupBucket resource.
+func (b *backupBucketValidator) validateUpdate(oldBackupBucket, backupBucket *gardencorev1beta1.BackupBucket) field.ErrorList {
+	var (
+		allErrs            = field.ErrorList{}
+		providerConfigPath = field.NewPath("spec", "providerConfig")
+	)
+
+	if oldBackupBucket.Spec.ProviderConfig == nil {
+		return b.validateCreate(backupBucket)
+	}
+
+	oldConfig, err := DecodeBackupBucketConfig(b.lenientDecoder, oldBackupBucket.Spec.ProviderConfig)
+	if err != nil {
+		return append(allErrs, field.InternalError(providerConfigPath, fmt.Errorf("failed to decode old provider config: %W", err)))
+	}
+
+	config, err := DecodeBackupBucketConfig(b.decoder, backupBucket.Spec.ProviderConfig)
+	if err != nil {
+		return append(allErrs, field.InternalError(providerConfigPath, fmt.Errorf("failed to decode new provider config: %W", err)))
+	}
+
+	allErrs = append(allErrs, alicloudvalidation.ValidateBackupBucketConfig(config, providerConfigPath)...)
+	allErrs = append(allErrs, alicloudvalidation.ValidateBackupBucketConfigUpdate(oldConfig, config, providerConfigPath)...)
+	allErrs = append(allErrs, alicloudvalidation.ValidateBackupBucketCredentialsRef(backupBucket.Spec.CredentialsRef, field.NewPath("spec", "credentialsRef"))...)
+
+	return allErrs
+}

--- a/pkg/admission/validator/backupbucket.go
+++ b/pkg/admission/validator/backupbucket.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -35,13 +35,13 @@ func NewBackupBucketValidator(mgr manager.Manager) extensionswebhook.Validator {
 
 // Validate validates the BackupBucket resource during create or update operations.
 func (s *backupBucketValidator) Validate(_ context.Context, newObj, oldObj client.Object) error {
-	newBackupBucket, ok := newObj.(*gardencorev1beta1.BackupBucket)
+	newBackupBucket, ok := newObj.(*gardencore.BackupBucket)
 	if !ok {
 		return fmt.Errorf("wrong object type %T for new object", newObj)
 	}
 
 	if oldObj != nil {
-		oldBackupBucket, ok := oldObj.(*gardencorev1beta1.BackupBucket)
+		oldBackupBucket, ok := oldObj.(*gardencore.BackupBucket)
 		if !ok {
 			return fmt.Errorf("wrong object type %T for old object", oldObj)
 		}
@@ -52,7 +52,7 @@ func (s *backupBucketValidator) Validate(_ context.Context, newObj, oldObj clien
 }
 
 // validateCreate validates the BackupBucket object upon creation.
-func (b *backupBucketValidator) validateCreate(backupBucket *gardencorev1beta1.BackupBucket) field.ErrorList {
+func (b *backupBucketValidator) validateCreate(backupBucket *gardencore.BackupBucket) field.ErrorList {
 	var (
 		allErrs            = field.ErrorList{}
 		providerConfigPath = field.NewPath("spec", "providerConfig")
@@ -70,7 +70,7 @@ func (b *backupBucketValidator) validateCreate(backupBucket *gardencorev1beta1.B
 }
 
 // validateUpdate validates updates to the BackupBucket resource.
-func (b *backupBucketValidator) validateUpdate(oldBackupBucket, backupBucket *gardencorev1beta1.BackupBucket) field.ErrorList {
+func (b *backupBucketValidator) validateUpdate(oldBackupBucket, backupBucket *gardencore.BackupBucket) field.ErrorList {
 	var (
 		allErrs            = field.ErrorList{}
 		providerConfigPath = field.NewPath("spec", "providerConfig")

--- a/pkg/admission/validator/backupbucket_test.go
+++ b/pkg/admission/validator/backupbucket_test.go
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator_test
+
+import (
+	"context"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	mockmanager "github.com/gardener/gardener/third_party/mock/controller-runtime/manager"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/admission/validator"
+	apisalicloud "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
+	apisalicloudv1alpha1 "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/v1alpha1"
+)
+
+var _ = Describe("BackupBucket Validator", func() {
+	Describe("#Validate", func() {
+		var (
+			ctx                   context.Context
+			credentialsRef        *corev1.ObjectReference
+			ctrl                  *gomock.Controller
+			mgr                   *mockmanager.MockManager
+			scheme                *runtime.Scheme
+			backupBucketValidator extensionswebhook.Validator
+		)
+
+		BeforeEach(func() {
+			ctx = context.TODO()
+			credentialsRef = &corev1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "Secret",
+				Name:       "backup-credentials",
+				Namespace:  "garden",
+			}
+
+			ctrl = gomock.NewController(GinkgoT())
+			scheme = runtime.NewScheme()
+			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
+			Expect(apisalicloudv1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(apisalicloud.AddToScheme(scheme)).To(Succeed())
+
+			mgr = mockmanager.NewMockManager(ctrl)
+			mgr.EXPECT().GetScheme().Return(scheme).AnyTimes()
+
+			backupBucketValidator = validator.NewBackupBucketValidator(mgr)
+		})
+
+		It("should return err when obj is not a core.gardener.cloud/v1beta1.BackupBucket", func() {
+			err := backupBucketValidator.Validate(ctx, &corev1.Secret{}, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("wrong object type *v1.Secret for new object"))
+		})
+
+		It("should return err when oldObj is not a core.gardener.cloud/v1beta1.BackupBucket", func() {
+			err := backupBucketValidator.Validate(ctx, &gardencorev1beta1.BackupBucket{}, &corev1.Secret{})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("wrong object type *v1.Secret for old object"))
+		})
+
+		Context("Create", func() {
+			It("should return error when BackupBucket provider config cannot be decoded", func() {
+				backupBucket := &gardencorev1beta1.BackupBucket{
+					Spec: gardencorev1beta1.BackupBucketSpec{
+						CredentialsRef: credentialsRef,
+						ProviderConfig: &runtime.RawExtension{
+							Raw: []byte(`invalid`),
+						},
+					},
+				}
+
+				err := backupBucketValidator.Validate(ctx, backupBucket, nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring(`failed to decode provider config: `)))
+			})
+
+			It("should succeed when BackupBucket is created with valid spec", func() {
+				backupBucket := &gardencorev1beta1.BackupBucket{
+					Spec: gardencorev1beta1.BackupBucketSpec{
+						CredentialsRef: credentialsRef,
+						ProviderConfig: &runtime.RawExtension{
+							Raw: []byte(`{"apiVersion": "alicloud.provider.extensions.gardener.cloud/v1alpha1", "kind": "BackupBucketConfig"}`),
+						},
+					},
+				}
+
+				Expect(backupBucketValidator.Validate(ctx, backupBucket, nil)).To(Succeed())
+			})
+		})
+
+		Context("Update", func() {
+			It("should return error when BackupBucket is updated with invalid spec and old had unset providerConfig", func() {
+				backupBucket := &gardencorev1beta1.BackupBucket{
+					Spec: gardencorev1beta1.BackupBucketSpec{
+						CredentialsRef: credentialsRef,
+						ProviderConfig: nil,
+					},
+				}
+
+				newBackupBucket := backupBucket.DeepCopy()
+				newBackupBucket.Spec.ProviderConfig = &runtime.RawExtension{
+					Raw: []byte(`{"apiVersion": "alicloud.provider.extensions.gardener.cloud/v1alpha1", "kind": "invalid"}`),
+				}
+
+				err := backupBucketValidator.Validate(ctx, newBackupBucket, backupBucket)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring(`failed to decode provider config: `)))
+			})
+
+			It("should succeed when BackupBucket is updated with valid spec and old had unset providerConfig", func() {
+				backupBucket := &gardencorev1beta1.BackupBucket{
+					Spec: gardencorev1beta1.BackupBucketSpec{
+						CredentialsRef: credentialsRef,
+						ProviderConfig: nil,
+					},
+				}
+
+				newBackupBucket := backupBucket.DeepCopy()
+				newBackupBucket.Spec.ProviderConfig = &runtime.RawExtension{
+					Raw: []byte(`{"apiVersion": "alicloud.provider.extensions.gardener.cloud/v1alpha1", "kind": "BackupBucketConfig"}`),
+				}
+
+				Expect(backupBucketValidator.Validate(ctx, newBackupBucket, backupBucket)).To(Succeed())
+			})
+
+			It("should return error when BackupBucket is updated and old had invalid providerConfig set", func() {
+				backupBucket := &gardencorev1beta1.BackupBucket{
+					Spec: gardencorev1beta1.BackupBucketSpec{
+						CredentialsRef: credentialsRef,
+						ProviderConfig: &runtime.RawExtension{
+							Raw: []byte(`{"apiVersion": "alicloud.provider.extensions.gardener.cloud/v1alpha1", "kind": "invalid"}`),
+						},
+					},
+				}
+
+				newBackupBucket := backupBucket.DeepCopy()
+				newBackupBucket.Spec.CredentialsRef = nil
+
+				err := backupBucketValidator.Validate(ctx, newBackupBucket, backupBucket)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("failed to decode old provider config")))
+			})
+
+			It("should return error when BackupBucket is updated with invalid providerConfig and old had valid providerConfig set", func() {
+				backupBucket := &gardencorev1beta1.BackupBucket{
+					Spec: gardencorev1beta1.BackupBucketSpec{
+						CredentialsRef: credentialsRef,
+						ProviderConfig: &runtime.RawExtension{
+							Raw: []byte(`{"apiVersion": "alicloud.provider.extensions.gardener.cloud/v1alpha1", "kind": "BackupBucketConfig"}`),
+						},
+					},
+				}
+
+				newBackupBucket := backupBucket.DeepCopy()
+				newBackupBucket.Spec.ProviderConfig = &runtime.RawExtension{
+					Raw: []byte(`{"apiVersion": "alicloud.provider.extensions.gardener.cloud/v1alpha1", "kind": "invalid"}`),
+				}
+
+				err := backupBucketValidator.Validate(ctx, newBackupBucket, backupBucket)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("failed to decode new provider config")))
+			})
+
+			It("should succeed when BackupBucket is updated with valid spec and old had valid providerConfig set", func() {
+				backupBucket := &gardencorev1beta1.BackupBucket{
+					Spec: gardencorev1beta1.BackupBucketSpec{
+						CredentialsRef: credentialsRef,
+						ProviderConfig: &runtime.RawExtension{
+							Raw: []byte(`{"apiVersion": "alicloud.provider.extensions.gardener.cloud/v1alpha1", "kind": "BackupBucketConfig", "immutability": {"retentionPeriod": 96, "retentionType": "bucket"}}`),
+						},
+					},
+				}
+
+				newBackupBucket := backupBucket.DeepCopy()
+				newBackupBucket.Spec.ProviderConfig = &runtime.RawExtension{
+					Raw: []byte(`{"apiVersion": "alicloud.provider.extensions.gardener.cloud/v1alpha1", "kind": "BackupBucketConfig"}`),
+				}
+
+				Expect(backupBucketValidator.Validate(ctx, newBackupBucket, backupBucket)).To(Succeed())
+			})
+		})
+	})
+})

--- a/pkg/admission/validator/backupbucket_test.go
+++ b/pkg/admission/validator/backupbucket_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	mockmanager "github.com/gardener/gardener/third_party/mock/controller-runtime/manager"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -43,7 +43,7 @@ var _ = Describe("BackupBucket Validator", func() {
 
 			ctrl = gomock.NewController(GinkgoT())
 			scheme = runtime.NewScheme()
-			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
+			Expect(gardencore.AddToScheme(scheme)).To(Succeed())
 			Expect(apisalicloudv1alpha1.AddToScheme(scheme)).To(Succeed())
 			Expect(apisalicloud.AddToScheme(scheme)).To(Succeed())
 
@@ -60,15 +60,15 @@ var _ = Describe("BackupBucket Validator", func() {
 		})
 
 		It("should return err when oldObj is not a core.gardener.cloud/v1beta1.BackupBucket", func() {
-			err := backupBucketValidator.Validate(ctx, &gardencorev1beta1.BackupBucket{}, &corev1.Secret{})
+			err := backupBucketValidator.Validate(ctx, &gardencore.BackupBucket{}, &corev1.Secret{})
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("wrong object type *v1.Secret for old object"))
 		})
 
 		Context("Create", func() {
 			It("should return error when BackupBucket provider config cannot be decoded", func() {
-				backupBucket := &gardencorev1beta1.BackupBucket{
-					Spec: gardencorev1beta1.BackupBucketSpec{
+				backupBucket := &gardencore.BackupBucket{
+					Spec: gardencore.BackupBucketSpec{
 						CredentialsRef: credentialsRef,
 						ProviderConfig: &runtime.RawExtension{
 							Raw: []byte(`invalid`),
@@ -82,8 +82,8 @@ var _ = Describe("BackupBucket Validator", func() {
 			})
 
 			It("should succeed when BackupBucket is created with valid spec", func() {
-				backupBucket := &gardencorev1beta1.BackupBucket{
-					Spec: gardencorev1beta1.BackupBucketSpec{
+				backupBucket := &gardencore.BackupBucket{
+					Spec: gardencore.BackupBucketSpec{
 						CredentialsRef: credentialsRef,
 						ProviderConfig: &runtime.RawExtension{
 							Raw: []byte(`{"apiVersion": "alicloud.provider.extensions.gardener.cloud/v1alpha1", "kind": "BackupBucketConfig"}`),
@@ -97,8 +97,8 @@ var _ = Describe("BackupBucket Validator", func() {
 
 		Context("Update", func() {
 			It("should return error when BackupBucket is updated with invalid spec and old had unset providerConfig", func() {
-				backupBucket := &gardencorev1beta1.BackupBucket{
-					Spec: gardencorev1beta1.BackupBucketSpec{
+				backupBucket := &gardencore.BackupBucket{
+					Spec: gardencore.BackupBucketSpec{
 						CredentialsRef: credentialsRef,
 						ProviderConfig: nil,
 					},
@@ -115,8 +115,8 @@ var _ = Describe("BackupBucket Validator", func() {
 			})
 
 			It("should succeed when BackupBucket is updated with valid spec and old had unset providerConfig", func() {
-				backupBucket := &gardencorev1beta1.BackupBucket{
-					Spec: gardencorev1beta1.BackupBucketSpec{
+				backupBucket := &gardencore.BackupBucket{
+					Spec: gardencore.BackupBucketSpec{
 						CredentialsRef: credentialsRef,
 						ProviderConfig: nil,
 					},
@@ -131,8 +131,8 @@ var _ = Describe("BackupBucket Validator", func() {
 			})
 
 			It("should return error when BackupBucket is updated and old had invalid providerConfig set", func() {
-				backupBucket := &gardencorev1beta1.BackupBucket{
-					Spec: gardencorev1beta1.BackupBucketSpec{
+				backupBucket := &gardencore.BackupBucket{
+					Spec: gardencore.BackupBucketSpec{
 						CredentialsRef: credentialsRef,
 						ProviderConfig: &runtime.RawExtension{
 							Raw: []byte(`{"apiVersion": "alicloud.provider.extensions.gardener.cloud/v1alpha1", "kind": "invalid"}`),
@@ -149,8 +149,8 @@ var _ = Describe("BackupBucket Validator", func() {
 			})
 
 			It("should return error when BackupBucket is updated with invalid providerConfig and old had valid providerConfig set", func() {
-				backupBucket := &gardencorev1beta1.BackupBucket{
-					Spec: gardencorev1beta1.BackupBucketSpec{
+				backupBucket := &gardencore.BackupBucket{
+					Spec: gardencore.BackupBucketSpec{
 						CredentialsRef: credentialsRef,
 						ProviderConfig: &runtime.RawExtension{
 							Raw: []byte(`{"apiVersion": "alicloud.provider.extensions.gardener.cloud/v1alpha1", "kind": "BackupBucketConfig"}`),
@@ -169,8 +169,8 @@ var _ = Describe("BackupBucket Validator", func() {
 			})
 
 			It("should succeed when BackupBucket is updated with valid spec and old had valid providerConfig set", func() {
-				backupBucket := &gardencorev1beta1.BackupBucket{
-					Spec: gardencorev1beta1.BackupBucketSpec{
+				backupBucket := &gardencore.BackupBucket{
+					Spec: gardencore.BackupBucketSpec{
 						CredentialsRef: credentialsRef,
 						ProviderConfig: &runtime.RawExtension{
 							Raw: []byte(`{"apiVersion": "alicloud.provider.extensions.gardener.cloud/v1alpha1", "kind": "BackupBucketConfig", "immutability": {"retentionPeriod": 96, "retentionType": "bucket"}}`),

--- a/pkg/admission/validator/seed.go
+++ b/pkg/admission/validator/seed.go
@@ -23,7 +23,6 @@ import (
 // seedValidator validates create and update operations on Seed resources,
 // enforcing immutability of backup configurations.
 type seedValidator struct {
-	client         client.Client
 	decoder        runtime.Decoder
 	lenientDecoder runtime.Decoder
 }
@@ -32,7 +31,6 @@ type seedValidator struct {
 // to validate backupbucket configuration.
 func NewSeedValidator(mgr manager.Manager) extensionswebhook.Validator {
 	return &seedValidator{
-		client:         mgr.GetClient(),
 		decoder:        serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
 		lenientDecoder: serializer.NewCodecFactory(mgr.GetScheme()).UniversalDecoder(),
 	}

--- a/pkg/admission/validator/seed.go
+++ b/pkg/admission/validator/seed.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	apisali "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
 	alivalidation "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/validation"
 )
 
@@ -59,22 +58,23 @@ func (s *seedValidator) Validate(_ context.Context, newObj, oldObj client.Object
 // validateCreate validates the Seed object upon creation.
 // It checks if immutable settings are provided and if provided then it validates the immutable settings.
 func (s *seedValidator) validateCreate(seed *core.Seed) field.ErrorList {
-	var (
-		allErrs               = field.ErrorList{}
-		providerConfigfldPath = field.NewPath("spec", "backup", "providerConfig")
-	)
+	allErrs := field.ErrorList{}
 
-	if seed.Spec.Backup == nil || seed.Spec.Backup.ProviderConfig == nil {
-		return allErrs
+	if seed.Spec.Backup != nil {
+		backupPath := field.NewPath("spec", "backup")
+		allErrs = append(allErrs, alivalidation.ValidateBackupBucketCredentialsRef(seed.Spec.Backup.CredentialsRef, backupPath.Child("credentialsRef"))...)
+
+		if seed.Spec.Backup.ProviderConfig != nil {
+			providerConfigPath := backupPath.Child("providerConfig")
+
+			backupBucketConfig, err := DecodeBackupBucketConfig(s.decoder, seed.Spec.Backup.ProviderConfig)
+			if err != nil {
+				return append(allErrs, field.InternalError(providerConfigPath, fmt.Errorf("failed to decode new provider config: %w", err)))
+			}
+
+			allErrs = append(allErrs, alivalidation.ValidateBackupBucketConfig(backupBucketConfig, providerConfigPath)...)
+		}
 	}
-
-	backupBucketConfig, err := s.extractBackupBucketConfig(seed, s.lenientDecoder)
-	if err != nil {
-		allErrs = append(allErrs, field.Invalid(providerConfigfldPath, seed.Spec.Backup.ProviderConfig, fmt.Errorf("failed to decode new provider config: %v", err).Error()))
-		return allErrs
-	}
-
-	allErrs = append(allErrs, alivalidation.ValidateBackupBucketConfig(backupBucketConfig, providerConfigfldPath)...)
 
 	return allErrs
 }
@@ -83,80 +83,29 @@ func (s *seedValidator) validateCreate(seed *core.Seed) field.ErrorList {
 // are correctly managed. It enforces constraints such as preventing the unlocking of retention policies,
 // disabling immutability once locked, and reduction of retention periods when policies are locked.
 func (s *seedValidator) validateUpdate(oldSeed, newSeed *core.Seed) field.ErrorList {
-	var (
-		allErrs               = field.ErrorList{}
-		providerConfigfldPath = field.NewPath("spec", "backup", "providerConfig")
-	)
-
 	if oldSeed.Spec.Backup == nil || oldSeed.Spec.Backup.ProviderConfig == nil {
 		return s.validateCreate(newSeed)
 	}
 
-	oldBackupBucketConfig, err := s.extractBackupBucketConfig(oldSeed, s.lenientDecoder)
-	if err != nil {
-		allErrs = append(allErrs, field.Invalid(providerConfigfldPath, oldSeed.Spec.Backup.ProviderConfig, fmt.Errorf("failed to decode old provider config: %v", err).Error()))
-		return allErrs
-	}
-
-	newBackupBucketConfig, err := s.extractBackupBucketConfig(newSeed, s.decoder)
-	if err != nil {
-		allErrs = append(allErrs, field.Invalid(providerConfigfldPath, newSeed.Spec.Backup.ProviderConfig, fmt.Errorf("failed to decode new provider config: %v", err).Error()))
-		return allErrs
-	}
-
-	allErrs = append(allErrs, alivalidation.ValidateBackupBucketConfig(newBackupBucketConfig, providerConfigfldPath)...)
-	allErrs = append(allErrs, s.validateImmutabilityUpdate(oldBackupBucketConfig, newBackupBucketConfig, providerConfigfldPath)...)
-
-	return allErrs
-}
-
-// extractBackupBucketConfig extracts BackupBucketConfig from the Seed.
-func (s *seedValidator) extractBackupBucketConfig(seed *core.Seed, decoder runtime.Decoder) (*apisali.BackupBucketConfig, error) {
-	if seed.Spec.Backup != nil && seed.Spec.Backup.ProviderConfig != nil {
-		config, err := DecodeBackupBucketConfig(decoder, seed.Spec.Backup.ProviderConfig)
-		if err != nil {
-			return nil, err
-		}
-		return config, nil
-	}
-
-	return nil, nil
-}
-
-// validateImmutability validates immutability constraints.
-func (s *seedValidator) validateImmutabilityUpdate(oldConfig, newConfig *apisali.BackupBucketConfig, fldPath *field.Path) field.ErrorList {
 	var (
-		allErrs          = field.ErrorList{}
-		immutabilityPath = fldPath.Child("immutability")
+		allErrs            = field.ErrorList{}
+		backupPath         = field.NewPath("spec", "backup")
+		providerConfigPath = backupPath.Child("providerConfig")
 	)
 
-	// Note: Right now, immutability can be disabled.
-	// TODO: @ishan16696 to remove these conditions "newConfig == nil || newConfig.Immutability == nil" to not allow disablement of immutability settings.
-	if oldConfig == nil || oldConfig.Immutability == nil || newConfig == nil || newConfig.Immutability == nil {
-		return allErrs
+	oldBackupBucketConfig, err := DecodeBackupBucketConfig(s.lenientDecoder, oldSeed.Spec.Backup.ProviderConfig)
+	if err != nil {
+		return append(allErrs, field.InternalError(providerConfigPath, fmt.Errorf("failed to decode old provider config: %w", err)))
 	}
 
-	// TODO: @ishan16696 uncomment this piece of code, so once disablement of the immutability settings on bucket is not allowed.
-	/*
-		if newConfig == nil || newConfig.Immutability == nil || *newConfig.Immutability == (apisaws.ImmutableConfig{}) {
-			allErrs = append(allErrs, field.Invalid(immutabilityPath, newConfig, "immutability cannot be disabled"))
-			return allErrs
-		}
-	*/
-
-	if oldConfig.Immutability.Locked && !newConfig.Immutability.Locked {
-		allErrs = append(allErrs, field.Forbidden(immutabilityPath.Child("locked"), "immutable retention policy lock cannot be unlocked once it is locked"))
+	newBackupBucketConfig, err := DecodeBackupBucketConfig(s.decoder, newSeed.Spec.Backup.ProviderConfig)
+	if err != nil {
+		return append(allErrs, field.InternalError(providerConfigPath, fmt.Errorf("failed to decode new provider config: %w", err)))
 	}
 
-	if newConfig.Immutability.RetentionPeriod < oldConfig.Immutability.RetentionPeriod {
-		allErrs = append(allErrs, field.Forbidden(
-			immutabilityPath.Child("retentionPeriod"),
-			fmt.Sprintf("reducing the retention period from %v to %v days is prohibited",
-				oldConfig.Immutability.RetentionPeriod,
-				newConfig.Immutability.RetentionPeriod,
-			),
-		))
-	}
+	allErrs = append(allErrs, alivalidation.ValidateBackupBucketConfig(newBackupBucketConfig, providerConfigPath)...)
+	allErrs = append(allErrs, alivalidation.ValidateBackupBucketConfigUpdate(oldBackupBucketConfig, newBackupBucketConfig, providerConfigPath)...)
+	allErrs = append(allErrs, alivalidation.ValidateBackupBucketCredentialsRef(newSeed.Spec.Backup.CredentialsRef, backupPath.Child("credentialsRef"))...)
 
 	return allErrs
 }

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -18,7 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	alicloudclient "github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud/client"
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
 	alicloudvalidation "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/validation"
 )
@@ -34,22 +33,15 @@ var (
 
 // NewShootValidator returns a new instance of a shoot validator.
 func NewShootValidator(mgr manager.Manager) extensionswebhook.Validator {
-	alicloudclientFactory := alicloudclient.NewClientFactory()
 	return &shoot{
-		client:                mgr.GetClient(),
-		apiReader:             mgr.GetAPIReader(),
-		decoder:               serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
-		lenientDecoder:        serializer.NewCodecFactory(mgr.GetScheme()).UniversalDecoder(),
-		alicloudClientFactory: alicloudclientFactory,
+		decoder:        serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
+		lenientDecoder: serializer.NewCodecFactory(mgr.GetScheme()).UniversalDecoder(),
 	}
 }
 
 type shoot struct {
-	client                client.Client
-	apiReader             client.Reader
-	decoder               runtime.Decoder
-	lenientDecoder        runtime.Decoder
-	alicloudClientFactory alicloudclient.ClientFactory
+	decoder        runtime.Decoder
+	lenientDecoder runtime.Decoder
 }
 
 // Validate validates the given shoot object.

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -7,6 +7,7 @@ package validator
 import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/security"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +41,7 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 			NewSecretBindingValidator(mgr):          {{Obj: &core.SecretBinding{}}},
 			NewCredentialsBindingValidator(mgr):     {{Obj: &security.CredentialsBinding{}}},
 			NewSeedValidator(mgr):                   {{Obj: &core.Seed{}}},
+			NewBackupBucketValidator(mgr):           {{Obj: &gardencorev1beta1.BackupBucket{}}},
 		},
 		Target: extensionswebhook.TargetSeed,
 		ObjectSelector: &metav1.LabelSelector{

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -7,7 +7,6 @@ package validator
 import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/security"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,7 +40,7 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 			NewSecretBindingValidator(mgr):          {{Obj: &core.SecretBinding{}}},
 			NewCredentialsBindingValidator(mgr):     {{Obj: &security.CredentialsBinding{}}},
 			NewSeedValidator(mgr):                   {{Obj: &core.Seed{}}},
-			NewBackupBucketValidator(mgr):           {{Obj: &gardencorev1beta1.BackupBucket{}}},
+			NewBackupBucketValidator(mgr):           {{Obj: &core.BackupBucket{}}},
 		},
 		Target: extensionswebhook.TargetSeed,
 		ObjectSelector: &metav1.LabelSelector{

--- a/pkg/apis/alicloud/validation/backupbucket.go
+++ b/pkg/apis/alicloud/validation/backupbucket.go
@@ -5,6 +5,10 @@
 package validation
 
 import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	apisali "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
@@ -26,6 +30,66 @@ func ValidateBackupBucketConfig(backupBucketConfig *apisali.BackupBucketConfig, 
 	// Alicloud OSS immutability period can only be set in days and can't be less than 1 day and must be a positive integer.
 	if backupBucketConfig.Immutability.RetentionPeriod < 1 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("immutability", "retentionPeriod"), backupBucketConfig.Immutability.RetentionPeriod, "can only be set in days, hence it can't be less than 1 day"))
+	}
+
+	return allErrs
+}
+
+// ValidateBackupBucketConfigUpdate validates updates to the BackupBucketConfig.
+func ValidateBackupBucketConfigUpdate(oldConfig, newConfig *apisali.BackupBucketConfig, fldPath *field.Path) field.ErrorList {
+	var (
+		allErrs          = field.ErrorList{}
+		immutabilityPath = fldPath.Child("immutability")
+	)
+
+	// Note: Right now, immutability can be disabled.
+	// TODO: @ishan16696 to remove these conditions "newConfig == nil || newConfig.Immutability == nil" to not allow disablement of immutability settings.
+	if oldConfig == nil || oldConfig.Immutability == nil || newConfig == nil || newConfig.Immutability == nil {
+		return allErrs
+	}
+
+	// TODO: @ishan16696 uncomment this piece of code, so once disablement of the immutability settings on bucket is not allowed.
+	/*
+		if newConfig == nil || newConfig.Immutability == nil || *newConfig.Immutability == (apisaws.ImmutableConfig{}) {
+			allErrs = append(allErrs, field.Invalid(immutabilityPath, newConfig, "immutability cannot be disabled"))
+			return allErrs
+		}
+	*/
+
+	if oldConfig.Immutability.Locked && !newConfig.Immutability.Locked {
+		allErrs = append(allErrs, field.Forbidden(immutabilityPath.Child("locked"), "immutable retention policy lock cannot be unlocked once it is locked"))
+	}
+
+	if newConfig.Immutability.RetentionPeriod < oldConfig.Immutability.RetentionPeriod {
+		allErrs = append(allErrs, field.Forbidden(
+			immutabilityPath.Child("retentionPeriod"),
+			fmt.Sprintf("reducing the retention period from %v to %v days is prohibited",
+				oldConfig.Immutability.RetentionPeriod,
+				newConfig.Immutability.RetentionPeriod,
+			),
+		))
+	}
+
+	return allErrs
+}
+
+// ValidateBackupBucketCredentialsRef validates credentialsRef is set to supported kind of credentials.
+func ValidateBackupBucketCredentialsRef(credentialsRef *corev1.ObjectReference, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if credentialsRef == nil {
+		return append(allErrs, field.Required(fldPath, "must be set"))
+	}
+
+	var (
+		secretGVK = corev1.SchemeGroupVersion.WithKind("Secret")
+
+		allowedGVKs = sets.New(secretGVK)
+		validGVKs   = []string{secretGVK.String()}
+	)
+
+	if !allowedGVKs.Has(credentialsRef.GroupVersionKind()) {
+		allErrs = append(allErrs, field.NotSupported(fldPath, credentialsRef.String(), validGVKs))
 	}
 
 	return allErrs

--- a/pkg/apis/alicloud/validation/backupbucket_test.go
+++ b/pkg/apis/alicloud/validation/backupbucket_test.go
@@ -7,67 +7,223 @@ package validation
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	apisali "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
 )
 
-var _ = Describe("ValidateBackupBucketConfig", func() {
+var _ = Describe("BackupBucket", func() {
 	var fldPath *field.Path
 
 	BeforeEach(func() {
 		fldPath = field.NewPath("spec")
 	})
 
-	DescribeTable("validation cases",
-		func(config *apisali.BackupBucketConfig, wantErr bool, errMsg string) {
-			errs := ValidateBackupBucketConfig(config, fldPath)
-			if wantErr {
-				Expect(errs).NotTo(BeEmpty())
-				Expect(errs[0].Error()).To(ContainSubstring(errMsg))
-			} else {
-				Expect(errs).To(BeEmpty())
+	Describe("ValidateBackupBucketConfig", func() {
+		DescribeTable("validation cases",
+			func(config *apisali.BackupBucketConfig, wantErr bool, errMsg string) {
+				errs := ValidateBackupBucketConfig(config, fldPath)
+				if wantErr {
+					Expect(errs).NotTo(BeEmpty())
+					Expect(errs[0].Error()).To(ContainSubstring(errMsg))
+				} else {
+					Expect(errs).To(BeEmpty())
+				}
+			},
+			Entry("valid config",
+				&apisali.BackupBucketConfig{
+					Immutability: &apisali.ImmutableConfig{
+						RetentionType:   "bucket",
+						RetentionPeriod: 1,
+						Locked:          false,
+					},
+				}, false, ""),
+			Entry("nil config",
+				&apisali.BackupBucketConfig{
+					Immutability: nil,
+				}, false, ""),
+			Entry("missing retentionType",
+				&apisali.BackupBucketConfig{
+					Immutability: &apisali.ImmutableConfig{
+						RetentionType:   "",
+						RetentionPeriod: 1,
+						Locked:          false,
+					},
+				}, true, "must be 'bucket'"),
+			Entry("invalid retentionType",
+				&apisali.BackupBucketConfig{
+					Immutability: &apisali.ImmutableConfig{
+						RetentionType:   "invalid",
+						RetentionPeriod: 1,
+						Locked:          false,
+					},
+				}, true, "must be 'bucket'"),
+			Entry("invalid retentionPeriod",
+				&apisali.BackupBucketConfig{
+					Immutability: &apisali.ImmutableConfig{
+						RetentionType:   "bucket",
+						RetentionPeriod: 0,
+						Locked:          false,
+					},
+				}, true, "can't be less than 1 day"),
+			Entry("negative retentionPeriod",
+				&apisali.BackupBucketConfig{
+					Immutability: &apisali.ImmutableConfig{
+						RetentionType:   "bucket",
+						RetentionPeriod: -1,
+						Locked:          false,
+					},
+				}, true, "can't be less than 1 day"),
+		)
+	})
+
+	Describe("ValidateBackupBucketConfigUpdate", func() {
+		DescribeTable("Valid update scenarios",
+			func(oldConfig, newConfig apisali.BackupBucketConfig) {
+				Expect(ValidateBackupBucketConfigUpdate(&oldConfig, &newConfig, fldPath).ToAggregate()).NotTo(HaveOccurred())
+			},
+			Entry("Immutable settings unchanged",
+				generateBackupBucketConfig("bucket", 1, false, true),
+				generateBackupBucketConfig("bucket", 1, false, true),
+			),
+			Entry("Retention period increased while unlocked",
+				generateBackupBucketConfig("bucket", 1, false, true),
+				generateBackupBucketConfig("bucket", 2, false, true),
+			),
+			Entry("Retention period increased while locked",
+				generateBackupBucketConfig("bucket", 1, true, true),
+				generateBackupBucketConfig("bucket", 2, true, true),
+			),
+			Entry("Adding immutability to an existing bucket",
+				generateBackupBucketConfig("", 0, false, false),
+				generateBackupBucketConfig("bucket", 1, false, true),
+			),
+			Entry("Adding immutability with locked set to true",
+				generateBackupBucketConfig("", 0, false, false),
+				generateBackupBucketConfig("bucket", 1, true, true),
+			),
+			Entry("Retention period exactly at minimum 1 day",
+				generateBackupBucketConfig("bucket", 1, false, true),
+				generateBackupBucketConfig("bucket", 1, false, true),
+			),
+			Entry("Transitioning from locked=false to locked=true",
+				generateBackupBucketConfig("bucket", 1, false, true),
+				generateBackupBucketConfig("bucket", 1, true, true),
+			),
+			// To be removed later
+			Entry("Disabling immutability when not locked",
+				generateBackupBucketConfig("bucket", 1, false, true),
+				generateBackupBucketConfig("", 0, false, false),
+			),
+			Entry("Backup not configured",
+				generateBackupBucketConfig("", 0, false, false),
+				generateBackupBucketConfig("", 0, false, false),
+			),
+		)
+
+		DescribeTable("Invalid update scenarios",
+			func(oldConfig, newConfig apisali.BackupBucketConfig, expectedError string) {
+				err := ValidateBackupBucketConfigUpdate(&oldConfig, &newConfig, fldPath).ToAggregate()
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring(expectedError)))
+			},
+			// TODO: @ishan16696 as currently disabling is allowed
+			// Entry("Disabling immutable settings is not allowed if locked",
+			// generateBackupBucketConfig("bucket", 2, true, true),
+			// generateBackupBucketConfig("", 0, false, false),
+			// 	"immutability cannot be disabled once it is locked",
+			// ),
+			Entry("Unlocking a locked retention policy is not allowed",
+				generateBackupBucketConfig("bucket", 1, true, true),
+				generateBackupBucketConfig("bucket", 1, false, true),
+				"immutable retention policy lock cannot be unlocked once it is locked",
+			),
+			Entry("Reducing retention period is not allowed when unlocked",
+				generateBackupBucketConfig("bucket", 2, false, true),
+				generateBackupBucketConfig("bucket", 1, false, true),
+				"reducing the retention period from",
+			),
+			Entry("Reducing retention period is not allowed when locked",
+				generateBackupBucketConfig("bucket", 2, true, true),
+				generateBackupBucketConfig("bucket", 1, true, true),
+				"reducing the retention period from",
+			),
+		)
+	})
+
+	Describe("ValidateBackupBucketCredentialsRef", func() {
+		BeforeEach(func() {
+			fldPath = field.NewPath("spec", "credentialsRef")
+		})
+
+		It("should forbid nil credentialsRef", func() {
+			errs := ValidateBackupBucketCredentialsRef(nil, fldPath)
+			Expect(errs).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.credentialsRef"),
+				"Detail": Equal("must be set"),
+			}))))
+		})
+
+		It("should forbid v1.ConfigMap credentials", func() {
+			credsRef := &corev1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+				Name:       "my-creds",
+				Namespace:  "my-namespace",
 			}
-		},
-		Entry("valid config",
-			&apisali.BackupBucketConfig{
-				Immutability: &apisali.ImmutableConfig{
-					RetentionType:   "bucket",
-					RetentionPeriod: 1,
-					Locked:          false,
-				},
-			}, false, ""),
-		Entry("missing retentionType",
-			&apisali.BackupBucketConfig{
-				Immutability: &apisali.ImmutableConfig{
-					RetentionType:   "",
-					RetentionPeriod: 1,
-					Locked:          false,
-				},
-			}, true, "must be 'bucket'"),
-		Entry("invalid retentionType",
-			&apisali.BackupBucketConfig{
-				Immutability: &apisali.ImmutableConfig{
-					RetentionType:   "invalid",
-					RetentionPeriod: 1,
-					Locked:          false,
-				},
-			}, true, "must be 'bucket'"),
-		Entry("invalid retentionPeriod",
-			&apisali.BackupBucketConfig{
-				Immutability: &apisali.ImmutableConfig{
-					RetentionType:   "bucket",
-					RetentionPeriod: 0,
-					Locked:          false,
-				},
-			}, true, "can't be less than 1 day"),
-		Entry("negative retentionPeriod",
-			&apisali.BackupBucketConfig{
-				Immutability: &apisali.ImmutableConfig{
-					RetentionType:   "bucket",
-					RetentionPeriod: -1,
-					Locked:          false,
-				},
-			}, true, "can't be less than 1 day"),
-	)
+			errs := ValidateBackupBucketCredentialsRef(credsRef, fldPath)
+			Expect(errs).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeNotSupported),
+				"Field":  Equal("spec.credentialsRef"),
+				"Detail": Equal("supported values: \"/v1, Kind=Secret\""),
+			}))))
+		})
+
+		It("should forbid security.gardener.cloud/v1alpha1.WorkloadIdentity credentials", func() {
+			credsRef := &corev1.ObjectReference{
+				APIVersion: "security.gardener.cloud/v1alpha1",
+				Kind:       "WorkloadIdentity",
+				Name:       "my-creds",
+				Namespace:  "my-namespace",
+			}
+			errs := ValidateBackupBucketCredentialsRef(credsRef, fldPath)
+			Expect(errs).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeNotSupported),
+				"Field":  Equal("spec.credentialsRef"),
+				"Detail": Equal("supported values: \"/v1, Kind=Secret\""),
+			}))))
+		})
+
+		It("should allow v1.Secret credentials", func() {
+			credsRef := &corev1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "Secret",
+				Name:       "my-creds",
+				Namespace:  "my-namespace",
+			}
+			errs := ValidateBackupBucketCredentialsRef(credsRef, fldPath)
+			Expect(errs).To(BeEmpty())
+		})
+	})
 })
+
+// Helper function to generate Seed objects
+func generateBackupBucketConfig(retentionType string, retentionPeriod int, locked bool, isImmutableConfigured bool) apisali.BackupBucketConfig {
+	if !isImmutableConfigured {
+		return apisali.BackupBucketConfig{}
+	}
+
+	config := apisali.BackupBucketConfig{Immutability: &apisali.ImmutableConfig{}}
+
+	if retentionType != "" {
+		config.Immutability.RetentionType = apisali.RetentionType(retentionType)
+	}
+
+	config.Immutability.RetentionPeriod = retentionPeriod
+	config.Immutability.Locked = locked
+
+	return config
+}

--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -27,21 +27,19 @@ import (
 )
 
 type delegateFactory struct {
-	gardenReader client.Reader
-	seedClient   client.Client
-	decoder      runtime.Decoder
-	restConfig   *rest.Config
-	scheme       *runtime.Scheme
+	seedClient client.Client
+	decoder    runtime.Decoder
+	restConfig *rest.Config
+	scheme     *runtime.Scheme
 }
 
 // NewActuator creates a new Actuator that updates the status of the handled WorkerPoolConfigs.
 func NewActuator(mgr manager.Manager, gardenCluster cluster.Cluster) worker.Actuator {
 	workerDelegate := &delegateFactory{
-		gardenReader: gardenCluster.GetAPIReader(),
-		seedClient:   mgr.GetClient(),
-		decoder:      serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
-		restConfig:   mgr.GetConfig(),
-		scheme:       mgr.GetScheme(),
+		seedClient: mgr.GetClient(),
+		decoder:    serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
+		restConfig: mgr.GetConfig(),
+		scheme:     mgr.GetScheme(),
 	}
 
 	return genericactuator.NewActuator(


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
Enable validation of `seed.spec.backup.credentialsRef` and `backupBucket.spec.credentialsRef`

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
cc @dimityrmirchev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Admission controller now allows `seed.spec.backup.credentialsRef` and `backupBucket.spec.credentialsRef` to use credentials of only `v1.Secret`.
```
