### PR TITLE
Avoid duplicate creation of Natgateway

### DIFF
--- a/pkg/controller/infrastructure/infraflow/aliclient/mock/mocks.go
+++ b/pkg/controller/infrastructure/infraflow/aliclient/mock/mocks.go
@@ -541,6 +541,21 @@ func (mr *MockActorMockRecorder) ListNatGateways(ctx, ids any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNatGateways", reflect.TypeOf((*MockActor)(nil).ListNatGateways), ctx, ids)
 }
 
+// ListNatGatewaysByVSwitchInVPC mocks base method.
+func (m *MockActor) ListNatGatewaysByVSwitchInVPC(ctx context.Context, vpcId string, vswitchIds []string) ([]*aliclient.NatGateway, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNatGatewaysByVSwitchInVPC", ctx, vpcId, vswitchIds)
+	ret0, _ := ret[0].([]*aliclient.NatGateway)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNatGatewaysByVSwitchInVPC indicates an expected call of ListNatGatewaysByVSwitchInVPC.
+func (mr *MockActorMockRecorder) ListNatGatewaysByVSwitchInVPC(ctx, vpcId, vswitchIds any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNatGatewaysByVSwitchInVPC", reflect.TypeOf((*MockActor)(nil).ListNatGatewaysByVSwitchInVPC), ctx, vpcId, vswitchIds)
+}
+
 // ListSecurityGroups mocks base method.
 func (m *MockActor) ListSecurityGroups(ctx context.Context, ids []string) ([]*aliclient.SecurityGroup, error) {
 	m.ctrl.T.Helper()

--- a/pkg/controller/infrastructure/infraflow/delete.go
+++ b/pkg/controller/infrastructure/infraflow/delete.go
@@ -32,7 +32,7 @@ func (c *FlowContext) buildDeleteGraph() *flow.Graph {
 
 	deleteZones := c.AddTask(g, "delete vswitch",
 		c.deleteZones,
-		Timeout(defaultTimeout))
+		Timeout(defaultLongTimeout))
 
 	deleteSecurityGroup := c.AddTask(g, "delete security group",
 		c.deleteSecurityGroup,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
Since Alibaba asynchronously creates Natgateway, in some extreme cases, it may lead to the duplicate creation of Natgateway. This PR optimizes for such situations to avoid duplicate creation of Natgateway.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Avoid duplicate creation of Natgateway
```
