### PR TITLE
Drop support for K8s `<= 1.31`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.34 | 1.34.0+ | [![Gardener v1.34 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.34%20Alibaba%20Cloud/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.34%20Alibaba%20Cloud) |
 | Kubernetes 1.33 | 1.33.0+ | [![Gardener v1.33 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.33%20Alibaba%20Cloud/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.33%20Alibaba%20Cloud) |
 | Kubernetes 1.32 | 1.32.0+ | [![Gardener v1.32 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.32%20Alibaba%20Cloud/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.32%20Alibaba%20Cloud) |
-| Kubernetes 1.31 | 1.31.0+ | [![Gardener v1.31 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.31%20Alibaba%20Cloud/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.31%20Alibaba%20Cloud) |
-| Kubernetes 1.30 | 1.30.0+ | [![Gardener v1.30 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.30%20Alibaba%20Cloud/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.30%20Alibaba%20Cloud) |
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 

--- a/charts/gardener-extension-admission-alicloud/charts/runtime/templates/service.yaml
+++ b/charts/gardener-extension-admission-alicloud/charts/runtime/templates/service.yaml
@@ -5,14 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":{{ .Values.webhookConfig.serverPort }}}]'
-    {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.31-0" .Capabilities.KubeVersion.Version) }}
-    service.kubernetes.io/topology-mode: "auto"
-    {{- end }}
   labels:
 {{ include "labels" . | indent 4 }}
-    {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.32-0" .Capabilities.KubeVersion.Version) }}
-    endpoint-slice-hints.resources.gardener.cloud/consider: "true"
-    {{- end }}
 spec:
   type: ClusterIP
   selector:
@@ -21,7 +15,7 @@ spec:
   - port: 443
     protocol: TCP
     targetPort: {{ .Values.webhookConfig.serverPort }}
-  {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) (semverCompare "< 1.34-0" .Capabilities.KubeVersion.Version) }}
+  {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.34-0" .Capabilities.KubeVersion.Version) }}
   trafficDistribution: PreferClose
   {{- end }}
   {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare ">= 1.34-0" .Capabilities.KubeVersion.Version) }}

--- a/charts/gardener-extension-provider-alicloud/templates/service.yaml
+++ b/charts/gardener-extension-provider-alicloud/templates/service.yaml
@@ -12,17 +12,11 @@ metadata:
     {{- if .Values.ignoreResources }}
     resources.gardener.cloud/ignore: "true"
     {{- end }}
-    {{- if and (include "topologyAwareRouting.enabled" .) (semverCompare "< 1.31-0" .Capabilities.KubeVersion.Version) }}
-    service.kubernetes.io/topology-mode: "auto"
-    {{- end }}
     # TODO: This label approach is deprecated and no longer needed in the future. Remove them as soon as gardener/gardener@v1.75 has been released.
     networking.resources.gardener.cloud/from-policy-pod-label-selector: all-seed-scrape-targets
     networking.resources.gardener.cloud/from-policy-allowed-ports: '[{"port":{{ tpl .Values.metricsPort . }},"protocol":"TCP"}]'
   labels:
 {{ include "labels" . | indent 4 }}
-    {{- if and (include "topologyAwareRouting.enabled" .) (semverCompare "< 1.32-0" .Capabilities.KubeVersion.Version) }}
-    endpoint-slice-hints.resources.gardener.cloud/consider: "true"
-    {{- end }}
 spec:
   type: ClusterIP
   selector:
@@ -31,7 +25,7 @@ spec:
   - port: {{ .Values.webhookConfig.servicePort }}
     protocol: TCP
     targetPort: {{ tpl .Values.webhookConfig.serverPort . }}
-  {{- if and (include "topologyAwareRouting.enabled" .) (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) (semverCompare "< 1.34-0" .Capabilities.KubeVersion.Version) }}
+  {{- if and (include "topologyAwareRouting.enabled" .) (semverCompare "< 1.34-0" .Capabilities.KubeVersion.Version) }}
   trafficDistribution: PreferClose
   {{- end }}
   {{- if and (include "topologyAwareRouting.enabled" .) (semverCompare ">= 1.34-0" .Capabilities.KubeVersion.Version) }}

--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -42,8 +42,8 @@ spec:
   type: alicloud
   kubernetes:
     versions:
+    - version: 1.33.0
     - version: 1.32.0
-    - version: 1.31.1
       expirationDate: "2026-03-31T23:59:59Z"
   machineImages:
   - name: coreos

--- a/example/10-fake-shoot-controlplane.yaml
+++ b/example/10-fake-shoot-controlplane.yaml
@@ -146,7 +146,6 @@ spec:
       - command:
         - /usr/local/bin/kube-apiserver
         - --enable-admission-plugins=Priority,NamespaceLifecycle,LimitRanger,ServiceAccount,NodeRestriction,DefaultStorageClass,DefaultTolerationSeconds,ResourceQuota,StorageObjectInUseProtection,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
-        - --disable-admission-plugins=PersistentVolumeLabel
         - --allow-privileged=true
         - --anonymous-auth=false
         - --authorization-mode=Node,RBAC

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -14,7 +14,6 @@ import (
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
 	"github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager"
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -73,26 +72,6 @@ func (e *ensurer) EnsureMachineControllerManagerVPA(_ context.Context, _ gcontex
 	return nil
 }
 
-// EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
-func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx gcontext.GardenContext, newObj, _ *appsv1.Deployment) error {
-	ps := &newObj.Spec.Template.Spec
-
-	cluster, err := gctx.GetCluster(ctx)
-	if err != nil {
-		return err
-	}
-
-	k8sVersion, err := semver.NewVersion(cluster.Shoot.Spec.Kubernetes.Version)
-	if err != nil {
-		return err
-	}
-
-	if c := extensionswebhook.ContainerWithName(ps.Containers, "kube-apiserver"); c != nil {
-		ensureKubeAPIServerCommandLineArgs(c, k8sVersion)
-	}
-	return nil
-}
-
 // EnsureKubeControllerManagerDeployment ensures that the kube-controller-manager deployment conforms to the provider requirements.
 func (e *ensurer) EnsureKubeControllerManagerDeployment(_ context.Context, _ gcontext.GardenContext, newObj, _ *appsv1.Deployment) error {
 	ps := &newObj.Spec.Template.Spec
@@ -100,16 +79,6 @@ func (e *ensurer) EnsureKubeControllerManagerDeployment(_ context.Context, _ gco
 		ensureKubeControllerManagerCommandLineArgs(c)
 	}
 	return nil
-}
-
-func ensureKubeAPIServerCommandLineArgs(c *corev1.Container, k8sVersion *semver.Version) {
-	// Ensure CSI-related admission plugins
-	if versionutils.ConstraintK8sLess131.Check(k8sVersion) {
-		c.Command = extensionswebhook.EnsureNoStringWithPrefixContains(c.Command, "--enable-admission-plugins=",
-			"PersistentVolumeLabel", ",")
-		c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--disable-admission-plugins=",
-			"PersistentVolumeLabel", ",")
-	}
 }
 
 func ensureKubeControllerManagerCommandLineArgs(c *corev1.Container) {

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -14,13 +14,11 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
-	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/test"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
-	"github.com/gardener/gardener/pkg/utils/version"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -40,23 +38,12 @@ func TestController(t *testing.T) {
 var _ = Describe("Ensurer", func() {
 	var (
 		ctrl       *gomock.Controller
-		eContext30 = gcontext.NewInternalGardenContext(
+		eContext32 = gcontext.NewInternalGardenContext(
 			&extensionscontroller.Cluster{
 				Shoot: &gardencorev1beta1.Shoot{
 					Spec: gardencorev1beta1.ShootSpec{
 						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.30.0",
-						},
-					},
-				},
-			},
-		)
-		eContext31 = gcontext.NewInternalGardenContext(
-			&extensionscontroller.Cluster{
-				Shoot: &gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.31.0",
+							Version: "1.32.0",
 						},
 					},
 				},
@@ -70,58 +57,6 @@ var _ = Describe("Ensurer", func() {
 
 	AfterEach(func() {
 		ctrl.Finish()
-	})
-
-	Describe("#EnsureKubeAPIServerDeployment", func() {
-		var (
-			dep     *appsv1.Deployment
-			ensurer genericmutator.Ensurer
-		)
-
-		BeforeEach(func() {
-			dep = &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer},
-				Spec: appsv1.DeploymentSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name: "kube-apiserver",
-								},
-							},
-						},
-					},
-				},
-			}
-
-			ensurer = NewEnsurer(logger)
-		})
-
-		It("should add missing elements to kube-apiserver deployment (k8s < 1.31)", func() {
-			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), eContext30, dep, nil)
-			Expect(err).To(Not(HaveOccurred()))
-
-			checkKubeAPIServerDeployment(dep, "1.30.0", []string{})
-		})
-
-		It("should add missing elements to kube-apiserver deployment (k8s >= 1.31)", func() {
-			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), eContext31, dep, nil)
-			Expect(err).To(Not(HaveOccurred()))
-
-			checkKubeAPIServerDeployment(dep, "1.31.0", []string{})
-		})
-
-		It("should modify existing elements of kube-apiserver deployment", func() {
-			dep.Spec.Template.Spec.Containers[0].Command = []string{
-				"--enable-admission-plugins=Priority,PersistentVolumeLabel",
-				"--feature-gates=Foo=true,ExpandInUsePersistentVolumes=false,ExpandCSIVolumes=false",
-			}
-
-			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), eContext31, dep, nil)
-			Expect(err).To(Not(HaveOccurred()))
-
-			checkKubeAPIServerDeployment(dep, "1.31.0", []string{"Foo=true"})
-		})
 	})
 
 	Describe("#EnsureKubeControllerManagerDeployment", func() {
@@ -147,7 +82,7 @@ var _ = Describe("Ensurer", func() {
 			ensurer := NewEnsurer(logger)
 
 			// Call EnsureKubeControllerManagerDeployment method and check the result
-			err := ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), eContext31, dep, nil)
+			err := ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), eContext32, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			checkKubeControllerManagerDeployment(dep)
 		})
