### PR TITLE
[DNSRecord controller] Filter `RR` exactly on retrieving records by domain name

### DIFF
--- a/pkg/alicloud/client/client_dns.go
+++ b/pkg/alicloud/client/client_dns.go
@@ -41,6 +41,7 @@ func (f *clientFactory) NewDNSClient(region, accessKeyID, accessKeySecret string
 	if err != nil {
 		return nil, err
 	}
+	client.AppendUserAgent("application", "gardener-extension-provider-alicloud")
 
 	return &dnsClient{
 		Client:                 *client,
@@ -258,7 +259,11 @@ func (d *dnsClient) getDomainRecords(ctx context.Context, domainName, rr, record
 			return nil, err
 		}
 		for _, record := range resp.DomainRecords.Record {
-			records[record.Value] = record
+			// The check is required to keep only records whose RR exactly matches the requested host part.
+			// DescribeDomainRecords is queried with a keyword-style filter, so the API response can still include records that are not the exact target entry
+			if record.RR == rr {
+				records[record.Value] = record
+			}
 		}
 		if resp.PageNumber*int64(pageSize) >= resp.TotalCount {
 			break


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform alicloud

**What this PR does / why we need it**:
The API's RRKeyWord parameter uses keyword-style filtering, which can return partial matches.                                                                                                                                                                                                        
Without this filter, searching for "foo" could also return unrelated "foobar" records.
This fixes a potentially serious bug where DNS operations could affect unintended records.
 
Additionally, an user-agent has been added to DNS client for trouble shooting.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
[DNSRecord controller] Filter `RR` exactly on retrieving records by domain name to prevent updating unintended records in edge cases.
```
