### PR TITLE
Validate VSwitch CIDR conflicts in shared VPC

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -247,7 +247,7 @@ Once dual-stack is enabled, the Cloud Controller Manager can provision **DualSta
 
 **Zone requirement:** Alibaba Cloud requires an NLB instance to span at least **two VSwitches in different NLB-supported zones**. Before creating an NLB service, verify that the shoot's infrastructure contains at least two zones. If not, add additional zones to `networks.zones` in the `InfrastructureConfig` and reconcile the shoot first.
 
-*Note:* Alibaba Cloud supports **Single Zone** instances via a privilege quota (which is disabled by default). You can apply for this privilege through the [NLB Quotas](https://www.alibabacloud.com/help/en/slb/network-load-balancer/user-guide/nlb-quotas) page. Once the application is approved, you will be able to create an NLB instance in a single zone.
+*Note:* Alibaba Cloud supports **Single Zone** instances via a privilege quota (which is disabled by default) . You can apply for this privilege through the [NLB Quotas](https://www.alibabacloud.com/help/en/slb/network-load-balancer/user-guide/nlb-quotas) page. Once the application is approved, you will be able to create an NLB instance in a single zone.
 
 The VSwitch IDs and their corresponding zones are available in the shoot's infrastructure status, which can be found in the shoot's control plane namespace on the seed cluster.
 

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -247,6 +247,8 @@ Once dual-stack is enabled, the Cloud Controller Manager can provision **DualSta
 
 **Zone requirement:** Alibaba Cloud requires an NLB instance to span at least **two VSwitches in different NLB-supported zones**. Before creating an NLB service, verify that the shoot's infrastructure contains at least two zones. If not, add additional zones to `networks.zones` in the `InfrastructureConfig` and reconcile the shoot first.
 
+*Note:* Alibaba Cloud supports **Single Zone** instances via a privilege quota (which is disabled by default). You can apply for this privilege through the [NLB Quotas](https://www.alibabacloud.com/help/en/slb/network-load-balancer/user-guide/nlb-quotas) page. Once the application is approved, you will be able to create an NLB instance in a single zone.
+
 The VSwitch IDs and their corresponding zones are available in the shoot's infrastructure status, which can be found in the shoot's control plane namespace on the seed cluster.
 
 The following is an example of a dual-stack NLB Service. Replace the `zone-maps` annotation values with the actual zone names and VSwitch IDs from the shoot's infrastructure status:

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -7,19 +7,24 @@ package validator
 import (
 	"context"
 	"fmt"
+	"net"
 	"reflect"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
+	"github.com/gardener/gardener/pkg/apis/security"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	provideralicloud "github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
 	alicloudvalidation "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/validation"
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/infrastructure/infraflow/aliclient"
 )
 
 var (
@@ -36,12 +41,26 @@ func NewShootValidator(mgr manager.Manager) extensionswebhook.Validator {
 	return &shoot{
 		decoder:        serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
 		lenientDecoder: serializer.NewCodecFactory(mgr.GetScheme()).UniversalDecoder(),
+		apiReader:      mgr.GetAPIReader(),
+		newActorFn:     aliclient.NewActor,
+	}
+}
+
+// NewShootValidatorWithActorFn creates a shoot validator with a custom actor constructor, for testing.
+func NewShootValidatorWithActorFn(mgr manager.Manager, fn func(accessKeyID, secretAccessKey, region string) (aliclient.Actor, error)) extensionswebhook.Validator {
+	return &shoot{
+		decoder:        serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
+		lenientDecoder: serializer.NewCodecFactory(mgr.GetScheme()).UniversalDecoder(),
+		apiReader:      mgr.GetAPIReader(),
+		newActorFn:     fn,
 	}
 }
 
 type shoot struct {
 	decoder        runtime.Decoder
 	lenientDecoder runtime.Decoder
+	apiReader      client.Reader
+	newActorFn     func(accessKeyID, secretAccessKey, region string) (aliclient.Actor, error)
 }
 
 // Validate validates the given shoot object.
@@ -128,7 +147,22 @@ func (s *shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.S
 		return errList.ToAggregate()
 	}
 
-	return s.validateShoot(ctx, shoot, infraConfig, cpConfig)
+	if err := s.validateShoot(ctx, shoot, infraConfig, cpConfig); err != nil {
+		return err
+	}
+
+	// Only check newly added zones against existing vswitches in the VPC.
+	if infraConfig != nil && infraConfig.Networks.VPC.ID != nil {
+		newZones := infraConfig.Networks.Zones
+		oldZones := oldInfraConfig.Networks.Zones
+		if len(newZones) > len(oldZones) {
+			if err := s.validateVSwitchCIDRConflict(ctx, shoot, *infraConfig.Networks.VPC.ID, newZones[len(oldZones):], len(oldZones)); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (s *shoot) validateShootCreation(ctx context.Context, shoot *core.Shoot) error {
@@ -156,5 +190,93 @@ func (s *shoot) validateShootCreation(ctx context.Context, shoot *core.Shoot) er
 		return errList.ToAggregate()
 	}
 
+	if infraConfig != nil && infraConfig.Networks.VPC.ID != nil {
+		if err := s.validateVSwitchCIDRConflict(ctx, shoot, *infraConfig.Networks.VPC.ID, infraConfig.Networks.Zones, 0); err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+// validateVSwitchCIDRConflict queries all existing vswitches in the given VPC and checks whether
+// any of the supplied zones' worker CIDRs overlap with an existing vswitch's CIDR block.
+// startIndex is the position of zonesToCheck[0] within the full zones slice, used for correct field paths.
+func (s *shoot) validateVSwitchCIDRConflict(ctx context.Context, shoot *core.Shoot, vpcID string, zonesToCheck []alicloud.Zone, startIndex int) error {
+	credentials, err := s.getCredentials(ctx, shoot)
+	if err != nil {
+		return field.InternalError(infraConfigFldPath, fmt.Errorf("could not get Alicloud credentials: %w", err))
+	}
+
+	actor, err := s.newActorFn(credentials.AccessKeyID, credentials.AccessKeySecret, shoot.Spec.Region)
+	if err != nil {
+		return field.InternalError(infraConfigFldPath, fmt.Errorf("could not create Alicloud client: %w", err))
+	}
+
+	existingVSwitches, err := actor.FindVSwitchesByVPC(ctx, vpcID)
+	if err != nil {
+		return field.InternalError(infraConfigFldPath, fmt.Errorf("could not list vswitches in VPC %s: %w", vpcID, err))
+	}
+
+	allErrs := field.ErrorList{}
+	zonesPath := field.NewPath("networks", "zones")
+	for i, zone := range zonesToCheck {
+		workerCIDR := zone.Workers
+		if workerCIDR == "" {
+			workerCIDR = zone.Worker
+		}
+		if workerCIDR == "" {
+			continue
+		}
+		fldPath := zonesPath.Index(startIndex + i).Child("workers")
+		_, netA, err := net.ParseCIDR(workerCIDR)
+		if err != nil {
+			continue
+		}
+		for _, vsw := range existingVSwitches {
+			_, netB, err := net.ParseCIDR(vsw.CidrBlock)
+			if err != nil {
+				continue
+			}
+			if netA.Contains(netB.IP) || netB.Contains(netA.IP) {
+				allErrs = append(allErrs, field.Invalid(fldPath, workerCIDR,
+					fmt.Sprintf("conflicts with existing vswitch %s (%s) in VPC %s", vsw.VSwitchId, vsw.CidrBlock, vpcID)))
+			}
+		}
+	}
+	return allErrs.ToAggregate()
+}
+
+// getCredentials retrieves Alicloud credentials from the secret referenced by the shoot's
+// SecretBinding or CredentialsBinding.
+func (s *shoot) getCredentials(ctx context.Context, shoot *core.Shoot) (*provideralicloud.Credentials, error) {
+	var secretRef corev1.SecretReference
+
+	switch {
+	case shoot.Spec.SecretBindingName != nil:
+		secretBinding := &core.SecretBinding{}
+		if err := s.apiReader.Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: *shoot.Spec.SecretBindingName}, secretBinding); err != nil {
+			return nil, err
+		}
+		secretRef = secretBinding.SecretRef
+
+	case shoot.Spec.CredentialsBindingName != nil:
+		credentialsBinding := &security.CredentialsBinding{}
+		if err := s.apiReader.Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: *shoot.Spec.CredentialsBindingName}, credentialsBinding); err != nil {
+			return nil, err
+		}
+		secretRef = corev1.SecretReference{
+			Namespace: credentialsBinding.CredentialsRef.Namespace,
+			Name:      credentialsBinding.CredentialsRef.Name,
+		}
+
+	default:
+		return nil, fmt.Errorf("shoot has neither secretBindingName nor credentialsBindingName")
+	}
+
+	secret := &corev1.Secret{}
+	if err := s.apiReader.Get(ctx, client.ObjectKey{Namespace: secretRef.Namespace, Name: secretRef.Name}, secret); err != nil {
+		return nil, err
+	}
+	return provideralicloud.ReadSecretCredentials(secret, false)
 }

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -13,7 +13,7 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
-	"github.com/gardener/gardener/pkg/apis/security"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -255,7 +255,7 @@ func (s *shoot) getCredentials(ctx context.Context, shoot *core.Shoot) (*provide
 		secretRef = secretBinding.SecretRef
 
 	case shoot.Spec.CredentialsBindingName != nil:
-		credentialsBinding := &security.CredentialsBinding{}
+		credentialsBinding := &securityv1alpha1.CredentialsBinding{}
 		if err := s.apiReader.Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: *shoot.Spec.CredentialsBindingName}, credentialsBinding); err != nil {
 			return nil, err
 		}

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -190,12 +190,6 @@ func (s *shoot) validateShootCreation(ctx context.Context, shoot *core.Shoot) er
 		return errList.ToAggregate()
 	}
 
-	if infraConfig != nil && infraConfig.Networks.VPC.ID != nil {
-		if err := s.validateVSwitchCIDRConflict(ctx, shoot, *infraConfig.Networks.VPC.ID, infraConfig.Networks.Zones, 0); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for validateVSwitchCIDRConflict and getCredentials are in package validator (white-box)
+// so they can call unexported methods directly, avoiding the need to satisfy all static validation
+// constraints that ValidateWorkers/ValidateInfrastructureConfig impose on a full Shoot.
+
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/security"
+	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	provideralicloud "github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
+	apisalicloud "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
+	"github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/infrastructure/infraflow/aliclient"
+	mockaliclient "github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/infrastructure/infraflow/aliclient/mock"
+)
+
+var _ = Describe("shoot.validateVSwitchCIDRConflict", func() {
+	const (
+		shootNamespace = "shoot--project--test"
+		shootRegion    = "cn-hangzhou"
+		testVPCID      = "vpc-abc123"
+		secretName     = "my-provider-secret"
+		bindingName    = "my-binding"
+		akID           = "AKID1234567890123456"
+		akSecret       = "secretsecretsecretsecretsecretsecr"
+	)
+
+	var (
+		ctrl      *gomock.Controller
+		apiReader *mockclient.MockReader
+		mockActor *mockaliclient.MockActor
+		ctx       context.Context
+
+		providerSecret *corev1.Secret
+		baseShoot      *core.Shoot
+		s              *shoot
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		ctx = context.TODO()
+
+		apiReader = mockclient.NewMockReader(ctrl)
+		mockActor = mockaliclient.NewMockActor(ctrl)
+
+		providerSecret = &corev1.Secret{
+			Data: map[string][]byte{
+				provideralicloud.AccessKeyID:     []byte(akID),
+				provideralicloud.AccessKeySecret: []byte(akSecret),
+			},
+		}
+
+		baseShoot = &core.Shoot{
+			ObjectMeta: metav1.ObjectMeta{Namespace: shootNamespace},
+			Spec: core.ShootSpec{
+				Region:            shootRegion,
+				SecretBindingName: ptr.To(bindingName),
+			},
+		}
+
+		s = &shoot{
+			apiReader: apiReader,
+			newActorFn: func(ak, sk, region string) (aliclient.Actor, error) {
+				return mockActor, nil
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	expectSecretBindingLookup := func() {
+		secretBinding := &core.SecretBinding{
+			SecretRef: corev1.SecretReference{Namespace: shootNamespace, Name: secretName},
+		}
+		apiReader.EXPECT().
+			Get(ctx, client.ObjectKey{Namespace: shootNamespace, Name: bindingName}, gomock.AssignableToTypeOf(&core.SecretBinding{})).
+			DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *core.SecretBinding, _ ...client.GetOption) error {
+				*obj = *secretBinding
+				return nil
+			})
+		apiReader.EXPECT().
+			Get(ctx, client.ObjectKey{Namespace: shootNamespace, Name: secretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+			DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+				*obj = *providerSecret
+				return nil
+			})
+	}
+
+	zones := func(cidrs ...string) []apisalicloud.Zone {
+		var zs []apisalicloud.Zone
+		for i, c := range cidrs {
+			zs = append(zs, apisalicloud.Zone{
+				Name:    fmt.Sprintf("cn-hangzhou-%c", 'a'+i),
+				Workers: c,
+			})
+		}
+		return zs
+	}
+
+	Describe("CIDR conflict detection", func() {
+		It("should return nil when no existing vswitches in VPC", func() {
+			expectSecretBindingLookup()
+			mockActor.EXPECT().FindVSwitchesByVPC(ctx, testVPCID).Return([]*aliclient.VSwitch{}, nil)
+
+			err := s.validateVSwitchCIDRConflict(ctx, baseShoot, testVPCID, zones("192.168.1.0/24"), 0)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return nil when zone CIDR does not overlap any existing vswitch", func() {
+			expectSecretBindingLookup()
+			mockActor.EXPECT().FindVSwitchesByVPC(ctx, testVPCID).Return([]*aliclient.VSwitch{
+				{VSwitchId: "vsw-other", CidrBlock: "192.168.2.0/24"},
+			}, nil)
+
+			err := s.validateVSwitchCIDRConflict(ctx, baseShoot, testVPCID, zones("192.168.1.0/24"), 0)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return field.Invalid when zone CIDR exactly matches an existing vswitch", func() {
+			expectSecretBindingLookup()
+			mockActor.EXPECT().FindVSwitchesByVPC(ctx, testVPCID).Return([]*aliclient.VSwitch{
+				{VSwitchId: "vsw-existing", CidrBlock: "192.168.1.0/24"},
+			}, nil)
+
+			err := s.validateVSwitchCIDRConflict(ctx, baseShoot, testVPCID, zones("192.168.1.0/24"), 0)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("networks.zones[0].workers"))
+			Expect(err.Error()).To(ContainSubstring("conflicts with existing vswitch vsw-existing"))
+			Expect(err.Error()).To(ContainSubstring("192.168.1.0/24"))
+		})
+
+		It("should return field.Invalid when zone CIDR is a subset of an existing vswitch CIDR", func() {
+			expectSecretBindingLookup()
+			mockActor.EXPECT().FindVSwitchesByVPC(ctx, testVPCID).Return([]*aliclient.VSwitch{
+				{VSwitchId: "vsw-large", CidrBlock: "192.168.0.0/16"},
+			}, nil)
+
+			err := s.validateVSwitchCIDRConflict(ctx, baseShoot, testVPCID, zones("192.168.1.0/24"), 0)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("conflicts with existing vswitch vsw-large"))
+		})
+
+		It("should use startIndex to produce correct field path for newly added zones", func() {
+			expectSecretBindingLookup()
+			mockActor.EXPECT().FindVSwitchesByVPC(ctx, testVPCID).Return([]*aliclient.VSwitch{
+				{VSwitchId: "vsw-b", CidrBlock: "192.168.2.0/24"},
+			}, nil)
+
+			// zones[1] is newly added (startIndex=1)
+			err := s.validateVSwitchCIDRConflict(ctx, baseShoot, testVPCID, zones("192.168.2.0/24"), 1)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("networks.zones[1].workers"))
+		})
+
+		It("should return InternalError when FindVSwitchesByVPC fails", func() {
+			expectSecretBindingLookup()
+			mockActor.EXPECT().FindVSwitchesByVPC(ctx, testVPCID).Return(nil, fmt.Errorf("api error"))
+
+			err := s.validateVSwitchCIDRConflict(ctx, baseShoot, testVPCID, zones("192.168.1.0/24"), 0)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("could not list vswitches"))
+		})
+
+		It("should skip zones with empty CIDR", func() {
+			expectSecretBindingLookup()
+			mockActor.EXPECT().FindVSwitchesByVPC(ctx, testVPCID).Return([]*aliclient.VSwitch{
+				{VSwitchId: "vsw-x", CidrBlock: "192.168.1.0/24"},
+			}, nil)
+
+			err := s.validateVSwitchCIDRConflict(ctx, baseShoot, testVPCID,
+				[]apisalicloud.Zone{{Name: "cn-hangzhou-a"}}, 0)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("getCredentials via CredentialsBinding", func() {
+		It("should resolve credentials via CredentialsBinding when SecretBindingName is nil", func() {
+			sh := baseShoot.DeepCopy()
+			sh.Spec.SecretBindingName = nil
+			sh.Spec.CredentialsBindingName = ptr.To(bindingName)
+
+			credentialsBinding := &security.CredentialsBinding{
+				CredentialsRef: corev1.ObjectReference{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Secret",
+					Namespace:  shootNamespace,
+					Name:       secretName,
+				},
+			}
+			apiReader.EXPECT().
+				Get(ctx, client.ObjectKey{Namespace: shootNamespace, Name: bindingName}, gomock.AssignableToTypeOf(&security.CredentialsBinding{})).
+				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *security.CredentialsBinding, _ ...client.GetOption) error {
+					*obj = *credentialsBinding
+					return nil
+				})
+			apiReader.EXPECT().
+				Get(ctx, client.ObjectKey{Namespace: shootNamespace, Name: secretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+					*obj = *providerSecret
+					return nil
+				})
+			mockActor.EXPECT().FindVSwitchesByVPC(ctx, testVPCID).Return([]*aliclient.VSwitch{}, nil)
+
+			err := s.validateVSwitchCIDRConflict(ctx, sh, testVPCID, zones("192.168.1.0/24"), 0)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return error when neither SecretBindingName nor CredentialsBindingName is set", func() {
+			sh := baseShoot.DeepCopy()
+			sh.Spec.SecretBindingName = nil
+			sh.Spec.CredentialsBindingName = nil
+
+			err := s.validateVSwitchCIDRConflict(ctx, sh, testVPCID, zones("192.168.1.0/24"), 0)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("neither secretBindingName nor credentialsBindingName"))
+		})
+	})
+})

