### PR TITLE
out put error info during infra config validate

### DIFF
--- a/pkg/controller/infrastructure/configvalidator.go
+++ b/pkg/controller/infrastructure/configvalidator.go
@@ -105,13 +105,18 @@ func (c *configValidator) validateVPC(ctx context.Context, actor aliclient.Actor
 		return allErrs
 	}
 	if checkNatgatewayExists {
-		gw, err := actor.FindNatGatewayByVPC(ctx, vpcID)
+		gw_list, err := actor.ListNatGatewaysByVPC(ctx, vpcID)
 		if err != nil {
 			allErrs = append(allErrs, field.InternalError(fldPath, fmt.Errorf("validateVPC FindNatGatewayByVPC %s failed: %+v", vpcID, err)))
 			return allErrs
 		}
-		if gw == nil {
+		if len(gw_list) == 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath, vpcID, "no user natgateway found"))
+			return allErrs
+		}
+		if len(gw_list) > 1 {
+			allErrs = append(allErrs, field.Invalid(fldPath, vpcID, "more than one natgateway found"))
+			return allErrs
 		}
 	}
 

--- a/pkg/controller/infrastructure/infraflow/aliclient/actor.go
+++ b/pkg/controller/infrastructure/infraflow/aliclient/actor.go
@@ -46,6 +46,7 @@ type Actor interface {
 	FindNatGatewayByVPC(ctx context.Context, vpcId string) (*NatGateway, error)
 	DeleteNatGateway(ctx context.Context, id string) error
 	ListNatGatewaysByVSwitchInVPC(ctx context.Context, vpcId string, vswitchIds []string) ([]*NatGateway, error)
+	ListNatGatewaysByVPC(ctx context.Context, vpcId string) ([]*NatGateway, error)
 
 	CreateEIP(ctx context.Context, eip *EIP) (*EIP, error)
 	GetEIP(ctx context.Context, id string) (*EIP, error)
@@ -725,6 +726,18 @@ func (c *actor) getNatGateway(id string) (*NatGateway, error) {
 
 func (c *actor) ListNatGateways(_ context.Context, ids []string) ([]*NatGateway, error) {
 	return listByIds(c.getNatGateway, ids)
+}
+
+func (c *actor) ListNatGatewaysByVPC(_ context.Context, vpcId string) ([]*NatGateway, error) {
+	var ngwList []*NatGateway
+	req := vpc.CreateDescribeNatGatewaysRequest()
+	req.VpcId = vpcId
+
+	resp, err := c.describeNatGateway(req)
+	if err != nil {
+		return ngwList, err
+	}
+	return resp, nil
 }
 
 func (c *actor) ListNatGatewaysByVSwitchInVPC(_ context.Context, vpcId string, vswitchIds []string) ([]*NatGateway, error) {

--- a/pkg/controller/infrastructure/infraflow/aliclient/mock/mocks.go
+++ b/pkg/controller/infrastructure/infraflow/aliclient/mock/mocks.go
@@ -541,6 +541,21 @@ func (mr *MockActorMockRecorder) ListNatGateways(ctx, ids any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNatGateways", reflect.TypeOf((*MockActor)(nil).ListNatGateways), ctx, ids)
 }
 
+// ListNatGatewaysByVPC mocks base method.
+func (m *MockActor) ListNatGatewaysByVPC(ctx context.Context, vpcId string) ([]*aliclient.NatGateway, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNatGatewaysByVPC", ctx, vpcId)
+	ret0, _ := ret[0].([]*aliclient.NatGateway)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNatGatewaysByVPC indicates an expected call of ListNatGatewaysByVPC.
+func (mr *MockActorMockRecorder) ListNatGatewaysByVPC(ctx, vpcId any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNatGatewaysByVPC", reflect.TypeOf((*MockActor)(nil).ListNatGatewaysByVPC), ctx, vpcId)
+}
+
 // ListNatGatewaysByVSwitchInVPC mocks base method.
 func (m *MockActor) ListNatGatewaysByVSwitchInVPC(ctx context.Context, vpcId string, vswitchIds []string) ([]*aliclient.NatGateway, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug
/platform alicloud

**What this PR does / why we need it**:
out put error info during infra config validate

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-alicloud/issues/861

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
out put error info during infra config validate
```
