### PR TITLE
[release-v1.68] Bump `github.com/gardener/gardener` from `v1.134.0` to `v1.134.2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aliyun/aliyun-oss-go-sdk v2.1.8+incompatible
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/gardener/etcd-druid/api v0.34.0
-	github.com/gardener/gardener v1.134.0
+	github.com/gardener/gardener v1.134.2
 	github.com/gardener/machine-controller-manager v0.60.2
 	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.27.1

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/gardener/cert-management v0.19.0 h1:BNumdw748Pg9798NzxHmmpKuXFRLHSPuv
 github.com/gardener/cert-management v0.19.0/go.mod h1:u5OKwiDyUdCuW9vhDV92ozCVkynXUBrYCMHr4rVNiCY=
 github.com/gardener/etcd-druid/api v0.34.0 h1:GNeKNN/KS9Iy1su0N695/wq/VtNW9ekeRjihAza5xbc=
 github.com/gardener/etcd-druid/api v0.34.0/go.mod h1:SvgJtzYbrtBMPRL+AkRV5tXV2LjbSLCSBFu3cC6XjJs=
-github.com/gardener/gardener v1.134.0 h1:qmbDZWwPtwlbUsoIuDxx7+CqS8nmY/0ID+fa3K9zLlg=
-github.com/gardener/gardener v1.134.0/go.mod h1:Fk8RpMK3bhgc25mO/1FPeRDc9Mfxa2iOR8Ty+YeSlBE=
+github.com/gardener/gardener v1.134.2 h1:FXo//rR538EfkBsClK3pguiIeW7FtXf8Ci7TNZeXXOg=
+github.com/gardener/gardener v1.134.2/go.mod h1:Fk8RpMK3bhgc25mO/1FPeRDc9Mfxa2iOR8Ty+YeSlBE=
 github.com/gardener/machine-controller-manager v0.60.2 h1:lY6z67lDlwl9dQUEmlJbrmpxWK10o/rVRUu4JB7xK4U=
 github.com/gardener/machine-controller-manager v0.60.2/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind bug
/platform alicloud

**What this PR does / why we need it**:
This PR bumps the `gardener/gardener` dependency to `v1.134.2` to include a fix from the extensions library for a bug that caused the `BackupEntry` deletion to get stuck with the following error, if the deletion of the backups on the provider side took too long:
```
failed to remove finalizer from secret: Operation cannot be fulfilled on secrets \"entry-source-shoot--project--==shoot==--uid\": the object has been modified; please apply your changes to the latest version and try again
```
Refs:
- https://github.com/gardener/gardener/pull/13793
- https://github.com/gardener/gardener/pull/13775

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `github.com/gardener/gardener` dependency was bumped to `v1.134.2` to include a fix for an issue causing deletions of `extensions.BackupEntry` to be stuck due to conflicts while removing the finalizer from the `BackupEntry` Secret. This mostly affected the deletion of the source `BackupEntry` during the `restore` phase of control plane migration ([Release Notes](https://github.com/gardener/gardener/releases/tag/v1.134.2)).
```