@@ -177,7 +112,7 @@ var _ = Describe("Ensurer", func() {
 			ensurer := NewEnsurer(logger)
 
 			// Call EnsureKubeControllerManagerDeployment method and check the result
-			err := ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), eContext31, dep, nil)
+			err := ensurer.EnsureKubeControllerManagerDeployment(context.TODO(), eContext32, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			checkKubeControllerManagerDeployment(dep)
 		})
@@ -219,7 +154,7 @@ var _ = Describe("Ensurer", func() {
 				}
 			)
 
-			actual, err := ensurer.EnsureKubeletServiceUnitOptions(context.TODO(), eContext31, semver.MustParse("1.31.0"), oldUnitOptions, nil)
+			actual, err := ensurer.EnsureKubeletServiceUnitOptions(context.TODO(), eContext32, semver.MustParse("1.32.0"), oldUnitOptions, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(actual).To(Equal(expected))
 		})
@@ -251,7 +186,7 @@ var _ = Describe("Ensurer", func() {
 
 			kubeletConfig := *oldKubeletConfig
 
-			err := ensurer.EnsureKubeletConfiguration(context.TODO(), eContext31, semver.MustParse("1.31.0"), &kubeletConfig, nil)
+			err := ensurer.EnsureKubeletConfiguration(context.TODO(), eContext32, semver.MustParse("1.32.0"), &kubeletConfig, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(&kubeletConfig).To(Equal(newKubeletConfig))
 		})
@@ -283,7 +218,7 @@ var _ = Describe("Ensurer", func() {
 
 		It("should inject the sidecar container", func() {
 			Expect(deployment.Spec.Template.Spec.Containers).To(BeEmpty())
-			Expect(ensurer.EnsureMachineControllerManagerDeployment(context.TODO(), eContext31, deployment, nil)).To(Succeed())
+			Expect(ensurer.EnsureMachineControllerManagerDeployment(context.TODO(), eContext32, deployment, nil)).To(Succeed())
 			expectedContainer := machinecontrollermanager.ProviderSidecarContainer(shoot, deployment.Namespace, "provider-alicloud", "foo:bar")
 			Expect(deployment.Spec.Template.Spec.Containers).To(ConsistOf(expectedContainer))
 		})
@@ -312,23 +247,6 @@ var _ = Describe("Ensurer", func() {
 		})
 	})
 })
