### PR TITLE
  Add custom route table per shoot for multi-cluster VPC support

### DIFF
--- a/pkg/alicloud/client/types.go
+++ b/pkg/alicloud/client/types.go
@@ -168,6 +168,12 @@ type VPC interface {
 	UnassociateEipAddress(request *vpc.UnassociateEipAddressRequest) (response *vpc.UnassociateEipAddressResponse, err error)
 	CreateSnatEntry(request *vpc.CreateSnatEntryRequest) (response *vpc.CreateSnatEntryResponse, err error)
 	DeleteSnatEntry(request *vpc.DeleteSnatEntryRequest) (response *vpc.DeleteSnatEntryResponse, err error)
+
+	CreateRouteTable(request *vpc.CreateRouteTableRequest) (response *vpc.CreateRouteTableResponse, err error)
+	DescribeRouteTableList(request *vpc.DescribeRouteTableListRequest) (response *vpc.DescribeRouteTableListResponse, err error)
+	DeleteRouteTable(request *vpc.DeleteRouteTableRequest) (response *vpc.DeleteRouteTableResponse, err error)
+	AssociateRouteTable(request *vpc.AssociateRouteTableRequest) (response *vpc.AssociateRouteTableResponse, err error)
+	UnassociateRouteTable(request *vpc.UnassociateRouteTableRequest) (response *vpc.UnassociateRouteTableResponse, err error)
 }
 
 // ramClient implements the RAM interface.

--- a/pkg/apis/alicloud/types_infrastructure.go
+++ b/pkg/apis/alicloud/types_infrastructure.go
@@ -49,6 +49,8 @@ type VPCStatus struct {
 	VSwitches []VSwitch
 	// SecurityGroups is a list of security groups.
 	SecurityGroups []SecurityGroup
+	// RouteTableID is the ID of the custom route table created for this shoot cluster.
+	RouteTableID string
 }
 
 // Purpose is a purpose of a subnet.

--- a/pkg/apis/alicloud/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/alicloud/v1alpha1/types_infrastructure.go
@@ -50,6 +50,9 @@ type VPCStatus struct {
 	VSwitches []VSwitch `json:"vswitches"`
 	// SecurityGroups is a list of security groups.
 	SecurityGroups []SecurityGroup `json:"securityGroups"`
+	// RouteTableID is the ID of the custom route table created for this shoot cluster.
+	// +optional
+	RouteTableID string `json:"routeTableID,omitempty"`
 }
 
 // Purpose is a purpose of a subnet.

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -286,6 +286,8 @@ type cloudConfig struct {
 
 		AccessKeyID     string `json:"accessKeyID"`
 		AccessKeySecret string `json:"accessKeySecret"`
+
+		RouteTableIDS string `json:"routeTableIDS,omitempty"`
 	}
 }
 
