### PR TITLE
Allow volume expansion for the `gardener.cloud-fast` StorageClass

### DIFF
--- a/charts/gardener-extension-provider-alicloud/templates/storageclass.yaml
+++ b/charts/gardener-extension-provider-alicloud/templates/storageclass.yaml
@@ -16,6 +16,7 @@ parameters:
 {{- else }}
 provisioner: diskplugin.csi.alibabacloud.com
 volumeBindingMode: {{ .Values.config.etcd.storage.volumeBindingMode }}
+allowVolumeExpansion: true
 parameters:
   csi.storage.k8s.io/fstype: ext4
   type: cloud_essd


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:
@Kostov6 discovered that among all StorageClasses we deploy to Seeds and Shoots across the providers, the `gardener.cloud-fast` StorageClass for alicloud is the only one that supports resize but does not declare it in the StorageClass spec via the `allowVolumeExpansion` field.

This PR sets `allowVolumeExpansion=true` for the `gardener.cloud-fast` StorageClass.

**Which issue(s) this PR fixes**:
N/A
Indirectly part of the pvc-autoscaler story

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `gardener.cloud-fast` StorageClass is now updated with `allowVolumeExpansion=true` to correctly reflect that it supports volume resize when the Gardener volume provider is CSI (`gardener.seed.volumeProvider=csi`).
```