-
-func checkKubeAPIServerDeployment(dep *appsv1.Deployment, k8sVersion string, featureGates []string) {
-	k8sVersionAtLeast131, _ := version.CompareVersions(k8sVersion, ">=", "1.31")
-
-	// Check that the kube-apiserver container still exists and contains all needed command line args,
-	// env vars, and volume mounts
-	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-apiserver")
-	Expect(c).To(Not(BeNil()))
-
-	if !k8sVersionAtLeast131 {
-		Expect(c.Command).To(Not(test.ContainElementWithPrefixContaining("--enable-admission-plugins=", "PersistentVolumeLabel", ",")))
-		Expect(c.Command).To(test.ContainElementWithPrefixContaining("--disable-admission-plugins=", "PersistentVolumeLabel", ","))
-	}
-	for _, fg := range featureGates {
-		Expect(c.Command).To(test.ContainElementWithPrefixContaining("--feature-gates=", fg, ","))
-	}
-}
 
 func checkKubeControllerManagerDeployment(dep *appsv1.Deployment) {
 	// Check that the kube-controller-manager container still exists and contains all needed command line args,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area open-source
/kind cleanup
/platform alicloud

**What this PR does / why we need it**:
This PR removes the support for Kubernetes versions <= 1.31.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13919

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
⚠️ This extension no longer supports Kubernetes versions `<= 1.31`. Please make sure to upgrade all Garden, Seed and Shoot clusters to at least version 1.32 before deploying this extension version.
```