@@ -338,6 +340,11 @@ func (vp *valuesProvider) getCloudControllerManagerConfigFileContent(
 	cfg.Global.AccessKeyID = base64.StdEncoding.EncodeToString([]byte(credentials.AccessKeyID))
 	cfg.Global.AccessKeySecret = base64.StdEncoding.EncodeToString([]byte(credentials.AccessKeySecret))
 	cfg.Global.Region = cp.Spec.Region
+
+	// Set route table ID so the CCM uses this specific table instead of auto-discovering
+	if infraStatus.VPC.RouteTableID != "" {
+		cfg.Global.RouteTableIDS = infraStatus.VPC.RouteTableID
+	}
 
 	cfgJSON, err := json.Marshal(cfg)
 	if err != nil {

--- a/pkg/controller/infrastructure/flow_reconciler.go
+++ b/pkg/controller/infrastructure/flow_reconciler.go
@@ -272,6 +272,9 @@ func computeProviderStatusFromFlowState(config *aliapi.InfrastructureConfig, sta
 			ID:        vpcID,
 			VSwitches: vswitches,
 		}
+		if routeTableID := state.Data[infraflow.IdentifierRouteTable]; shared.IsValidValue(routeTableID) {
+			status.VPC.RouteTableID = routeTableID
+		}
 		if groupID := state.Data[infraflow.IdentifierNodesSecurityGroup]; shared.IsValidValue(groupID) {
 			status.VPC.SecurityGroups = []aliv1alpha1.SecurityGroup{
 				{

--- a/pkg/controller/infrastructure/infraflow/aliclient/actor.go
+++ b/pkg/controller/infrastructure/infraflow/aliclient/actor.go
@@ -74,6 +74,13 @@ type Actor interface {
 
 	AuthorizeSecurityGroupRule(ctx context.Context, sgId string, rule SecurityGroupRule) error
 	RevokeSecurityGroupRule(ctx context.Context, sgId, ruleId, direction string) error
+
+	CreateRouteTable(ctx context.Context, rt *RouteTable) (*RouteTable, error)
+	GetRouteTable(ctx context.Context, id string) (*RouteTable, error)
+	DeleteRouteTable(ctx context.Context, id string) error
+	FindRouteTablesByTags(ctx context.Context, tags Tags) ([]*RouteTable, error)
+	AssociateRouteTable(ctx context.Context, routeTableId, vswitchId string) error
+	UnassociateRouteTable(ctx context.Context, routeTableId, vswitchId string) error
 }
 
 type actor struct {
@@ -1348,6 +1355,127 @@ func (c *actor) fromVpc(item vpc.Vpc) (*VPC, error) {
 	vpc.Tags = tags
 
 	return vpc, nil
+}
+
+func (c *actor) CreateRouteTable(ctx context.Context, rt *RouteTable) (*RouteTable, error) {
+	req := vpc.CreateCreateRouteTableRequest()
+	req.VpcId = rt.VpcId
+	req.RouteTableName = rt.Name
+
+	resp, err := callApi(c.vpcClient.CreateRouteTable, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var created *RouteTable
+	err = wait.PollUntilContextCancel(ctx, 5*time.Second, false, func(_ context.Context) (bool, error) {
+		created, err = c.GetRouteTable(ctx, resp.RouteTableId)
+		if err != nil {
+			return false, err
+		}
+		if created == nil {
+			return false, nil
+		}
+		if *created.Status != "Available" {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return created, nil
+}
+
+func (c *actor) GetRouteTable(_ context.Context, id string) (*RouteTable, error) {
+	return c.getRouteTable(id)
+}
+
+func (c *actor) getRouteTable(id string) (*RouteTable, error) {
+	req := vpc.CreateDescribeRouteTableListRequest()
+	req.RouteTableId = id
+	resp, err := callApi(c.vpcClient.DescribeRouteTableList, req)
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.RouterTableList.RouterTableListType) == 0 {
+		return nil, nil
+	}
+	item := resp.RouterTableList.RouterTableListType[0]
+	rt := &RouteTable{
+		Name:         item.RouteTableName,
+		RouteTableId: item.RouteTableId,
+		VpcId:        item.VpcId,
+		Status:       &item.Status,
+	}
+	tags := Tags{}
+	for _, t := range item.Tags.Tag {
+		tags[t.Key] = t.Value
+	}
+	rt.Tags = tags
+	return rt, nil
+}
+
+func (c *actor) DeleteRouteTable(ctx context.Context, id string) error {
+	current, err := c.GetRouteTable(ctx, id)
+	if err != nil {
+		return err
+	}
+	if current == nil {
+		return nil
+	}
+	req := vpc.CreateDeleteRouteTableRequest()
+	req.RouteTableId = id
+	_, err = callApi(c.vpcClient.DeleteRouteTable, req)
+	if err != nil {
+		return err
+	}
+	err = wait.PollUntilContextCancel(ctx, 5*time.Second, false, func(_ context.Context) (bool, error) {
+		current, err := c.GetRouteTable(ctx, id)
+		if err != nil {
+			return false, err
+		}
+		if current == nil {
+			return true, nil
+		}
+		return false, nil
+	})
+	return err
+}
+
+func (c *actor) FindRouteTablesByTags(ctx context.Context, tags Tags) ([]*RouteTable, error) {
+	req := vpc.CreateListTagResourcesRequest()
+	req.ResourceType = "ROUTETABLE"
+
+	var reqTag []vpc.ListTagResourcesTag
+	for k, v := range tags {
+		reqTag = append(reqTag, vpc.ListTagResourcesTag{Key: k, Value: v})
+	}
+	req.Tag = &reqTag
+
+	idList, err := c.listVpcTagResources(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return listByIds(c.getRouteTable, idList)
+}
+
+func (c *actor) AssociateRouteTable(_ context.Context, routeTableId, vswitchId string) error {
+	req := vpc.CreateAssociateRouteTableRequest()
+	req.RouteTableId = routeTableId
+	req.VSwitchId = vswitchId
+	_, err := callApi(c.vpcClient.AssociateRouteTable, req)
+	return err
+}
+
+func (c *actor) UnassociateRouteTable(_ context.Context, routeTableId, vswitchId string) error {
+	req := vpc.CreateUnassociateRouteTableRequest()
+	req.RouteTableId = routeTableId
+	req.VSwitchId = vswitchId
+	_, err := callApi(c.vpcClient.UnassociateRouteTable, req)
+	return err
 }
 
 func listByIds[RESP any](geter func(id string) (*RESP, error), ids []string) ([]*RESP, error) {

--- a/pkg/controller/infrastructure/infraflow/aliclient/types.go
+++ b/pkg/controller/infrastructure/infraflow/aliclient/types.go
@@ -86,6 +86,15 @@ type SecurityGroup struct {
 	Rules           []*SecurityGroupRule
 }
 
+// RouteTable is the struct for a route table object
+type RouteTable struct {
+	Tags
+	Name         string
+	RouteTableId string
+	VpcId        string
+	Status       *string
+}
+
 // SecurityGroupRule is the struct for a SecurityGroupRule object
 type SecurityGroupRule struct {
 	SecurityGroupRuleId string

--- a/pkg/controller/infrastructure/infraflow/context.go
+++ b/pkg/controller/infrastructure/infraflow/context.go
@@ -44,6 +44,8 @@ const (
 	ZoneNATGWElasticIPAddress = "NATGatewayElasticIPAddress"
 	// IdentifierNodesSecurityGroup is the key for the id of the nodes security group
 	IdentifierNodesSecurityGroup = "NodesSecurityGroup"
+	// IdentifierRouteTable is the key for the id of the custom route table
+	IdentifierRouteTable = "RouteTable"
 
 	// IdentifierZoneSuffix is the key for the suffix used for a zone
 	IdentifierZoneSuffix = "Suffix"

--- a/pkg/controller/infrastructure/infraflow/delete.go
+++ b/pkg/controller/infrastructure/infraflow/delete.go
@@ -34,13 +34,17 @@ func (c *FlowContext) buildDeleteGraph() *flow.Graph {
 		c.deleteZones,
 		Timeout(defaultLongTimeout))
 
+	deleteRouteTable := c.AddTask(g, "delete route table",
+		c.deleteRouteTable,
+		Timeout(defaultTimeout), Dependencies(deleteZones))
+
 	deleteSecurityGroup := c.AddTask(g, "delete security group",
 		c.deleteSecurityGroup,
 		Timeout(defaultTimeout))
 
 	_ = c.AddTask(g, "delete VPC",
 		c.deleteVpc,
-		DoIf(deleteVPC && c.hasVPC()), Timeout(defaultTimeout), Dependencies(deleteZones, deleteSecurityGroup))
+		DoIf(deleteVPC && c.hasVPC()), Timeout(defaultTimeout), Dependencies(deleteRouteTable, deleteSecurityGroup))
 
 	return g
 }
@@ -67,6 +71,26 @@ func (c *FlowContext) deleteSecurityGroup(ctx context.Context) error {
 		}
 	}
 	c.state.SetAsDeleted(IdentifierNodesSecurityGroup)
+	return nil
+}
+
+func (c *FlowContext) deleteRouteTable(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(IdentifierRouteTable) {
+		return nil
+	}
+	log := c.LogFromContext(ctx)
+	current, err := findExisting(ctx, c.state.Get(IdentifierRouteTable), c.commonTagsWithSuffix("rt"),
+		c.actor.GetRouteTable, c.actor.FindRouteTablesByTags)
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		log.Info("deleting custom route table ...", "RouteTableId", current.RouteTableId)
+		if err := c.actor.DeleteRouteTable(ctx, current.RouteTableId); err != nil {
+			return err
+		}
+	}
+	c.state.SetAsDeleted(IdentifierRouteTable)
 	return nil
 }
 

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -7,6 +7,7 @@ package infraflow
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -45,9 +46,13 @@ func (c *FlowContext) buildReconcileGraph() *flow.Graph {
 		c.ensureVSwitches,
 		Timeout(defaultLongTimeout), Dependencies(ensureVpc))
 
+	ensureRouteTable := c.AddTask(g, "ensure route table",
+		c.ensureRouteTable,
+		Timeout(defaultLongTimeout), Dependencies(ensureVSwitches))
+
 	ensureNatGateway := c.AddTask(g, "ensure natgateway",
 		c.ensureNatGateway,
-		Timeout(defaultLongTimeout), Dependencies(ensureVSwitches))
+		Timeout(defaultLongTimeout), Dependencies(ensureRouteTable))
 
 	_ = c.AddTask(g, "ensure zones",
 		c.ensureZones,
@@ -378,4 +383,65 @@ func (c *FlowContext) ensureManagedNatGateway(ctx context.Context) error {
 
 func getZoneName(item *aliclient.VSwitch) string {
 	return item.ZoneId
+}
+
+func (c *FlowContext) ensureRouteTable(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+	vpcId := c.state.Get(IdentifierVPC)
+	if vpcId == nil {
+		return fmt.Errorf("IdentifierVPC is nil")
+	}
+
+	desired := &aliclient.RouteTable{
+		Tags:  c.commonTagsWithSuffix("rt"),
+		Name:  c.namespace + "-rt",
+		VpcId: *vpcId,
+	}
+
+	current, err := findExisting(ctx, c.state.Get(IdentifierRouteTable), c.commonTagsWithSuffix("rt"),
+		c.actor.GetRouteTable, c.actor.FindRouteTablesByTags)
+	if err != nil {
+		return err
+	}
+
+	if current == nil {
+		log.Info("creating custom route table ...")
+		created, err := c.actor.CreateRouteTable(ctx, desired)
+		if err != nil {
+			return fmt.Errorf("create RouteTable failed: %w", err)
+		}
+		if created == nil {
+			return fmt.Errorf("create RouteTable failed")
+		}
+		current = created
+		// Tag the new route table
+		if err := c.actor.CreateTags(ctx, []string{current.RouteTableId}, desired.Tags, "ROUTETABLE"); err != nil {
+			return fmt.Errorf("failed to tag route table: %w", err)
+		}
+	}
+
+	c.state.Set(IdentifierRouteTable, current.RouteTableId)
+
+	// Associate all VSwitches of this shoot with the custom route table
+	vswitchIds := c.getAllVSwitchids()
+	for _, vswitchId := range vswitchIds {
+		if err := c.actor.AssociateRouteTable(ctx, current.RouteTableId, vswitchId); err != nil {
+			// Ignore "already associated" errors
+			if !isAlreadyAssociatedError(err) {
+				return fmt.Errorf("failed to associate route table %s with vswitch %s: %w", current.RouteTableId, vswitchId, err)
+			}
+		}
+	}
+
+	return c.PersistState(ctx, true)
+}
+
+func isAlreadyAssociatedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errMsg := err.Error()
+	return strings.Contains(errMsg, "bindError") ||
+		strings.Contains(errMsg, "IncorrectRouteTableStatus") ||
+		strings.Contains(errMsg, "AlreadyAssociated")
 }


### PR DESCRIPTION
When multiple Gardener shoot clusters are deployed into the same Alicloud VPC, the second cluster fails because the CCM cannot handle routing correctly, a single system route table can only hold one default route (0.0.0.0/0), causing the second cluster's nodes to be unreachable by the API server.

This change creates a custom route table per shoot and associates its VSwitches with it, so each cluster has its own isolated routing. The route table ID is passed to the CCM via the existing RouteTableIDS config field, bypassing the CCM's auto-discovery which fails with multiple route tables.

Changes:
- Add RouteTableID to VPCStatus in API types
- Add route table CRUD methods to Actor and VPC client interface
- Add ensureRouteTable/deleteRouteTable steps to infrastructure flow
- Set RouteTableIDS in CCM cloud config from InfrastructureStatus

