### PR TITLE
[GEP-28] Use technicalID from `Cluster` instead of `Worker.Namespace`

### DIFF
--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -69,6 +69,7 @@ var _ = Describe("Machines", func() {
 		Describe("#GenerateMachineDeployments, #DeployMachineClasses", func() {
 			var (
 				namespace        string
+				technicalID      string
 				cloudProfileName string
 
 				region string
@@ -163,7 +164,8 @@ var _ = Describe("Machines", func() {
 			)
 
 			BeforeEach(func() {
-				namespace = "shoot--foobar--alicloud"
+				namespace = "control-plane-namespace"
+				technicalID = "shoot--foobar--alicloud"
 				cloudProfileName = "alicloud"
 
 				region = "china"
@@ -307,6 +309,9 @@ var _ = Describe("Machines", func() {
 							Kubernetes: gardencorev1beta1.Kubernetes{
 								Version: shootVersion,
 							},
+						},
+						Status: gardencorev1beta1.ShootStatus{
+							TechnicalID: technicalID,
 						},
 					},
 				}
@@ -580,8 +585,8 @@ var _ = Describe("Machines", func() {
 						"internetMaxBandwidthOut": internetMaxBandwidthOut,
 						"spotStrategy":            spotStrategy,
 						"tags": map[string]string{
-							fmt.Sprintf("kubernetes.io/cluster/%s", namespace):     "1",
-							fmt.Sprintf("kubernetes.io/role/worker/%s", namespace): "1",
+							fmt.Sprintf("kubernetes.io/cluster/%s", technicalID):     "1",
+							fmt.Sprintf("kubernetes.io/role/worker/%s", technicalID): "1",
 						},
 						"secret": map[string]interface{}{
 							"userData": string(userData),
@@ -603,7 +608,7 @@ var _ = Describe("Machines", func() {
 							"deleteWithInstance": true,
 							"category":           dataVolume1Type,
 							"encrypted":          dataVolume1Encrypted,
-							"description":        namespace + "-datavol-" + dataVolume1Name,
+							"description":        technicalID + "-datavol-" + dataVolume1Name,
 						},
 						{
 							"name":               dataVolume2Name,
@@ -611,7 +616,7 @@ var _ = Describe("Machines", func() {
 							"deleteWithInstance": true,
 							"category":           dataVolume2Type,
 							"encrypted":          dataVolume2Encrypted,
-							"description":        namespace + "-datavol-" + dataVolume2Name,
+							"description":        technicalID + "-datavol-" + dataVolume2Name,
 						},
 					}
 
@@ -657,14 +662,14 @@ var _ = Describe("Machines", func() {
 							"imageID", encryptedImageID,
 						)
 
-						machineClassNamePool1Zone1 = fmt.Sprintf("%s-%s-%s", namespace, namePool1, zone1)
-						machineClassNamePool1Zone2 = fmt.Sprintf("%s-%s-%s", namespace, namePool1, zone2)
-						machineClassNamePool2Zone1 = fmt.Sprintf("%s-%s-%s", namespace, namePool2, zone1)
-						machineClassNamePool2Zone2 = fmt.Sprintf("%s-%s-%s", namespace, namePool2, zone2)
-						machineClassNamePool3Zone1 = fmt.Sprintf("%s-%s-%s", namespace, namePool3, zone1)
-						machineClassNamePool3Zone2 = fmt.Sprintf("%s-%s-%s", namespace, namePool3, zone2)
-						machineClassNamePool4Zone1 = fmt.Sprintf("%s-%s-%s", namespace, namePool4, zone1)
-						machineClassNamePool4Zone2 = fmt.Sprintf("%s-%s-%s", namespace, namePool4, zone2)
+						machineClassNamePool1Zone1 = fmt.Sprintf("%s-%s-%s", technicalID, namePool1, zone1)
+						machineClassNamePool1Zone2 = fmt.Sprintf("%s-%s-%s", technicalID, namePool1, zone2)
+						machineClassNamePool2Zone1 = fmt.Sprintf("%s-%s-%s", technicalID, namePool2, zone1)
+						machineClassNamePool2Zone2 = fmt.Sprintf("%s-%s-%s", technicalID, namePool2, zone2)
+						machineClassNamePool3Zone1 = fmt.Sprintf("%s-%s-%s", technicalID, namePool3, zone1)
+						machineClassNamePool3Zone2 = fmt.Sprintf("%s-%s-%s", technicalID, namePool3, zone2)
+						machineClassNamePool4Zone1 = fmt.Sprintf("%s-%s-%s", technicalID, namePool4, zone1)
+						machineClassNamePool4Zone2 = fmt.Sprintf("%s-%s-%s", technicalID, namePool4, zone2)
 
 						machineClassWithHashPool1Zone1 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone1, workerPoolHash1)
 						machineClassWithHashPool1Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone2, workerPoolHash1)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:

To support self-hosted shoots with managed infrastructure, the `Worker` controller/delegate needs to use the technical ID from `Cluster.shoot.status.technicalID` for prefixing the names of machine-related objects. The `Worker` namespace is `kube-system` for self-hosted shoots.
This PR is similar to [gardener/gardener@`22f4295` (#13485)](https://github.com/gardener/gardener/pull/13485/commits/22f429593ba87fb08c3a37fb0ce3c1da914c0f21).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/pull/13485

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `Worker` controller is prepared to support self-hosted shoot clusters with managed infrastructure (see [GEP-28](https://github.com/gardener/gardener/blob/master/docs/proposals/28-self-hosted-shoot-clusters.md#managed-infrastructure)).
```