--- a/pkg/controller/infrastructure/configvalidator.go
+++ b/pkg/controller/infrastructure/configvalidator.go
@@ -7,6 +7,7 @@ package infrastructure
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
@@ -19,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/alicloud"
+	apisalicloud "github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud"
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/apis/alicloud/helper"
 	"github.com/gardener/gardener-extension-provider-alicloud/pkg/controller/infrastructure/infraflow/aliclient"
 )
@@ -77,8 +79,17 @@ func (c *configValidator) Validate(ctx context.Context, infra *extensionsv1alpha
 		}
 
 		if infra.Status.LastOperation != nil && infra.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeCreate {
-			logger.Info("Validating multi-shoot VPC sharing constraints for new shoot")
-			allErrs = append(allErrs, c.validateMultiShootVPC(ctx, actor, *config.Networks.VPC.ID, infra.Namespace, config.Networks.VPC.GardenerManagedNATGateway, config.Networks.VPC.UseCustomRouteTable, field.NewPath("networks", "vpc"))...)
+			vswitches, err := actor.FindVSwitchesByVPC(ctx, *config.Networks.VPC.ID)
+			if err != nil {
+				allErrs = append(allErrs, field.InternalError(field.NewPath("networks", "vpc", "id"),
+					fmt.Errorf("FindVSwitchesByVPC %s failed: %+v", *config.Networks.VPC.ID, err)))
+			} else {
+				logger.Info("Validating multi-shoot VPC sharing constraints for new shoot")
+				allErrs = append(allErrs, c.validateMultiShootVPC(vswitches, infra.Namespace, config.Networks.VPC.GardenerManagedNATGateway, config.Networks.VPC.UseCustomRouteTable, field.NewPath("networks", "vpc"))...)
+
+				logger.Info("Validating vswitch CIDR conflicts for new shoot")
+				allErrs = append(allErrs, c.validateVSwitchCIDRConflict(vswitches, *config.Networks.VPC.ID, infra.Namespace, config.Networks.Zones)...)
+			}
 		}
 	}
 	if createManagedNATGateway {
@@ -213,14 +224,8 @@ func (c *configValidator) validateVpcIPv6(ctx context.Context, actor aliclient.A
 	return allErrs
 }
 
-func (c *configValidator) validateMultiShootVPC(ctx context.Context, actor aliclient.Actor, vpcID string, namespace string, gardenerManagedNATGateway *bool, useCustomRouteTable *bool, fldPath *field.Path) field.ErrorList {
+func (c *configValidator) validateMultiShootVPC(vswitches []*aliclient.VSwitch, namespace string, gardenerManagedNATGateway *bool, useCustomRouteTable *bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-
-	vswitches, err := actor.FindVSwitchesByVPC(ctx, vpcID)
-	if err != nil {
-		allErrs = append(allErrs, field.InternalError(fldPath, fmt.Errorf("validateMultiShootVPC FindVSwitchesByVPC %s failed: %+v", vpcID, err)))
-		return allErrs
-	}
 
 	ownClusterTagKey := fmt.Sprintf("kubernetes.io/cluster/%s", namespace)
 	hasOtherShoot := false
@@ -247,5 +252,49 @@ func (c *configValidator) validateMultiShootVPC(ctx context.Context, actor alicl
 		}
 	}
 
+	return allErrs
+}
+
+// validateVSwitchCIDRConflict checks whether any of the configured zone worker CIDRs overlap with
+// vswitches already existing in the VPC that are not owned by this shoot.
+// Called only on create, but create may be retried after partial failure, so vswitches whose name
+// starts with "<namespace>-" (the naming convention used by this extension) are excluded to avoid
+// false positives on retry.
+func (c *configValidator) validateVSwitchCIDRConflict(vswitches []*aliclient.VSwitch, vpcID string, namespace string, zones []apisalicloud.Zone) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	ownPrefix := namespace + "-"
+	var foreignVSwitches []*aliclient.VSwitch
+	for _, vsw := range vswitches {
+		if !strings.HasPrefix(vsw.Name, ownPrefix) {
+			foreignVSwitches = append(foreignVSwitches, vsw)
+		}
+	}
+
+	zonesPath := field.NewPath("networks", "zones")
+	for i, zone := range zones {
+		workerCIDR := zone.Workers
+		if workerCIDR == "" {
+			workerCIDR = zone.Worker
+		}
+		if workerCIDR == "" {
+			continue
+		}
+		fldPath := zonesPath.Index(i).Child("workers")
+		_, netA, err := net.ParseCIDR(workerCIDR)
+		if err != nil {
+			continue
+		}
+		for _, vsw := range foreignVSwitches {
+			_, netB, err := net.ParseCIDR(vsw.CidrBlock)
+			if err != nil {
+				continue
+			}
+			if netA.Contains(netB.IP) || netB.Contains(netA.IP) {
+				allErrs = append(allErrs, field.Invalid(fldPath, workerCIDR,
+					fmt.Sprintf("conflicts with existing vswitch %s (%s) in VPC %s", vsw.VSwitchId, vsw.CidrBlock, vpcID)))
+			}
+		}
+	}
 	return allErrs
 }

--- a/pkg/controller/infrastructure/configvalidator_test.go
+++ b/pkg/controller/infrastructure/configvalidator_test.go
@@ -427,6 +427,96 @@ var _ = Describe("ConfigValidator", func() {
 		Expect(errorList).To(BeEmpty())
 	})
 
+	It("should skip CIDR conflict check when LastOperation is not Create", func() {
+		infra.Status.LastOperation = &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeReconcile}
+		infra.Spec.ProviderConfig.Raw = encode(&apisalicloud.InfrastructureConfig{
+			Networks: apisalicloud.Networks{
+				VPC: apisalicloud.VPC{
+					ID: ptr.To(vpcID),
+				},
+				Zones: []apisalicloud.Zone{{Name: "zone_1", Workers: "192.168.1.0/24"}},
+			},
+		})
+		actor.EXPECT().GetVpc(ctx, vpcID).Return(&aliclient.VPC{}, nil)
+		actor.EXPECT().ListNatGatewaysByVPC(ctx, vpcID).Return([]*aliclient.NatGateway{{NatGatewayId: "ngw-1"}}, nil)
+		actor.EXPECT().GetNatGatewayTags(ctx, gomock.Any()).Return(map[string]aliclient.Tags{"ngw-1": {}}, nil)
+		// FindVSwitchesByVPC must NOT be called on reconcile
+
+		errorList := cv.Validate(ctx, infra)
+		Expect(errorList).To(BeEmpty())
+	})
+
+	It("should return field.Invalid when a zone worker CIDR conflicts with a foreign vswitch on create", func() {
+		infra.Status.LastOperation = &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeCreate}
+		infra.Spec.ProviderConfig.Raw = encode(&apisalicloud.InfrastructureConfig{
+			Networks: apisalicloud.Networks{
+				VPC: apisalicloud.VPC{
+					ID: ptr.To(vpcID),
+				},
+				Zones: []apisalicloud.Zone{{Name: "zone_1", Workers: "192.168.1.0/24"}},
+			},
+		})
+		actor.EXPECT().GetVpc(ctx, vpcID).Return(&aliclient.VPC{}, nil)
+		actor.EXPECT().ListNatGatewaysByVPC(ctx, vpcID).Return([]*aliclient.NatGateway{{NatGatewayId: "ngw-1"}}, nil)
+		actor.EXPECT().GetNatGatewayTags(ctx, gomock.Any()).Return(map[string]aliclient.Tags{"ngw-1": {}}, nil)
+		actor.EXPECT().FindVSwitchesByVPC(ctx, vpcID).Return([]*aliclient.VSwitch{
+			{VSwitchId: "vsw-foreign", Name: "user-vsw", CidrBlock: "192.168.1.0/24"},
+		}, nil)
+
+		errorList := cv.Validate(ctx, infra)
+		Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+			"Type":   Equal(field.ErrorTypeInvalid),
+			"Field":  Equal("networks.zones[0].workers"),
+			"Detail": ContainSubstring("conflicts with existing vswitch vsw-foreign"),
+		}))))
+	})
+
+	It("should pass when a zone worker CIDR matches only this shoot's own vswitch on create retry", func() {
+		infra.Status.LastOperation = &gardencorev1beta1.LastOperation{
+			Type:  gardencorev1beta1.LastOperationTypeCreate,
+			State: gardencorev1beta1.LastOperationStateError,
+		}
+		infra.Spec.ProviderConfig.Raw = encode(&apisalicloud.InfrastructureConfig{
+			Networks: apisalicloud.Networks{
+				VPC: apisalicloud.VPC{
+					ID: ptr.To(vpcID),
+				},
+				Zones: []apisalicloud.Zone{{Name: "zone_1", Workers: "192.168.1.0/24"}},
+			},
+		})
+		actor.EXPECT().GetVpc(ctx, vpcID).Return(&aliclient.VPC{}, nil)
+		actor.EXPECT().ListNatGatewaysByVPC(ctx, vpcID).Return([]*aliclient.NatGateway{{NatGatewayId: "ngw-1"}}, nil)
+		actor.EXPECT().GetNatGatewayTags(ctx, gomock.Any()).Return(map[string]aliclient.Tags{"ngw-1": {}}, nil)
+		// vswitch name starts with "<namespace>-" — treated as own, must not trigger conflict
+		actor.EXPECT().FindVSwitchesByVPC(ctx, vpcID).Return([]*aliclient.VSwitch{
+			{VSwitchId: "vsw-own", Name: namespace + "-zone_1-vsw", CidrBlock: "192.168.1.0/24"},
+		}, nil)
+
+		errorList := cv.Validate(ctx, infra)
+		Expect(errorList).To(BeEmpty())
+	})
+
+	It("should pass when no foreign vswitches have overlapping CIDRs on create", func() {
+		infra.Status.LastOperation = &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeCreate}
+		infra.Spec.ProviderConfig.Raw = encode(&apisalicloud.InfrastructureConfig{
+			Networks: apisalicloud.Networks{
+				VPC: apisalicloud.VPC{
+					ID: ptr.To(vpcID),
+				},
+				Zones: []apisalicloud.Zone{{Name: "zone_1", Workers: "192.168.1.0/24"}},
+			},
+		})
+		actor.EXPECT().GetVpc(ctx, vpcID).Return(&aliclient.VPC{}, nil)
+		actor.EXPECT().ListNatGatewaysByVPC(ctx, vpcID).Return([]*aliclient.NatGateway{{NatGatewayId: "ngw-1"}}, nil)
+		actor.EXPECT().GetNatGatewayTags(ctx, gomock.Any()).Return(map[string]aliclient.Tags{"ngw-1": {}}, nil)
+		actor.EXPECT().FindVSwitchesByVPC(ctx, vpcID).Return([]*aliclient.VSwitch{
+			{VSwitchId: "vsw-other", Name: "user-vsw", CidrBlock: "192.168.2.0/24"},
+		}, nil)
+
+		errorList := cv.Validate(ctx, infra)
+		Expect(errorList).To(BeEmpty())
+	})
+
 })
 
 func encode(obj runtime.Object) []byte {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform alicloud

**What this PR does / why we need it**:

When multiple Shoot clusters share a VPC (BYO-VPC scenario), each new zone requires creating a VSwitch. If the configured CIDR overlaps with an existing VSwitch in the VPC, the infrastructure reconciliation will fail at the Alicloud API level. This PR adds proactive validation to catch such conflicts early.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
When new zones are added to an existing BYO-VPC Shoot, the admission webhook validates CIDR conflicts against existing VSwitches.
```
